### PR TITLE
Add 10 new trading strategies

### DIFF
--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -18,6 +18,13 @@ from midas.models import PortfolioConfig
 from midas.sizing import SizingConfig, SizingEngine
 from midas.strategies import STRATEGY_REGISTRY
 
+# Parameters that should be cast to int when building strategy instances.
+_INT_PARAMS = {
+    "window", "short_window", "long_window",
+    "fast_period", "slow_period", "signal_period",
+    "frequency_days",
+}
+
 # Default parameter ranges per strategy.
 # Each entry: (min, max, coarse_step, fine_step)
 PARAM_RANGES: dict[str, dict[str, tuple[float, float, float, float]]] = {
@@ -30,6 +37,43 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float, float]]] = {
     },
     "Momentum": {
         "window": (5, 50, 5, 2),
+    },
+    "RSIOversold": {
+        "window": (7, 28, 7, 2),
+        "oversold_threshold": (15.0, 40.0, 5.0, 2.0),
+    },
+    "RSIOverbought": {
+        "window": (7, 28, 7, 2),
+        "overbought_threshold": (60.0, 85.0, 5.0, 2.0),
+    },
+    "BollingerBand": {
+        "window": (10, 50, 10, 5),
+        "num_std": (1.5, 3.0, 0.5, 0.25),
+    },
+    "MACDCrossover": {
+        "fast_period": (8, 16, 4, 2),
+        "slow_period": (20, 32, 4, 2),
+        "signal_period": (5, 13, 4, 2),
+    },
+    "DollarCostAveraging": {
+        "frequency_days": (5, 30, 5, 2),
+    },
+    "GapDownRecovery": {
+        "gap_threshold": (0.02, 0.08, 0.02, 0.005),
+    },
+    "TrailingStop": {
+        "trail_pct": (0.05, 0.25, 0.05, 0.02),
+    },
+    "StopLoss": {
+        "loss_threshold": (0.05, 0.25, 0.05, 0.02),
+    },
+    "VWAPReversion": {
+        "window": (10, 50, 10, 5),
+        "threshold": (0.01, 0.05, 0.01, 0.005),
+    },
+    "MovingAverageCrossover": {
+        "short_window": (10, 30, 5, 2),
+        "long_window": (40, 100, 10, 5),
     },
 }
 
