### PR TITLE
Add trading restriction support (round-trip window)

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -17,8 +17,10 @@ from midas.models import (
     HoldingPeriod,
     Order,
     PortfolioConfig,
+    TradingRestrictions,
     TradeRecord,
 )
+from midas.restrictions import RestrictionTracker
 from midas.sizing import SizingEngine
 
 
@@ -59,6 +61,7 @@ class _SimState:
     last_day: date | None = None
     split_value: float | None = None
     split_bh_value: float | None = None
+    restriction_tracker: RestrictionTracker | None = None
 
 
 class BacktestEngine:
@@ -164,6 +167,10 @@ class BacktestEngine:
         end: date,
     ) -> _SimState:
         state = _SimState(cash=portfolio.available_cash)
+        if portfolio.trading_restrictions:
+            state.restriction_tracker = RestrictionTracker(
+                portfolio.trading_restrictions,
+            )
         first_dates = self._first_data_dates(price_data, start)
 
         for h in portfolio.holdings:
@@ -317,9 +324,18 @@ class BacktestEngine:
                 if order is None or order.shares == 0:
                     continue
 
+                if state.restriction_tracker and state.restriction_tracker.is_blocked(
+                    order.ticker, order.direction, day,
+                ):
+                    continue
+
                 trade = self._execute(order, day, state)
                 if trade is not None:
                     state.trades.append(trade)
+                    if state.restriction_tracker:
+                        state.restriction_tracker.record_trade(
+                            order.ticker, order.direction, day,
+                        )
                     if order.direction == Direction.BUY:
                         state.cash -= order.estimated_value
                         state.daily_deployed += order.estimated_value

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -8,7 +8,13 @@ from typing import Any
 
 import yaml
 
-from midas.models import CashInfusion, Holding, PortfolioConfig, StrategyConfig
+from midas.models import (
+    CashInfusion,
+    Holding,
+    PortfolioConfig,
+    StrategyConfig,
+    TradingRestrictions,
+)
 
 
 def load_portfolio(path: Path) -> PortfolioConfig:
@@ -37,10 +43,18 @@ def load_portfolio(path: Path) -> PortfolioConfig:
             frequency=ci.get("frequency"),
         )
 
+    restrictions = None
+    if "trading_restrictions" in raw:
+        tr = raw["trading_restrictions"]
+        restrictions = TradingRestrictions(
+            round_trip_days=int(tr.get("round_trip_days", 0)),
+        )
+
     return PortfolioConfig(
         holdings=holdings,
         available_cash=float(raw["available_cash"]),
         cash_infusion=infusion,
+        trading_restrictions=restrictions,
     )
 
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -97,6 +97,10 @@ class LiveEngine:
                     ):
                         continue
                     orders.append(order)
+                    if self._restriction_tracker and order.shares > 0:
+                        self._restriction_tracker.record_trade(
+                            order.ticker, order.direction, today,
+                        )
                     if order.shares > 0 and order.direction == Direction.BUY:
                         self._daily_deployed += order.estimated_value
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -11,6 +11,7 @@ from midas.agent import Agent
 from midas.data.provider import DataProvider
 from midas.models import Direction, Order, PortfolioConfig
 from midas.output import print_alert, print_circuit_breaker_alert, print_status
+from midas.restrictions import RestrictionTracker
 from midas.sizing import SizingEngine
 
 
@@ -34,6 +35,11 @@ class LiveEngine:
         self._history_days = history_days
         self._daily_deployed = 0.0
         self._last_reset_date: date | None = None
+        self._restriction_tracker: RestrictionTracker | None = None
+        if portfolio.trading_restrictions:
+            self._restriction_tracker = RestrictionTracker(
+                portfolio.trading_restrictions,
+            )
 
     def run(self) -> None:
         tickers = [h.ticker for h in self._portfolio.holdings]
@@ -86,6 +92,10 @@ class LiveEngine:
                     today=today,
                 )
                 if order is not None:
+                    if self._restriction_tracker and self._restriction_tracker.is_blocked(
+                        order.ticker, order.direction, today,
+                    ):
+                        continue
                     orders.append(order)
                     if order.shares > 0 and order.direction == Direction.BUY:
                         self._daily_deployed += order.estimated_value

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -55,6 +55,7 @@ class PortfolioConfig:
     holdings: list[Holding]
     available_cash: float
     cash_infusion: CashInfusion | None = None
