### PR TITLE
Fix optimizer to maximize train-set return, not full-period return

### DIFF
--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -314,7 +314,7 @@ def optimize(
                 ranges[name],
             )
 
-        total_ret, bh_ret, train_ret, test_ret = pool.submit(
+        _total_ret, bh_ret, train_ret, test_ret = pool.submit(
             _trial_worker,
             strategy_params,
         ).result()
@@ -330,7 +330,7 @@ def optimize(
             if trials_done % 25 == 0 or trials_done == n_trials:
                 log(f"  {trials_done}/{n_trials} — best so far: {study.best_value:.2%}")
 
-        return total_ret
+        return train_ret
 
     try:
         study.optimize(objective, n_trials=n_trials, n_jobs=max_workers)


### PR DESCRIPTION
## Summary
- The optimizer's objective function returned `total_ret` (full-period return) to Optuna, meaning the 30% test period was included in optimization — making it in-sample
- Changed to return `train_ret` so Optuna only optimizes against the 70% training set
- The test period is now genuinely out-of-sample

## Test plan
- [ ] Run `midas optimize` and verify the "best so far" values reflect train-set return, not total return
- [ ] Confirm test return diverges from train return (evidence of real out-of-sample evaluation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)