@@ -92,7 +136,7 @@ def _run_trial(
         # Convert window params to int
         clean_params = {}
         for k, v in params.items():
-            clean_params[k] = int(v) if k == "window" else v
+            clean_params[k] = int(v) if k in _INT_PARAMS else v
         strategy = cls(**clean_params)
         agents.append(Agent(strategy=strategy, cooldown_days=5))
 
@@ -232,7 +276,7 @@ def write_strategies_yaml(
         # Convert window to int for cleaner YAML
         clean = {}
         for k, v in p.items():
-            clean[k] = int(v) if k == "window" else round(v, 4)
+            clean[k] = int(v) if k in _INT_PARAMS else round(v, 4)
         strategies.append({"name": name, "params": clean})
 
     with open(path, "w") as f:

--- a/src/midas/strategies/__init__.py
+++ b/src/midas/strategies/__init__.py
@@ -1,20 +1,50 @@
 """Strategy library with auto-registration."""
 
 from midas.strategies.base import Strategy
+from midas.strategies.bollinger_band import BollingerBand
+from midas.strategies.dca import DollarCostAveraging
+from midas.strategies.gap_down_recovery import GapDownRecovery
+from midas.strategies.ma_crossover import MovingAverageCrossover
+from midas.strategies.macd_crossover import MACDCrossover
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.momentum import Momentum
 from midas.strategies.profit_taking import ProfitTaking
+from midas.strategies.rsi_overbought import RSIOverbought
+from midas.strategies.rsi_oversold import RSIOversold
+from midas.strategies.stop_loss import StopLoss
+from midas.strategies.trailing_stop import TrailingStop
+from midas.strategies.vwap_reversion import VWAPReversion
 
 STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
     "MeanReversion": MeanReversion,
     "Momentum": Momentum,
     "ProfitTaking": ProfitTaking,
+    "RSIOversold": RSIOversold,
+    "RSIOverbought": RSIOverbought,
+    "BollingerBand": BollingerBand,
+    "MACDCrossover": MACDCrossover,
+    "DollarCostAveraging": DollarCostAveraging,
+    "GapDownRecovery": GapDownRecovery,
+    "TrailingStop": TrailingStop,
+    "StopLoss": StopLoss,
+    "VWAPReversion": VWAPReversion,
+    "MovingAverageCrossover": MovingAverageCrossover,
 }
 
 __all__ = [
     "STRATEGY_REGISTRY",
+    "BollingerBand",
+    "DollarCostAveraging",
+    "GapDownRecovery",
+    "MACDCrossover",
     "MeanReversion",
     "Momentum",
+    "MovingAverageCrossover",
     "ProfitTaking",
+    "RSIOverbought",
+    "RSIOversold",
+    "StopLoss",
     "Strategy",
+    "TrailingStop",
+    "VWAPReversion",
 ]

--- a/src/midas/strategies/bollinger_band.py
+++ b/src/midas/strategies/bollinger_band.py
@@ -1,0 +1,65 @@
+"""Bollinger Band strategy: buy when price touches lower band."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class BollingerBand(Strategy):
+    def __init__(self, window: int = 20, num_std: float = 2.0) -> None:
+        self._window = window
+        self._num_std = num_std
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._window:
+            return []
+
+        values = np.asarray(price_history)
+        window_data = values[-self._window :]
+        ma = float(window_data.mean())
+        std = float(window_data.std(ddof=1))
+
+        if std == 0:
+            return []
+
+        lower_band = ma - self._num_std * std
+        current = float(values[-1])
+
+        if current <= lower_band:
+            pct_below = (lower_band - current) / std
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=pct_below / self._num_std,
+                reasoning=(
+                    f"{ticker} at ${current:.2f} touched lower Bollinger Band "
+                    f"(${lower_band:.2f}), {self._window}-day MA ${ma:.2f} "
+                    f"± {self._num_std}σ"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"BollingerBand(window={self._window}, num_std={self._num_std})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.BROAD_MARKET_ETF, AssetSuitability.LARGE_CAP]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy when price touches the lower Bollinger Band "
+            f"({self._window}-day MA − {self._num_std}σ)"
+        )

--- a/src/midas/strategies/dca.py
+++ b/src/midas/strategies/dca.py
@@ -1,0 +1,50 @@
+"""Dollar-cost averaging strategy: buy on a regular cadence."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class DollarCostAveraging(Strategy):
+    def __init__(self, frequency_days: int = 14) -> None:
+        self._frequency_days = frequency_days
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._frequency_days:
+            return []
+
+        # Signal fires when the number of trading days in the series
+        # is a multiple of the frequency — i.e. "it's time to buy again."
+        if len(price_history) % self._frequency_days == 0:
+            current = float(price_history.iloc[-1])
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=0.5,  # constant, disciplined buying
+                reasoning=(
+                    f"{ticker} DCA trigger: {self._frequency_days}-day "
+                    f"interval reached at ${current:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"DollarCostAveraging(frequency_days={self._frequency_days})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.BROAD_MARKET_ETF, AssetSuitability.LARGE_CAP]
+
+    @property
+    def description(self) -> str:
+        return f"Buy every {self._frequency_days} trading days regardless of price"

--- a/src/midas/strategies/gap_down_recovery.py
+++ b/src/midas/strategies/gap_down_recovery.py
@@ -1,0 +1,63 @@
+"""Gap down recovery strategy: buy when price gaps down then recovers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class GapDownRecovery(Strategy):
+    def __init__(self, gap_threshold: float = 0.03) -> None:
+        self._gap_threshold = gap_threshold
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < 3:
+            return []
+
+        values = np.asarray(price_history)
+        prev_close = float(values[-3])
+        gap_open = float(values[-2])  # proxy: previous day's close
+        current = float(values[-1])
+
+        if prev_close == 0:
+            return []
+
+        gap_pct = (prev_close - gap_open) / prev_close
+
+        # Gap down occurred and price recovered above the gap open
+        if gap_pct >= self._gap_threshold and current > gap_open:
+            recovery_pct = (current - gap_open) / (prev_close - gap_open)
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=min(recovery_pct, 1.0),
+                reasoning=(
+                    f"{ticker} gapped down {gap_pct:.1%} from ${prev_close:.2f} "
+                    f"to ${gap_open:.2f}, recovered to ${current:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"GapDownRecovery(gap_threshold={self._gap_threshold})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.INDIVIDUAL_EQUITY, AssetSuitability.HIGH_VOLATILITY]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy when price gaps down >{self._gap_threshold:.0%} "
+            f"then recovers above the gap level"
+        )

--- a/src/midas/strategies/ma_crossover.py
+++ b/src/midas/strategies/ma_crossover.py
@@ -1,0 +1,85 @@
+"""Moving average crossover: buy on golden cross, sell on death cross."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class MovingAverageCrossover(Strategy):
+    def __init__(self, short_window: int = 20, long_window: int = 50) -> None:
+        self._short_window = short_window
+        self._long_window = long_window
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._long_window + 1:
+            return []
+
+        values = np.asarray(price_history)
+        current = float(values[-1])
+
+        short_ma = float(values[-self._short_window :].mean())
+        long_ma = float(values[-self._long_window :].mean())
+        prev_short_ma = float(values[-(self._short_window + 1) : -1].mean())
+        prev_long_ma = float(values[-(self._long_window + 1) : -1].mean())
+
+        if long_ma == 0:
+            return []
+
+        # Golden cross: short MA crosses above long MA
+        if prev_short_ma <= prev_long_ma and short_ma > long_ma:
+            spread = (short_ma - long_ma) / long_ma
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=spread / 0.05,
+                reasoning=(
+                    f"{ticker} golden cross: {self._short_window}-day MA "
+                    f"(${short_ma:.2f}) crossed above {self._long_window}-day "
+                    f"MA (${long_ma:.2f}) at ${current:.2f}"
+                ),
+                price=current,
+            )]
+
+        # Death cross: short MA crosses below long MA
+        if prev_short_ma >= prev_long_ma and short_ma < long_ma:
+            spread = (long_ma - short_ma) / long_ma
+            return [self._make_signal(
+                ticker,
+                Direction.SELL,
+                strength=spread / 0.05,
+                reasoning=(
+                    f"{ticker} death cross: {self._short_window}-day MA "
+                    f"(${short_ma:.2f}) crossed below {self._long_window}-day "
+                    f"MA (${long_ma:.2f}) at ${current:.2f}"
+                ),
+                price=current,
+            )]
+
+        return []
+
+    @property
+    def name(self) -> str:
+        return (
+            f"MovingAverageCrossover(short={self._short_window}, "
+            f"long={self._long_window})"
+        )
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy on golden cross ({self._short_window}/{self._long_window}-day MA), "
+            f"sell on death cross"
+        )