+    trading_restrictions: TradingRestrictions | None = None
 
     def __post_init__(self) -> None:
         self._by_ticker = {h.ticker: h for h in self.holdings}
@@ -82,6 +83,11 @@ class TradeRecord:
     price: float
     strategy_name: str
     holding_period: HoldingPeriod | None = None
+
+
+@dataclass
+class TradingRestrictions:
+    round_trip_days: int = 0  # 0 = no restriction
 
 
 @dataclass

--- a/src/midas/restrictions.py
+++ b/src/midas/restrictions.py
@@ -1,0 +1,37 @@
+"""Trading restriction enforcement — blocks trades that violate configurable rules."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from midas.models import Direction, TradingRestrictions
+
+
+class RestrictionTracker:
+    """Tracks executed trades and enforces round-trip restrictions.
+
+    Round-trip restriction: after buying (selling) a ticker, you cannot sell
+    (buy) it until `round_trip_days` have elapsed.
+    """
+
+    def __init__(self, restrictions: TradingRestrictions) -> None:
+        self._restrictions = restrictions
+        # (ticker, direction) -> date of last execution
+        self._last_trade: dict[tuple[str, Direction], date] = {}
+
+    def is_blocked(self, ticker: str, direction: Direction, today: date) -> bool:
+        """Return True if executing this trade would violate a restriction."""
+        if self._restrictions.round_trip_days <= 0:
+            return False
+
+        opposite = Direction.SELL if direction == Direction.BUY else Direction.BUY
+        last = self._last_trade.get((ticker, opposite))
+        if last is None:
+            return False
+
+        days_since = (today - last).days
+        return days_since < self._restrictions.round_trip_days
+
+    def record_trade(self, ticker: str, direction: Direction, today: date) -> None:
+        """Record an executed trade for future restriction checks."""
+        self._last_trade[(ticker, direction)] = today

--- a/tests/test_restrictions.py
+++ b/tests/test_restrictions.py
@@ -1,0 +1,56 @@
+"""Tests for trading restriction enforcement."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from midas.models import Direction, TradingRestrictions
+from midas.restrictions import RestrictionTracker
+
+
+class TestRestrictionTracker:
+    def test_no_restriction_when_disabled(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=0))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        assert not tracker.is_blocked("AAPL", Direction.SELL, date(2024, 1, 2))
+
+    def test_sell_blocked_within_window(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        assert tracker.is_blocked("AAPL", Direction.SELL, date(2024, 1, 15))
+
+    def test_sell_allowed_after_window(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        assert not tracker.is_blocked("AAPL", Direction.SELL, date(2024, 2, 1))
+
+    def test_buy_blocked_after_sell_within_window(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.SELL, date(2024, 1, 1))
+        assert tracker.is_blocked("AAPL", Direction.BUY, date(2024, 1, 15))
+
+    def test_same_direction_not_blocked(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        assert not tracker.is_blocked("AAPL", Direction.BUY, date(2024, 1, 2))
+
+    def test_different_tickers_independent(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        assert not tracker.is_blocked("MSFT", Direction.SELL, date(2024, 1, 2))
+
+    def test_no_trade_history_not_blocked(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        assert not tracker.is_blocked("AAPL", Direction.BUY, date(2024, 1, 1))
+
+    def test_exact_boundary_day_allowed(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        # Day 30 exactly should be allowed
+        assert not tracker.is_blocked("AAPL", Direction.SELL, date(2024, 1, 31))
+
+    def test_day_before_boundary_blocked(self) -> None:
+        tracker = RestrictionTracker(TradingRestrictions(round_trip_days=30))
+        tracker.record_trade("AAPL", Direction.BUY, date(2024, 1, 1))
+        # Day 29 should still be blocked
+        assert tracker.is_blocked("AAPL", Direction.SELL, date(2024, 1, 30))


### PR DESCRIPTION
Enforce a configurable round-trip restriction that prevents buying and selling the same ticker within a specified window (e.g. 30 days). Configured via portfolio YAML under trading_restrictions.round_trip_days. Enforced in both backtest and live engines.