### PR TITLE
Optimize backtest performance: parallel trials and np.ndarray interface

### DIFF
--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -6,7 +6,7 @@ import logging
 import math
 from dataclasses import dataclass
 
-import pandas as pd
+import numpy as np
 
 from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints
 from midas.strategies.base import Strategy
@@ -85,7 +85,7 @@ class Allocator:
     def allocate(
         self,
         tickers: list[str],
-        price_data: dict[str, pd.Series],
+        price_data: dict[str, np.ndarray],
         context: dict[str, dict[str, object]] | None = None,
     ) -> AllocationResult:
         """Compute target weights for all tickers.

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -319,10 +319,7 @@ class BacktestEngine:
         day: date,
     ) -> None:
         # Build price arrays and current prices for active tickers
-        active_tickers = [
-            t for t in state.positions
-            if state.positions.get(t, 0) > 0 or t in current_data
-        ]
+        active_tickers = [t for t in state.positions if state.positions.get(t, 0) > 0 or t in current_data]
         # Only include tickers that have price data
         active_tickers = [t for t in active_tickers if t in current_data]
 
@@ -343,7 +340,9 @@ class BacktestEngine:
 
         # Phase 1-3: Allocator scores, blends, and applies vetoes
         allocation = self._allocator.allocate(
-            active_tickers, current_data, context,
+            active_tickers,
+            current_data,
+            context,
         )
 
         # Phase 4: Rebalancer diffs target vs current, generates orders
@@ -363,7 +362,9 @@ class BacktestEngine:
                 if ticker in current_data:
                     ticker_ctx = context.get(ticker, {})
                     intents = strat.generate_intents(
-                        ticker, current_data[ticker], **ticker_ctx,
+                        ticker,
+                        current_data[ticker],
+                        **ticker_ctx,
                     )
                     mechanical_intents.extend(intents)
 

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -318,21 +318,20 @@ class BacktestEngine:
         current_data: dict[str, np.ndarray],
         day: date,
     ) -> None:
-        # Build price series and current prices for active tickers
-        active_tickers = [t for t in state.positions if state.positions.get(t, 0) > 0 or t in current_data]
+        # Build price arrays and current prices for active tickers
+        active_tickers = [
+            t for t in state.positions
+            if state.positions.get(t, 0) > 0 or t in current_data
+        ]
         # Only include tickers that have price data
         active_tickers = [t for t in active_tickers if t in current_data]
 
         if not active_tickers:
             return
 
-        # Build pd.Series for allocator (from numpy arrays)
-        price_series: dict[str, pd.Series] = {}
         current_prices: dict[str, float] = {}
         for ticker in active_tickers:
-            arr = current_data[ticker]
-            price_series[ticker] = pd.Series(arr)
-            current_prices[ticker] = float(arr[-1])
+            current_prices[ticker] = float(current_data[ticker][-1])
 
         # Build per-ticker context (cost_basis for strategies that need it)
         context: dict[str, dict[str, object]] = {}
@@ -344,9 +343,7 @@ class BacktestEngine:
 
         # Phase 1-3: Allocator scores, blends, and applies vetoes
         allocation = self._allocator.allocate(
-            active_tickers,
-            price_series,
-            context,
+            active_tickers, current_data, context,
         )
 
         # Phase 4: Rebalancer diffs target vs current, generates orders
@@ -363,12 +360,10 @@ class BacktestEngine:
         mechanical_intents: list[MechanicalIntent] = []
         for strat in self._mechanical:
             for ticker in active_tickers:
-                if ticker in price_series:
+                if ticker in current_data:
                     ticker_ctx = context.get(ticker, {})
                     intents = strat.generate_intents(
-                        ticker,
-                        price_series[ticker],
-                        **ticker_ctx,
+                        ticker, current_data[ticker], **ticker_ctx,
                     )
                     mechanical_intents.extend(intents)
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -99,9 +99,7 @@ class LiveEngine:
 
         # Convert pd.Series to numpy arrays at the boundary — strategies
         # and the allocator operate on np.ndarray for performance.
-        price_arrays: dict[str, np.ndarray] = {
-            t: np.asarray(price_data[t]) for t in active_tickers
-        }
+        price_arrays: dict[str, np.ndarray] = {t: np.asarray(price_data[t]) for t in active_tickers}
 
         # Phase 1-3: Allocate
         allocation = self._allocator.allocate(active_tickers, price_arrays, context)
@@ -127,7 +125,9 @@ class LiveEngine:
                 if ticker in price_arrays:
                     ticker_ctx = context.get(ticker, {})
                     intents = strat.generate_intents(
-                        ticker, price_arrays[ticker], **ticker_ctx,
+                        ticker,
+                        price_arrays[ticker],
+                        **ticker_ctx,
                     )
                     mechanical_intents.extend(intents)
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from datetime import UTC, date, datetime, timedelta
 
+import numpy as np
 import pandas as pd
 
 from midas.allocator import Allocator
@@ -96,8 +97,14 @@ class LiveEngine:
 
         active_tickers = [t for t in tickers if t in price_data]
 
+        # Convert pd.Series to numpy arrays at the boundary — strategies
+        # and the allocator operate on np.ndarray for performance.
+        price_arrays: dict[str, np.ndarray] = {
+            t: np.asarray(price_data[t]) for t in active_tickers
+        }
+
         # Phase 1-3: Allocate
-        allocation = self._allocator.allocate(active_tickers, price_data, context)
+        allocation = self._allocator.allocate(active_tickers, price_arrays, context)
 
         # Phase 4: Rebalance
         positions = {}
@@ -117,12 +124,10 @@ class LiveEngine:
         mechanical_intents: list[MechanicalIntent] = []
         for strat in self._mechanical:
             for ticker in active_tickers:
-                if ticker in price_data:
+                if ticker in price_arrays:
                     ticker_ctx = context.get(ticker, {})
                     intents = strat.generate_intents(
-                        ticker,
-                        price_data[ticker],
-                        **ticker_ctx,
+                        ticker, price_arrays[ticker], **ticker_ctx,
                     )
                     mechanical_intents.extend(intents)
 

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass
@@ -299,6 +300,7 @@ def optimize(
     )
 
     trials_done = 0
+    progress_lock = threading.Lock()
 
     def objective(trial: optuna.Trial) -> float:
         nonlocal trials_done
@@ -322,14 +324,15 @@ def optimize(
         trial.set_user_attr("test_return", test_ret)
         trial.set_user_attr("params", strategy_params)
 
-        trials_done += 1
-        if trials_done % 25 == 0 or trials_done == n_trials:
-            log(f"  {trials_done}/{n_trials} — best so far: {study.best_value:.2%}")
+        with progress_lock:
+            trials_done += 1
+            if trials_done % 25 == 0 or trials_done == n_trials:
+                log(f"  {trials_done}/{n_trials} — best so far: {study.best_value:.2%}")
 
         return total_ret
 
     try:
-        study.optimize(objective, n_trials=n_trials)
+        study.optimize(objective, n_trials=n_trials, n_jobs=max_workers)
     finally:
         pool.shutdown(wait=False)
 

--- a/src/midas/strategies/base.py
+++ b/src/midas/strategies/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-import pandas as pd
+import numpy as np
 
 from midas.models import AssetSuitability, MechanicalIntent, StrategyTier
 
@@ -19,7 +19,7 @@ class Strategy(ABC):
     @abstractmethod
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         """Return conviction score.
@@ -41,7 +41,7 @@ class Strategy(ABC):
     def generate_intents(
         self,
         ticker: str,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> list[MechanicalIntent]:
         """Return mechanical order intents. Override for MECHANICAL strategies."""

--- a/src/midas/strategies/bollinger_band.py
+++ b/src/midas/strategies/bollinger_band.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -16,14 +15,13 @@ class BollingerBand(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window:
             return None
 
-        values = np.asarray(price_history)
-        window_data = values[-self._window :]
+        window_data = price_history[-self._window :]
         ma = float(window_data.mean())
         std = float(window_data.std(ddof=1))
 
@@ -31,7 +29,7 @@ class BollingerBand(Strategy):
             return 0.0
 
         lower_band = ma - self._num_std * std
-        current = float(values[-1])
+        current = float(price_history[-1])
 
         if current <= lower_band:
             pct_below = (lower_band - current) / std

--- a/src/midas/strategies/dca.py
+++ b/src/midas/strategies/dca.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd
+import numpy as np
 
 from midas.models import (
     AssetSuitability,
@@ -24,7 +24,7 @@ class DollarCostAveraging(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         # MECHANICAL strategies don't participate in scoring.
@@ -33,23 +33,24 @@ class DollarCostAveraging(Strategy):
     def generate_intents(
         self,
         ticker: str,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> list[MechanicalIntent]:
         if len(price_history) < self._frequency_days:
             return []
 
         if len(price_history) % self._frequency_days == 0:
-            current = float(price_history.iloc[-1])
-            return [
-                MechanicalIntent(
-                    ticker=ticker,
-                    direction=Direction.BUY,
-                    target_value=self._amount,
-                    reason=(f"{ticker} DCA trigger: {self._frequency_days}-day interval reached at ${current:.2f}"),
-                    source=self.name,
-                )
-            ]
+            current = float(price_history[-1])
+            return [MechanicalIntent(
+                ticker=ticker,
+                direction=Direction.BUY,
+                target_value=self._amount,
+                reason=(
+                    f"{ticker} DCA trigger: {self._frequency_days}-day "
+                    f"interval reached at ${current:.2f}"
+                ),
+                source=self.name,
+            )]
         return []
 
     @property

--- a/src/midas/strategies/dca.py
+++ b/src/midas/strategies/dca.py
@@ -41,16 +41,15 @@ class DollarCostAveraging(Strategy):
 
         if len(price_history) % self._frequency_days == 0:
             current = float(price_history[-1])
-            return [MechanicalIntent(
-                ticker=ticker,
-                direction=Direction.BUY,
-                target_value=self._amount,
-                reason=(
-                    f"{ticker} DCA trigger: {self._frequency_days}-day "
-                    f"interval reached at ${current:.2f}"
-                ),
-                source=self.name,
-            )]
+            return [
+                MechanicalIntent(
+                    ticker=ticker,
+                    direction=Direction.BUY,
+                    target_value=self._amount,
+                    reason=(f"{ticker} DCA trigger: {self._frequency_days}-day interval reached at ${current:.2f}"),
+                    source=self.name,
+                )
+            ]
         return []
 
     @property

--- a/src/midas/strategies/gap_down_recovery.py
+++ b/src/midas/strategies/gap_down_recovery.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -15,16 +14,15 @@ class GapDownRecovery(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < 3:
             return None
 
-        values = np.asarray(price_history)
-        prev_close = float(values[-3])
-        gap_open = float(values[-2])
-        current = float(values[-1])
+        prev_close = float(price_history[-3])
+        gap_open = float(price_history[-2])
+        current = float(price_history[-1])
 
         if prev_close == 0:
             return 0.0

--- a/src/midas/strategies/ma_crossover.py
+++ b/src/midas/strategies/ma_crossover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -16,18 +15,16 @@ class MovingAverageCrossover(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._long_window + 1:
             return None
 
-        values = np.asarray(price_history)
-
-        short_ma = float(values[-self._short_window :].mean())
-        long_ma = float(values[-self._long_window :].mean())
-        prev_short_ma = float(values[-(self._short_window + 1) : -1].mean())
-        prev_long_ma = float(values[-(self._long_window + 1) : -1].mean())
+        short_ma = float(price_history[-self._short_window :].mean())
+        long_ma = float(price_history[-self._long_window :].mean())
+        prev_short_ma = float(price_history[-(self._short_window + 1) : -1].mean())
+        prev_long_ma = float(price_history[-(self._long_window + 1) : -1].mean())
 
         if long_ma == 0:
             return 0.0

--- a/src/midas/strategies/macd_crossover.py
+++ b/src/midas/strategies/macd_crossover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -32,21 +31,20 @@ class MACDCrossover(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         min_len = self._slow_period + self._signal_period
         if len(price_history) < min_len:
             return None
 
-        values = np.asarray(price_history, dtype=float)
-        fast_ema = _ema(values, self._fast_period)
-        slow_ema = _ema(values, self._slow_period)
+        fast_ema = _ema(price_history, self._fast_period)
+        slow_ema = _ema(price_history, self._slow_period)
         macd_line = fast_ema - slow_ema
         signal_line = _ema(macd_line, self._signal_period)
 
         if macd_line[-2] <= signal_line[-2] and macd_line[-1] > signal_line[-1]:
-            current = float(values[-1])
+            current = float(price_history[-1])
             diff = float(macd_line[-1] - signal_line[-1])
             return self._clamp(min(abs(diff) / current * 100, 1.0))
         return 0.0

--- a/src/midas/strategies/mean_reversion.py
+++ b/src/midas/strategies/mean_reversion.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -16,15 +15,14 @@ class MeanReversion(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window:
             return None
 
-        values = np.asarray(price_history)
-        current = float(values[-1])
-        ma = float(values[-self._window :].mean())
+        current = float(price_history[-1])
+        ma = float(price_history[-self._window:].mean())
 
         if ma == 0:
             return 0.0

--- a/src/midas/strategies/mean_reversion.py
+++ b/src/midas/strategies/mean_reversion.py
@@ -22,7 +22,7 @@ class MeanReversion(Strategy):
             return None
 
         current = float(price_history[-1])
-        ma = float(price_history[-self._window:].mean())
+        ma = float(price_history[-self._window :].mean())
 
         if ma == 0:
             return 0.0

--- a/src/midas/strategies/momentum.py
+++ b/src/midas/strategies/momentum.py
@@ -21,8 +21,8 @@ class Momentum(Strategy):
             return None
 
         current, prev = float(price_history[-1]), float(price_history[-2])
-        ma = float(price_history[-self._window:].mean())
-        prev_ma = float(price_history[-(self._window + 1):-1].mean())
+        ma = float(price_history[-self._window :].mean())
+        prev_ma = float(price_history[-(self._window + 1) : -1].mean())
 
         if prev <= prev_ma and current > ma:
             pct_above = (current - ma) / ma

--- a/src/midas/strategies/momentum.py
+++ b/src/midas/strategies/momentum.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -15,16 +14,15 @@ class Momentum(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window + 1:
             return None
 
-        values = np.asarray(price_history)
-        current, prev = float(values[-1]), float(values[-2])
-        ma = float(values[-self._window :].mean())
-        prev_ma = float(values[-(self._window + 1) : -1].mean())
+        current, prev = float(price_history[-1]), float(price_history[-2])
+        ma = float(price_history[-self._window:].mean())
+        prev_ma = float(price_history[-(self._window + 1):-1].mean())
 
         if prev <= prev_ma and current > ma:
             pct_above = (current - ma) / ma

--- a/src/midas/strategies/profit_taking.py
+++ b/src/midas/strategies/profit_taking.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -15,7 +14,7 @@ class ProfitTaking(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         *,
         cost_basis: float | None = None,
         **kwargs: object,
@@ -23,7 +22,7 @@ class ProfitTaking(Strategy):
         if cost_basis is None or cost_basis <= 0:
             return None
 
-        current = float(np.asarray(price_history)[-1])
+        current = float(price_history[-1])
         gain = (current - cost_basis) / cost_basis
 
         if gain >= self._gain_threshold:

--- a/src/midas/strategies/rsi_overbought.py
+++ b/src/midas/strategies/rsi_overbought.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -16,14 +15,13 @@ class RSIOverbought(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window + 1:
             return None
 
-        values = np.asarray(price_history)
-        deltas = np.diff(values[-(self._window + 1) :])
+        deltas = np.diff(price_history[-(self._window + 1) :])
         gains = np.where(deltas > 0, deltas, 0.0)
         losses = np.where(deltas < 0, -deltas, 0.0)
 

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -16,14 +15,13 @@ class RSIOversold(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window + 1:
             return None
 
-        values = np.asarray(price_history)
-        deltas = np.diff(values[-(self._window + 1) :])
+        deltas = np.diff(price_history[-(self._window + 1) :])
         gains = np.where(deltas > 0, deltas, 0.0)
         losses = np.where(deltas < 0, -deltas, 0.0)
 

--- a/src/midas/strategies/stop_loss.py
+++ b/src/midas/strategies/stop_loss.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability, StrategyTier
 from midas.strategies.base import Strategy
@@ -19,7 +18,7 @@ class StopLoss(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         *,
         cost_basis: float | None = None,
         **kwargs: object,
@@ -27,7 +26,7 @@ class StopLoss(Strategy):
         if cost_basis is None or cost_basis <= 0:
             return None
 
-        current = float(np.asarray(price_history)[-1])
+        current = float(price_history[-1])
         loss = (cost_basis - current) / cost_basis
 
         if loss >= self._loss_threshold:

--- a/src/midas/strategies/trailing_stop.py
+++ b/src/midas/strategies/trailing_stop.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability, StrategyTier
 from midas.strategies.base import Strategy
@@ -19,7 +18,7 @@ class TrailingStop(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         *,
         cost_basis: float | None = None,
         **kwargs: object,
@@ -30,9 +29,8 @@ class TrailingStop(Strategy):
         if len(price_history) < 2:
             return None
 
-        values = np.asarray(price_history)
-        current = float(values[-1])
-        high_water = float(max(values.max(), cost_basis))
+        current = float(price_history[-1])
+        high_water = float(max(price_history.max(), cost_basis))
 
         if high_water == 0:
             return 0.0

--- a/src/midas/strategies/vwap_reversion.py
+++ b/src/midas/strategies/vwap_reversion.py
@@ -8,7 +8,6 @@ extended to use true volume-weighted average price.
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 
 from midas.models import AssetSuitability
 from midas.strategies.base import Strategy
@@ -21,15 +20,14 @@ class VWAPReversion(Strategy):
 
     def score(
         self,
-        price_history: pd.Series,
+        price_history: np.ndarray,
         **kwargs: object,
     ) -> float | None:
         if len(price_history) < self._window:
             return None
 
-        values = np.asarray(price_history)
-        current = float(values[-1])
-        avg_price = float(values[-self._window :].mean())
+        current = float(price_history[-1])
+        avg_price = float(price_history[-self._window :].mean())
 
         if avg_price == 0:
             return 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -32,9 +33,10 @@ def make_price_series(
     daily_returns: list[float] | None = None,
     name: str = "TEST",
 ) -> pd.Series:
-    """Generate a synthetic price series.
+    """Generate a synthetic price series with a date index.
 
-    If daily_returns is None, generates a flat price series.
+    Used by backtest/optimizer tests that need pd.Series with date indexes.
+    Strategy and allocator tests should use make_price_array() instead.
     """
     dates = []
     prices = []
@@ -53,67 +55,82 @@ def make_price_series(
     return series
 
 
+def make_price_array(
+    days: int,
+    base_price: float,
+    daily_returns: list[float] | None = None,
+) -> np.ndarray:
+    """Generate a synthetic price array for strategy/allocator tests."""
+    prices = []
+    price = base_price
+    for i in range(days):
+        if daily_returns and i < len(daily_returns):
+            price *= 1 + daily_returns[i]
+        prices.append(round(price, 2))
+    return np.array(prices)
+
+
 @pytest.fixture
-def flat_prices() -> pd.Series:
+def flat_prices() -> np.ndarray:
     """100 days of flat $100 price."""
-    return make_price_series(date(2024, 1, 2), 100, 100.0, name="FLAT")
+    return make_price_array(100, 100.0)
 
 
 @pytest.fixture
-def dropping_prices() -> pd.Series:
+def dropping_prices() -> np.ndarray:
     """Price is stable then drops sharply at the end — triggers mean reversion.
 
     The last few days are a sharp drop while the 30-day MA still includes
     the stable period, creating a gap between current price and MA.
     """
     returns = [0.0] * 90 + [-0.02] * 10
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="DROP")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def rising_prices() -> pd.Series:
+def rising_prices() -> np.ndarray:
     """Price rises steadily — triggers profit taking."""
     returns = [0.003] * 100
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="RISE")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def crossover_prices() -> pd.Series:
+def crossover_prices() -> np.ndarray:
     """Price dips below MA then crosses back above — triggers momentum."""
     returns = [0.0] * 20 + [-0.008] * 15 + [0.015] * 10 + [0.0] * 55
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="CROSS")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def volatile_dropping_prices() -> pd.Series:
+def volatile_dropping_prices() -> np.ndarray:
     """Price with sustained losses at the end — triggers RSI oversold."""
     returns = [0.001] * 80 + [-0.02] * 20
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="VDROP")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def volatile_rising_prices() -> pd.Series:
+def volatile_rising_prices() -> np.ndarray:
     """Strong sustained gains at the end — triggers RSI overbought."""
     returns = [0.001] * 80 + [0.02] * 20
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="VRISE")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def gap_down_recovery_prices() -> pd.Series:
+def gap_down_recovery_prices() -> np.ndarray:
     """Price stable then sharp drop then recovery — triggers gap down recovery."""
     returns = [0.0] * 95 + [-0.05, -0.04, 0.06] + [0.0] * 2
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="GAP")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def peak_then_drop_prices() -> pd.Series:
+def peak_then_drop_prices() -> np.ndarray:
     """Price rises then falls — triggers trailing stop."""
     returns = [0.01] * 30 + [-0.005] * 40 + [0.0] * 30
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="PEAK")
+    return make_price_array(100, 100.0, returns)
 
 
 @pytest.fixture
-def ma_crossover_prices() -> pd.Series:
+def ma_crossover_prices() -> np.ndarray:
     """Long decline followed by recovery — triggers golden cross."""
     returns = [-0.002] * 60 + [0.008] * 30 + [0.0] * 10
-    return make_price_series(date(2024, 1, 2), 100, 100.0, returns, name="MACROSS")
+    return make_price_array(100, 100.0, returns)

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 
-import pandas as pd
+import numpy as np
 
 from midas.allocator import Allocator
 from midas.models import AllocationConstraints
@@ -13,8 +13,8 @@ from midas.strategies.momentum import Momentum
 from midas.strategies.stop_loss import StopLoss
 
 
-def _prices(values: list[float]) -> pd.Series:
-    return pd.Series(values)
+def _prices(values: list[float]) -> np.ndarray:
+    return np.array(values)
 
 
 class TestAllocator:

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,6 +1,6 @@
 """Tests for individual strategies — score() interface."""
 
-import pandas as pd
+import numpy as np
 
 from midas.models import StrategyTier
 from midas.strategies.bollinger_band import BollingerBand
@@ -19,11 +19,11 @@ from midas.strategies.vwap_reversion import VWAPReversion
 
 
 class TestMeanReversion:
-    def test_no_signal_on_flat_prices(self, flat_prices: pd.Series) -> None:
+    def test_no_signal_on_flat_prices(self, flat_prices: np.ndarray) -> None:
         strategy = MeanReversion(window=30, threshold=0.10)
         assert strategy.score(flat_prices) == 0.0
 
-    def test_positive_score_on_drop(self, dropping_prices: pd.Series) -> None:
+    def test_positive_score_on_drop(self, dropping_prices: np.ndarray) -> None:
         strategy = MeanReversion(window=30, threshold=0.05)
         score = strategy.score(dropping_prices)
         assert score is not None
@@ -31,7 +31,7 @@ class TestMeanReversion:
         assert score <= 1.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 5, name="SHORT")
+        short = np.array([100.0] * 5)
         strategy = MeanReversion(window=30)
         assert strategy.score(short) is None
 
@@ -43,18 +43,18 @@ class TestMeanReversion:
 
 
 class TestProfitTaking:
-    def test_negative_score_on_gain(self, rising_prices: pd.Series) -> None:
+    def test_negative_score_on_gain(self, rising_prices: np.ndarray) -> None:
         strategy = ProfitTaking(gain_threshold=0.15)
         score = strategy.score(rising_prices, cost_basis=100.0)
         assert score is not None
         assert score < 0.0  # bearish (sell)
 
-    def test_abstain_without_cost_basis(self, rising_prices: pd.Series) -> None:
+    def test_abstain_without_cost_basis(self, rising_prices: np.ndarray) -> None:
         strategy = ProfitTaking(gain_threshold=0.15)
         assert strategy.score(rising_prices) is None
         assert strategy.score(rising_prices, cost_basis=None) is None
 
-    def test_neutral_below_threshold(self, flat_prices: pd.Series) -> None:
+    def test_neutral_below_threshold(self, flat_prices: np.ndarray) -> None:
         strategy = ProfitTaking(gain_threshold=0.20)
         score = strategy.score(flat_prices, cost_basis=100.0)
         assert score == 0.0
@@ -64,39 +64,41 @@ class TestProfitTaking:
 
 
 class TestMomentum:
-    def test_positive_score_on_crossover(self, crossover_prices: pd.Series) -> None:
+    def test_positive_score_on_crossover(self, crossover_prices: np.ndarray) -> None:
         strategy = Momentum(window=20)
         found_signal = False
         for i in range(21, len(crossover_prices)):
-            score = strategy.score(crossover_prices.iloc[: i + 1])
+            score = strategy.score(crossover_prices[: i + 1])
             if score is not None and score > 0:
                 found_signal = True
                 break
         assert found_signal, "Expected a positive momentum score"
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = Momentum(window=20)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 10, name="SHORT")
+        short = np.array([100.0] * 10)
         strategy = Momentum(window=20)
         assert strategy.score(short) is None
 
 
 class TestRSIOversold:
-    def test_positive_score_on_oversold(self, volatile_dropping_prices: pd.Series) -> None:
+    def test_positive_score_on_oversold(
+        self, volatile_dropping_prices: np.ndarray
+    ) -> None:
         strategy = RSIOversold(window=14, oversold_threshold=40.0)
         score = strategy.score(volatile_dropping_prices)
         assert score is not None
         assert 0.0 < score <= 1.0
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = RSIOversold(window=14, oversold_threshold=30.0)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 5)
+        short = np.array([100.0] * 5)
         strategy = RSIOversold(window=14)
         assert strategy.score(short) is None
 
@@ -108,35 +110,37 @@ class TestRSIOversold:
 
 
 class TestRSIOverbought:
-    def test_negative_score_on_overbought(self, volatile_rising_prices: pd.Series) -> None:
+    def test_negative_score_on_overbought(
+        self, volatile_rising_prices: np.ndarray
+    ) -> None:
         strategy = RSIOverbought(window=14, overbought_threshold=65.0)
         score = strategy.score(volatile_rising_prices)
         assert score is not None
         assert score < 0.0
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = RSIOverbought(window=14, overbought_threshold=70.0)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 5)
+        short = np.array([100.0] * 5)
         strategy = RSIOverbought(window=14)
         assert strategy.score(short) is None
 
 
 class TestBollingerBand:
-    def test_positive_score_on_lower_band(self, dropping_prices: pd.Series) -> None:
+    def test_positive_score_on_lower_band(self, dropping_prices: np.ndarray) -> None:
         strategy = BollingerBand(window=20, num_std=1.5)
         score = strategy.score(dropping_prices)
         assert score is not None
         assert score > 0.0
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = BollingerBand(window=20, num_std=2.0)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 5)
+        short = np.array([100.0] * 5)
         strategy = BollingerBand(window=20)
         assert strategy.score(short) is None
 
@@ -146,22 +150,22 @@ class TestBollingerBand:
 
 
 class TestMACDCrossover:
-    def test_positive_score_on_crossover(self, crossover_prices: pd.Series) -> None:
+    def test_positive_score_on_crossover(self, crossover_prices: np.ndarray) -> None:
         strategy = MACDCrossover(fast_period=12, slow_period=26, signal_period=9)
         found_signal = False
         for i in range(35, len(crossover_prices)):
-            score = strategy.score(crossover_prices.iloc[: i + 1])
+            score = strategy.score(crossover_prices[: i + 1])
             if score is not None and score > 0:
                 found_signal = True
                 break
         assert found_signal, "Expected a positive MACD crossover score"
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = MACDCrossover()
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 10)
+        short = np.array([100.0] * 10)
         strategy = MACDCrossover()
         assert strategy.score(short) is None
 
@@ -171,19 +175,19 @@ class TestDollarCostAveraging:
         strategy = DollarCostAveraging(frequency_days=10)
         assert strategy.tier == StrategyTier.MECHANICAL
 
-    def test_score_returns_none(self, flat_prices: pd.Series) -> None:
+    def test_score_returns_none(self, flat_prices: np.ndarray) -> None:
         strategy = DollarCostAveraging(frequency_days=10)
         assert strategy.score(flat_prices) is None
 
-    def test_generates_intent_on_frequency(self, flat_prices: pd.Series) -> None:
+    def test_generates_intent_on_frequency(self, flat_prices: np.ndarray) -> None:
         strategy = DollarCostAveraging(frequency_days=10)
-        intents = strategy.generate_intents("FLAT", flat_prices.iloc[:10])
+        intents = strategy.generate_intents("FLAT", flat_prices[:10])
         assert len(intents) == 1
         assert intents[0].target_value == 500.0
 
-    def test_no_intent_off_frequency(self, flat_prices: pd.Series) -> None:
+    def test_no_intent_off_frequency(self, flat_prices: np.ndarray) -> None:
         strategy = DollarCostAveraging(frequency_days=10)
-        intents = strategy.generate_intents("FLAT", flat_prices.iloc[:11])
+        intents = strategy.generate_intents("FLAT", flat_prices[:11])
         assert intents == []
 
     def test_name_and_description(self) -> None:
@@ -193,38 +197,44 @@ class TestDollarCostAveraging:
 
 
 class TestGapDownRecovery:
-    def test_positive_score_on_gap_recovery(self, gap_down_recovery_prices: pd.Series) -> None:
+    def test_positive_score_on_gap_recovery(
+        self, gap_down_recovery_prices: np.ndarray
+    ) -> None:
         strategy = GapDownRecovery(gap_threshold=0.03)
         found_signal = False
         for i in range(3, len(gap_down_recovery_prices)):
-            score = strategy.score(gap_down_recovery_prices.iloc[: i + 1])
+            score = strategy.score(
+                gap_down_recovery_prices[: i + 1]
+            )
             if score is not None and score > 0:
                 found_signal = True
                 break
         assert found_signal, "Expected a positive gap-down recovery score"
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = GapDownRecovery(gap_threshold=0.03)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0, 95.0])
+        short = np.array([100.0, 95.0])
         strategy = GapDownRecovery()
         assert strategy.score(short) is None
 
 
 class TestTrailingStop:
-    def test_negative_score_on_drawdown(self, peak_then_drop_prices: pd.Series) -> None:
+    def test_negative_score_on_drawdown(self, peak_then_drop_prices: np.ndarray) -> None:
         strategy = TrailingStop(trail_pct=0.08)
         score = strategy.score(peak_then_drop_prices, cost_basis=100.0)
         assert score is not None
         assert score < 0.0
 
-    def test_abstain_without_cost_basis(self, peak_then_drop_prices: pd.Series) -> None:
+    def test_abstain_without_cost_basis(
+        self, peak_then_drop_prices: np.ndarray
+    ) -> None:
         strategy = TrailingStop(trail_pct=0.08)
         assert strategy.score(peak_then_drop_prices) is None
 
-    def test_neutral_on_rising(self, rising_prices: pd.Series) -> None:
+    def test_neutral_on_rising(self, rising_prices: np.ndarray) -> None:
         strategy = TrailingStop(trail_pct=0.10)
         assert strategy.score(rising_prices, cost_basis=100.0) == 0.0
 
@@ -238,17 +248,19 @@ class TestTrailingStop:
 
 
 class TestStopLoss:
-    def test_negative_score_on_loss(self, dropping_prices: pd.Series) -> None:
+    def test_negative_score_on_loss(self, dropping_prices: np.ndarray) -> None:
         strategy = StopLoss(loss_threshold=0.10)
         score = strategy.score(dropping_prices, cost_basis=100.0)
         assert score is not None
         assert score < 0.0
 
-    def test_abstain_without_cost_basis(self, dropping_prices: pd.Series) -> None:
+    def test_abstain_without_cost_basis(
+        self, dropping_prices: np.ndarray
+    ) -> None:
         strategy = StopLoss(loss_threshold=0.10)
         assert strategy.score(dropping_prices) is None
 
-    def test_neutral_above_cost(self, rising_prices: pd.Series) -> None:
+    def test_neutral_above_cost(self, rising_prices: np.ndarray) -> None:
         strategy = StopLoss(loss_threshold=0.10)
         assert strategy.score(rising_prices, cost_basis=100.0) == 0.0
 
@@ -262,45 +274,49 @@ class TestStopLoss:
 
 
 class TestVWAPReversion:
-    def test_positive_score_below_average(self, dropping_prices: pd.Series) -> None:
+    def test_positive_score_below_average(self, dropping_prices: np.ndarray) -> None:
         strategy = VWAPReversion(window=20, threshold=0.01)
         score = strategy.score(dropping_prices)
         assert score is not None
         assert score > 0.0
 
-    def test_negative_score_above_average(self, rising_prices: pd.Series) -> None:
+    def test_negative_score_above_average(self, rising_prices: np.ndarray) -> None:
         strategy = VWAPReversion(window=20, threshold=0.01)
         score = strategy.score(rising_prices)
         assert score is not None
         assert score < 0.0
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = VWAPReversion(window=20, threshold=0.02)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 5)
+        short = np.array([100.0] * 5)
         strategy = VWAPReversion(window=20)
         assert strategy.score(short) is None
 
 
 class TestMovingAverageCrossover:
-    def test_positive_score_on_golden_cross(self, ma_crossover_prices: pd.Series) -> None:
+    def test_positive_score_on_golden_cross(
+        self, ma_crossover_prices: np.ndarray
+    ) -> None:
         strategy = MovingAverageCrossover(short_window=10, long_window=30)
         found_signal = False
         for i in range(31, len(ma_crossover_prices)):
-            score = strategy.score(ma_crossover_prices.iloc[: i + 1])
+            score = strategy.score(
+                ma_crossover_prices[: i + 1]
+            )
             if score is not None and score > 0:
                 found_signal = True
                 break
         assert found_signal, "Expected a positive golden cross score"
 
-    def test_neutral_on_flat(self, flat_prices: pd.Series) -> None:
+    def test_neutral_on_flat(self, flat_prices: np.ndarray) -> None:
         strategy = MovingAverageCrossover(short_window=10, long_window=30)
         assert strategy.score(flat_prices) == 0.0
 
     def test_insufficient_history(self) -> None:
-        short = pd.Series([100.0] * 20)
+        short = np.array([100.0] * 20)
         strategy = MovingAverageCrossover(short_window=10, long_window=50)
         assert strategy.score(short) is None
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -85,9 +85,7 @@ class TestMomentum:
 
 
 class TestRSIOversold:
-    def test_positive_score_on_oversold(
-        self, volatile_dropping_prices: np.ndarray
-    ) -> None:
+    def test_positive_score_on_oversold(self, volatile_dropping_prices: np.ndarray) -> None:
         strategy = RSIOversold(window=14, oversold_threshold=40.0)
         score = strategy.score(volatile_dropping_prices)
         assert score is not None
@@ -110,9 +108,7 @@ class TestRSIOversold:
 
 
 class TestRSIOverbought:
-    def test_negative_score_on_overbought(
-        self, volatile_rising_prices: np.ndarray
-    ) -> None:
+    def test_negative_score_on_overbought(self, volatile_rising_prices: np.ndarray) -> None:
         strategy = RSIOverbought(window=14, overbought_threshold=65.0)
         score = strategy.score(volatile_rising_prices)
         assert score is not None
@@ -197,15 +193,11 @@ class TestDollarCostAveraging:
 
 
 class TestGapDownRecovery:
-    def test_positive_score_on_gap_recovery(
-        self, gap_down_recovery_prices: np.ndarray
-    ) -> None:
+    def test_positive_score_on_gap_recovery(self, gap_down_recovery_prices: np.ndarray) -> None:
         strategy = GapDownRecovery(gap_threshold=0.03)
         found_signal = False
         for i in range(3, len(gap_down_recovery_prices)):
-            score = strategy.score(
-                gap_down_recovery_prices[: i + 1]
-            )
+            score = strategy.score(gap_down_recovery_prices[: i + 1])
             if score is not None and score > 0:
                 found_signal = True
                 break
@@ -228,9 +220,7 @@ class TestTrailingStop:
         assert score is not None
         assert score < 0.0
 
-    def test_abstain_without_cost_basis(
-        self, peak_then_drop_prices: np.ndarray
-    ) -> None:
+    def test_abstain_without_cost_basis(self, peak_then_drop_prices: np.ndarray) -> None:
         strategy = TrailingStop(trail_pct=0.08)
         assert strategy.score(peak_then_drop_prices) is None
 
@@ -254,9 +244,7 @@ class TestStopLoss:
         assert score is not None
         assert score < 0.0
 
-    def test_abstain_without_cost_basis(
-        self, dropping_prices: np.ndarray
-    ) -> None:
+    def test_abstain_without_cost_basis(self, dropping_prices: np.ndarray) -> None:
         strategy = StopLoss(loss_threshold=0.10)
         assert strategy.score(dropping_prices) is None
 
@@ -297,15 +285,11 @@ class TestVWAPReversion:
 
 
 class TestMovingAverageCrossover:
-    def test_positive_score_on_golden_cross(
-        self, ma_crossover_prices: np.ndarray
-    ) -> None:
+    def test_positive_score_on_golden_cross(self, ma_crossover_prices: np.ndarray) -> None:
         strategy = MovingAverageCrossover(short_window=10, long_window=30)
         found_signal = False
         for i in range(31, len(ma_crossover_prices)):
-            score = strategy.score(
-                ma_crossover_prices[: i + 1]
-            )
+            score = strategy.score(ma_crossover_prices[: i + 1])
             if score is not None and score > 0:
                 found_signal = True
                 break


### PR DESCRIPTION
## Summary
- **Parallel trial execution**: Use Optuna's `n_jobs` parameter so multiple trials run concurrently across the `ProcessPoolExecutor`, instead of blocking serially on each `.result()`. Gives ~Nx speedup where N = number of pool workers.
- **np.ndarray strategy interface**: Change `Strategy.score()` and `Allocator.allocate()` from `pd.Series` to `np.ndarray`. Every strategy was immediately calling `np.asarray()` on the Series anyway, and the backtest was constructing ~200K `pd.Series` objects per optimization run just to wrap numpy arrays. The live engine converts once at the boundary.

## Test plan
- [x] All 102 existing tests pass
- [ ] Run optimizer with `all-strategies.yaml` and compare wall-clock time before/after
- [ ] Verify live engine still produces correct alerts with the ndarray boundary conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)