--- a/src/midas/strategies/macd_crossover.py
+++ b/src/midas/strategies/macd_crossover.py
@@ -1,0 +1,82 @@
+"""MACD crossover strategy: buy when MACD line crosses above signal line."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+def _ema(values: np.ndarray, period: int) -> np.ndarray:
+    """Compute exponential moving average."""
+    alpha = 2.0 / (period + 1)
+    result = np.empty_like(values)
+    result[0] = values[0]
+    for i in range(1, len(values)):
+        result[i] = alpha * values[i] + (1 - alpha) * result[i - 1]
+    return result
+
+
+class MACDCrossover(Strategy):
+    def __init__(
+        self,
+        fast_period: int = 12,
+        slow_period: int = 26,
+        signal_period: int = 9,
+    ) -> None:
+        self._fast_period = fast_period
+        self._slow_period = slow_period
+        self._signal_period = signal_period
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        min_len = self._slow_period + self._signal_period
+        if len(price_history) < min_len:
+            return []
+
+        values = np.asarray(price_history, dtype=float)
+        fast_ema = _ema(values, self._fast_period)
+        slow_ema = _ema(values, self._slow_period)
+        macd_line = fast_ema - slow_ema
+        signal_line = _ema(macd_line, self._signal_period)
+
+        # Check for crossover: MACD was below signal, now above
+        if macd_line[-2] <= signal_line[-2] and macd_line[-1] > signal_line[-1]:
+            current = float(values[-1])
+            diff = float(macd_line[-1] - signal_line[-1])
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=min(abs(diff) / current * 100, 1.0),
+                reasoning=(
+                    f"{ticker} MACD({self._fast_period},{self._slow_period},"
+                    f"{self._signal_period}) crossed above signal line "
+                    f"at ${current:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return (
+            f"MACDCrossover(fast={self._fast_period}, "
+            f"slow={self._slow_period}, signal={self._signal_period})"
+        )
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy when MACD({self._fast_period},{self._slow_period}) "
+            f"crosses above {self._signal_period}-period signal line"
+        )

--- a/src/midas/strategies/rsi_overbought.py
+++ b/src/midas/strategies/rsi_overbought.py
@@ -1,0 +1,74 @@
+"""RSI overbought strategy: sell when RSI exceeds threshold."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class RSIOverbought(Strategy):
+    def __init__(self, window: int = 14, overbought_threshold: float = 70.0) -> None:
+        self._window = window
+        self._overbought_threshold = overbought_threshold
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._window + 1:
+            return []
+
+        values = np.asarray(price_history)
+        deltas = np.diff(values[-(self._window + 1) :])
+        gains = np.where(deltas > 0, deltas, 0.0)
+        losses = np.where(deltas < 0, -deltas, 0.0)
+
+        avg_gain = float(gains.mean())
+        avg_loss = float(losses.mean())
+
+        if avg_gain == 0 and avg_loss == 0:
+            return []  # No price movement — RSI undefined
+        elif avg_loss == 0:
+            rsi = 100.0  # All gains, no losses
+        else:
+            rs = avg_gain / avg_loss
+            rsi = 100.0 - (100.0 / (1.0 + rs))
+
+        current = float(values[-1])
+
+        if rsi >= self._overbought_threshold:
+            return [self._make_signal(
+                ticker,
+                Direction.SELL,
+                strength=(rsi - self._overbought_threshold)
+                / (100.0 - self._overbought_threshold),
+                reasoning=(
+                    f"{ticker} RSI({self._window}) at {rsi:.1f}, "
+                    f"above overbought threshold {self._overbought_threshold:.0f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return (
+            f"RSIOverbought(window={self._window}, "
+            f"overbought_threshold={self._overbought_threshold})"
+        )
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Sell when {self._window}-period RSI exceeds "
+            f"{self._overbought_threshold:.0f}"
+        )

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -1,0 +1,70 @@
+"""RSI oversold strategy: buy when RSI drops below threshold."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class RSIOversold(Strategy):
+    def __init__(self, window: int = 14, oversold_threshold: float = 30.0) -> None:
+        self._window = window
+        self._oversold_threshold = oversold_threshold
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._window + 1:
+            return []
+
+        values = np.asarray(price_history)
+        deltas = np.diff(values[-(self._window + 1) :])
+        gains = np.where(deltas > 0, deltas, 0.0)
+        losses = np.where(deltas < 0, -deltas, 0.0)
+
+        avg_gain = float(gains.mean())
+        avg_loss = float(losses.mean())
+
+        if avg_loss == 0:
+            return []
+
+        rs = avg_gain / avg_loss
+        rsi = 100.0 - (100.0 / (1.0 + rs))
+        current = float(values[-1])
+
+        if rsi <= self._oversold_threshold:
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=(self._oversold_threshold - rsi) / self._oversold_threshold,
+                reasoning=(
+                    f"{ticker} RSI({self._window}) at {rsi:.1f}, "
+                    f"below oversold threshold {self._oversold_threshold:.0f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return (
+            f"RSIOversold(window={self._window}, "
+            f"oversold_threshold={self._oversold_threshold})"
+        )
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy when {self._window}-period RSI drops below "
+            f"{self._oversold_threshold:.0f}"
+        )

--- a/src/midas/strategies/stop_loss.py
+++ b/src/midas/strategies/stop_loss.py
@@ -1,0 +1,56 @@
+"""Stop loss strategy: sell when unrealized loss exceeds threshold."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class StopLoss(Strategy):
+    def __init__(self, loss_threshold: float = 0.10) -> None:
+        self._loss_threshold = loss_threshold
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        *,
+        cost_basis: float | None = None,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if cost_basis is None or cost_basis <= 0:
+            return []
+
+        current = float(np.asarray(price_history)[-1])
+        loss = (cost_basis - current) / cost_basis
+
+        if loss >= self._loss_threshold:
+            return [self._make_signal(
+                ticker,
+                Direction.SELL,
+                strength=(loss - self._loss_threshold) / self._loss_threshold,
+                reasoning=(
+                    f"{ticker} down {loss:.0%} from "
+                    f"cost basis ${cost_basis:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"StopLoss(loss_threshold={self._loss_threshold})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Sell when unrealized loss exceeds {self._loss_threshold:.0%} "
+            f"of cost basis"
+        )

--- a/src/midas/strategies/trailing_stop.py
+++ b/src/midas/strategies/trailing_stop.py
@@ -1,0 +1,67 @@
+"""Trailing stop strategy: sell when price falls from high-water mark."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class TrailingStop(Strategy):
+    def __init__(self, trail_pct: float = 0.10) -> None:
+        self._trail_pct = trail_pct
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        *,
+        cost_basis: float | None = None,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if cost_basis is None or cost_basis <= 0:
+            return []
+
+        if len(price_history) < 2:
+            return []
+
+        values = np.asarray(price_history)
+        current = float(values[-1])
+
+        # High-water mark since entry: max of price history and cost basis
+        high_water = float(max(values.max(), cost_basis))
+
+        if high_water == 0:
+            return []
+
+        drawdown = (high_water - current) / high_water
+
+        if drawdown >= self._trail_pct and current > cost_basis:
+            return [self._make_signal(
+                ticker,
+                Direction.SELL,
+                strength=(drawdown - self._trail_pct) / self._trail_pct,
+                reasoning=(
+                    f"{ticker} down {drawdown:.1%} from high of ${high_water:.2f}, "
+                    f"trailing stop {self._trail_pct:.0%} triggered at ${current:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"TrailingStop(trail_pct={self._trail_pct})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Sell when price falls {self._trail_pct:.0%} from its "
+            f"high-water mark (while still above cost basis)"
+        )

--- a/src/midas/strategies/vwap_reversion.py
+++ b/src/midas/strategies/vwap_reversion.py
@@ -1,0 +1,77 @@
+"""VWAP reversion strategy: buy below average price, sell above.
+
+Note: Without volume data, this uses a simple moving average as a proxy
+for VWAP. With volume data available via the provider, this could be
+extended to use true volume-weighted average price.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from midas.models import AssetSuitability, Direction, Signal
+from midas.strategies.base import Strategy
+
+
+class VWAPReversion(Strategy):
+    def __init__(self, window: int = 20, threshold: float = 0.02) -> None:
+        self._window = window
+        self._threshold = threshold
+
+    def evaluate(
+        self,
+        ticker: str,
+        price_history: pd.Series,
+        **kwargs: object,
+    ) -> list[Signal]:
+        if len(price_history) < self._window:
+            return []
+
+        values = np.asarray(price_history)
+        current = float(values[-1])
+        avg_price = float(values[-self._window :].mean())
+
+        if avg_price == 0:
+            return []
+
+        deviation = (current - avg_price) / avg_price
+
+        if deviation <= -self._threshold:
+            return [self._make_signal(
+                ticker,
+                Direction.BUY,
+                strength=abs(deviation) / (self._threshold * 3),
+                reasoning=(
+                    f"{ticker} at ${current:.2f} is {abs(deviation):.1%} below "
+                    f"{self._window}-day VWAP proxy ${avg_price:.2f}"
+                ),
+                price=current,
+            )]
+        elif deviation >= self._threshold:
+            return [self._make_signal(
+                ticker,
+                Direction.SELL,
+                strength=deviation / (self._threshold * 3),
+                reasoning=(
+                    f"{ticker} at ${current:.2f} is {deviation:.1%} above "
+                    f"{self._window}-day VWAP proxy ${avg_price:.2f}"
+                ),
+                price=current,
+            )]
+        return []
+
+    @property
+    def name(self) -> str:
+        return f"VWAPReversion(window={self._window}, threshold={self._threshold})"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.LARGE_CAP, AssetSuitability.BROAD_MARKET_ETF]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy below / sell above {self._window}-day average price "
+            f"(VWAP proxy) by {self._threshold:.0%}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,3 +82,38 @@ def crossover_prices() -> pd.Series:
     """Price dips below MA then crosses back above — triggers momentum."""
     returns = [0.0] * 20 + [-0.008] * 15 + [0.015] * 10 + [0.0] * 55
     return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="CROSS")
+
+
+@pytest.fixture
+def volatile_dropping_prices() -> pd.Series:
+    """Price with sustained losses at the end — triggers RSI oversold."""
+    returns = [0.001] * 80 + [-0.02] * 20
+    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="VDROP")
+
+
+@pytest.fixture
+def volatile_rising_prices() -> pd.Series:
+    """Strong sustained gains at the end — triggers RSI overbought."""
+    returns = [0.001] * 80 + [0.02] * 20
+    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="VRISE")
+
+
+@pytest.fixture
+def gap_down_recovery_prices() -> pd.Series:
+    """Price stable then sharp drop then recovery — triggers gap down recovery."""
+    returns = [0.0] * 95 + [-0.05, -0.04, 0.06] + [0.0] * 2
+    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="GAP")
+
+
+@pytest.fixture
+def peak_then_drop_prices() -> pd.Series:
+    """Price rises then falls — triggers trailing stop."""
+    returns = [0.01] * 30 + [-0.005] * 40 + [0.0] * 30
+    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="PEAK")
+
+
+@pytest.fixture
+def ma_crossover_prices() -> pd.Series:
+    """Long decline followed by recovery — triggers golden cross."""
+    returns = [-0.002] * 60 + [0.008] * 30 + [0.0] * 10
+    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="MACROSS")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -107,8 +107,14 @@ def test_full_pipeline(tmp_path: Path) -> None:
 
 
 def test_strategy_registry_complete() -> None:
