### PR TITLE
Document trading restrictions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ portfolio:
 
 available_cash: 2000.00
 
+trading_restrictions:
+  round_trip_days: 30  # can't buy then sell (or vice versa) the same ticker within 30 days
+
 cash_infusion:
   amount: 1500.00
   next_date: 2026-04-03


### PR DESCRIPTION
## Summary
- Adds the `trading_restrictions` config block to the portfolio YAML example in the README, showing the `round_trip_days` option added in #1.

## Test plan
- [ ] Verify the YAML example in the README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)