-    """All three strategies should be registered and instantiable."""
-    expected = {"MeanReversion", "Momentum", "ProfitTaking"}
+    """All strategies should be registered and instantiable."""
+    expected = {
+        "MeanReversion", "Momentum", "ProfitTaking",
+        "RSIOversold", "RSIOverbought", "BollingerBand",
+        "MACDCrossover", "DollarCostAveraging", "GapDownRecovery",
+        "TrailingStop", "StopLoss", "VWAPReversion",
+        "MovingAverageCrossover",
+    }
     assert set(STRATEGY_REGISTRY.keys()) == expected
 
     for _name, cls in STRATEGY_REGISTRY.items():

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -3,9 +3,19 @@
 import pandas as pd
 
 from midas.models import Direction
+from midas.strategies.bollinger_band import BollingerBand
+from midas.strategies.dca import DollarCostAveraging
+from midas.strategies.gap_down_recovery import GapDownRecovery
+from midas.strategies.ma_crossover import MovingAverageCrossover
+from midas.strategies.macd_crossover import MACDCrossover
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.momentum import Momentum
 from midas.strategies.profit_taking import ProfitTaking
+from midas.strategies.rsi_overbought import RSIOverbought
+from midas.strategies.rsi_oversold import RSIOversold
+from midas.strategies.stop_loss import StopLoss
+from midas.strategies.trailing_stop import TrailingStop
+from midas.strategies.vwap_reversion import VWAPReversion
 
 
 class TestMeanReversion:
@@ -74,3 +84,256 @@ class TestMomentum:
         short = pd.Series([100.0] * 10, name="SHORT")
         strategy = Momentum(window=20)
         assert strategy.evaluate("SHORT", short) == []
+
+
+class TestRSIOversold:
+    def test_buy_signal_on_oversold(
+        self, volatile_dropping_prices: pd.Series
+    ) -> None:
+        strategy = RSIOversold(window=14, oversold_threshold=40.0)
+        signals = strategy.evaluate("VDROP", volatile_dropping_prices)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.BUY
+        assert 0.0 <= signals[0].strength <= 1.0
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = RSIOversold(window=14, oversold_threshold=30.0)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 5)
+        strategy = RSIOversold(window=14)
+        assert strategy.evaluate("SHORT", short) == []
+
+    def test_name_and_description(self) -> None:
+        s = RSIOversold(window=10, oversold_threshold=25.0)
+        assert "10" in s.name
+        assert "25" in s.name
+        assert len(s.suitability) > 0
+        assert s.description
+
+
+class TestRSIOverbought:
+    def test_sell_signal_on_overbought(
+        self, volatile_rising_prices: pd.Series
+    ) -> None:
+        strategy = RSIOverbought(window=14, overbought_threshold=65.0)
+        signals = strategy.evaluate("VRISE", volatile_rising_prices)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.SELL
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = RSIOverbought(window=14, overbought_threshold=70.0)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 5)
+        strategy = RSIOverbought(window=14)
+        assert strategy.evaluate("SHORT", short) == []
+
+
+class TestBollingerBand:
+    def test_buy_on_lower_band(self, dropping_prices: pd.Series) -> None:
+        strategy = BollingerBand(window=20, num_std=1.5)
+        signals = strategy.evaluate("DROP", dropping_prices)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.BUY
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = BollingerBand(window=20, num_std=2.0)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 5)
+        strategy = BollingerBand(window=20)
+        assert strategy.evaluate("SHORT", short) == []
+
+    def test_name_and_description(self) -> None:
+        s = BollingerBand(window=20, num_std=2.5)
+        assert "20" in s.name
+        assert "2.5" in s.name
+
+
+class TestMACDCrossover:
+    def test_buy_on_crossover(self, crossover_prices: pd.Series) -> None:
+        strategy = MACDCrossover(fast_period=12, slow_period=26, signal_period=9)
+        # Walk through price history to find crossover
+        found_signal = False
+        for i in range(35, len(crossover_prices)):
+            signals = strategy.evaluate("CROSS", crossover_prices.iloc[: i + 1])
+            if signals:
+                assert signals[0].direction == Direction.BUY
+                found_signal = True
+                break
+        assert found_signal, "Expected a MACD crossover signal"
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = MACDCrossover()
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 10)
+        strategy = MACDCrossover()
+        assert strategy.evaluate("SHORT", short) == []
+
+
+class TestDollarCostAveraging:
+    def test_signal_on_frequency(self, flat_prices: pd.Series) -> None:
+        strategy = DollarCostAveraging(frequency_days=10)
+        # Feed exactly 10 days — should trigger
+        signals = strategy.evaluate("FLAT", flat_prices.iloc[:10])
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.BUY
+        assert signals[0].strength == 0.5
+
+    def test_no_signal_off_frequency(self, flat_prices: pd.Series) -> None:
+        strategy = DollarCostAveraging(frequency_days=10)
+        signals = strategy.evaluate("FLAT", flat_prices.iloc[:11])
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 3)
+        strategy = DollarCostAveraging(frequency_days=5)
+        assert strategy.evaluate("SHORT", short) == []
+
+    def test_name_and_description(self) -> None:
+        s = DollarCostAveraging(frequency_days=7)
+        assert "7" in s.name
+        assert s.description
+
+
+class TestGapDownRecovery:
+    def test_buy_on_gap_recovery(
+        self, gap_down_recovery_prices: pd.Series
+    ) -> None:
+        strategy = GapDownRecovery(gap_threshold=0.03)
+        # Walk to find a gap-down + recovery
+        found_signal = False
+        for i in range(3, len(gap_down_recovery_prices)):
+            signals = strategy.evaluate(
+                "GAP", gap_down_recovery_prices.iloc[: i + 1]
+            )
+            if signals:
+                assert signals[0].direction == Direction.BUY
+                found_signal = True
+                break
+        assert found_signal, "Expected a gap-down recovery signal"
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = GapDownRecovery(gap_threshold=0.03)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0, 95.0])
+        strategy = GapDownRecovery()
+        assert strategy.evaluate("SHORT", short) == []
+
+
+class TestTrailingStop:
+    def test_sell_on_drawdown(self, peak_then_drop_prices: pd.Series) -> None:
+        strategy = TrailingStop(trail_pct=0.08)
+        signals = strategy.evaluate(
+            "PEAK", peak_then_drop_prices, cost_basis=100.0
+        )
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.SELL
+
+    def test_no_signal_without_cost_basis(
+        self, peak_then_drop_prices: pd.Series
+    ) -> None:
+        strategy = TrailingStop(trail_pct=0.08)
+        assert strategy.evaluate("PEAK", peak_then_drop_prices) == []
+
+    def test_no_signal_on_rising(self, rising_prices: pd.Series) -> None:
+        strategy = TrailingStop(trail_pct=0.10)
+        signals = strategy.evaluate("RISE", rising_prices, cost_basis=100.0)
+        assert signals == []
+
+    def test_name_and_description(self) -> None:
+        s = TrailingStop(trail_pct=0.15)
+        assert "0.15" in s.name
+        assert s.description
+
+
+class TestStopLoss:
+    def test_sell_on_loss(self, dropping_prices: pd.Series) -> None:
+        strategy = StopLoss(loss_threshold=0.10)
+        signals = strategy.evaluate("DROP", dropping_prices, cost_basis=100.0)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.SELL
+
+    def test_no_signal_without_cost_basis(
+        self, dropping_prices: pd.Series
+    ) -> None:
+        strategy = StopLoss(loss_threshold=0.10)
+        assert strategy.evaluate("DROP", dropping_prices) == []
+
+    def test_no_signal_above_cost(self, rising_prices: pd.Series) -> None:
+        strategy = StopLoss(loss_threshold=0.10)
+        signals = strategy.evaluate("RISE", rising_prices, cost_basis=100.0)
+        assert signals == []
+
+    def test_name_and_description(self) -> None:
+        s = StopLoss(loss_threshold=0.05)
+        assert "0.05" in s.name
+        assert s.description
+
+
+class TestVWAPReversion:
+    def test_buy_below_average(self, dropping_prices: pd.Series) -> None:
+        strategy = VWAPReversion(window=20, threshold=0.01)
+        signals = strategy.evaluate("DROP", dropping_prices)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.BUY
+
+    def test_sell_above_average(self, rising_prices: pd.Series) -> None:
+        strategy = VWAPReversion(window=20, threshold=0.01)
+        signals = strategy.evaluate("RISE", rising_prices)
+        assert len(signals) == 1
+        assert signals[0].direction == Direction.SELL
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = VWAPReversion(window=20, threshold=0.02)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 5)
+        strategy = VWAPReversion(window=20)
+        assert strategy.evaluate("SHORT", short) == []
+
+
+class TestMovingAverageCrossover:
+    def test_buy_on_golden_cross(
+        self, ma_crossover_prices: pd.Series
+    ) -> None:
+        strategy = MovingAverageCrossover(short_window=10, long_window=30)
+        found_signal = False
+        for i in range(31, len(ma_crossover_prices)):
+            signals = strategy.evaluate(
+                "MACROSS", ma_crossover_prices.iloc[: i + 1]
+            )
+            if signals and signals[0].direction == Direction.BUY:
+                found_signal = True
+                break
+        assert found_signal, "Expected a golden cross signal"
+
+    def test_no_signal_on_flat(self, flat_prices: pd.Series) -> None:
+        strategy = MovingAverageCrossover(short_window=10, long_window=30)
+        signals = strategy.evaluate("FLAT", flat_prices)
+        assert signals == []
+
+    def test_insufficient_history(self) -> None:
+        short = pd.Series([100.0] * 20)
+        strategy = MovingAverageCrossover(short_window=10, long_window=50)
+        assert strategy.evaluate("SHORT", short) == []
+
+    def test_name_and_description(self) -> None:
+        s = MovingAverageCrossover(short_window=15, long_window=45)
+        assert "15" in s.name
+        assert "45" in s.name


### PR DESCRIPTION
## Summary
- Adds 10 new strategies: RSI Oversold, RSI Overbought, Bollinger Band, MACD Crossover, Dollar-Cost Averaging, Gap Down Recovery, Trailing Stop, Stop Loss, VWAP Reversion, and Moving Average Crossover
- Adds optimizer parameter ranges for all new strategies, with `_INT_PARAMS` set to correctly handle integer params beyond just `window`
- Adds 37 new tests and 5 new fixtures covering all strategies (merged into `test_strategies.py`)

## Test plan
- [x] All 73 tests pass
- [x] Run `midas strategies` to verify all 13 strategies are listed
- [ ] Backtest with new strategies in `strategies.yaml`
- [ ] Run optimizer with new strategies

🤖 Generated with [Claude Code](https://claude.com/claude-code)