### PR TITLE
Reimplement cash_infusion support

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -313,6 +313,12 @@ class BacktestEngine:
         current_data: dict[str, np.ndarray],
         day: date,
     ) -> None:
+        # Credit cash infusion if it lands on or before today
+        infusion = portfolio.cash_infusion
+        if infusion and infusion.next_date <= day:
+            state.cash += infusion.amount
+            infusion.advance()
+
         # Build price arrays and current prices for active tickers
         active_tickers = [t for t in state.positions if state.positions.get(t, 0) > 0 or t in current_data]
         # Only include tickers that have price data
@@ -342,6 +348,7 @@ class BacktestEngine:
 
         # Phase 4: Rebalancer diffs target vs current, generates orders
         positions = {t: state.positions.get(t, 0.0) for t in active_tickers}
+
         rebalance_orders = self._rebalancer.generate_orders(
             allocation,
             positions,

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, timedelta
 from enum import Enum
 
 DEFAULT_MIN_CASH_PCT = 0.05
@@ -45,11 +45,28 @@ class Holding:
     cost_basis: float | None = None
 
 
+FREQUENCY_DAYS: dict[str, int] = {
+    "weekly": 7,
+    "biweekly": 14,
+    "monthly": 30,
+}
+
+
 @dataclass
 class CashInfusion:
     amount: float
     next_date: date
     frequency: str | None = None
+
+    def advance(self) -> None:
+        """Advance next_date by frequency. No-op if frequency is None."""
+        if self.frequency is None:
+            return
+        days = FREQUENCY_DAYS.get(self.frequency)
+        if days is None:
+            msg = f"Unknown cash_infusion frequency: {self.frequency!r}"
+            raise ValueError(msg)
+        self.next_date += timedelta(days=days)
 
 
 @dataclass

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -8,7 +8,7 @@ from conftest import make_price_series
 
 from midas.allocator import Allocator
 from midas.backtest import BacktestEngine, write_backtest_csv
-from midas.models import AllocationConstraints, Direction, Holding, PortfolioConfig
+from midas.models import AllocationConstraints, CashInfusion, Direction, Holding, PortfolioConfig
 from midas.rebalancer import Rebalancer
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.profit_taking import ProfitTaking
@@ -205,3 +205,66 @@ def test_backtest_excluded_ticker() -> None:
     assert "GHOST" in excluded_msgs[0]
 
     assert result.starting_value == 1000.0 + 10 * 100.0
+
+
+def test_backtest_cash_infusion_credits_cash() -> None:
+    """Cash infusions should be credited on their next_date during backtest."""
+    prices = make_price_series(date(2024, 1, 2), 100, 100.0, name="AAPL")
+    trading_days = list(prices.index)
+    # Pick an infusion date that falls on a trading day in the middle
+    infusion_date = trading_days[50]
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10)],
+        available_cash=1000.0,
+        cash_infusion=CashInfusion(
+            amount=2000.0,
+            next_date=infusion_date,
+        ),
+    )
+
+    mr = MeanReversion(window=20, threshold=0.05)
+    engine = _build_engine(
+        conviction_strategies=[(mr, 1.0)],
+        enable_split=False,
+    )
+
+    start = trading_days[0]
+    end = trading_days[-1]
+    result = engine.run(portfolio, {"AAPL": prices}, start, end)
+
+    # Final value should reflect the 2000 infusion (starting cash 1000 + infusion 2000 = 3000 base)
+    # Even with no trades, cash portion should include the infusion
+    assert result.final_value >= 3000.0
+
+
+def test_backtest_recurring_cash_infusion() -> None:
+    """Recurring cash infusions should credit multiple times."""
+    prices = make_price_series(date(2024, 1, 2), 100, 100.0, name="AAPL")
+    trading_days = list(prices.index)
+    # Start infusion early so multiple biweekly infusions land in the window
+    infusion_date = trading_days[5]
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10)],
+        available_cash=500.0,
+        cash_infusion=CashInfusion(
+            amount=1000.0,
+            next_date=infusion_date,
+            frequency="biweekly",
+        ),
+    )
+
+    mr = MeanReversion(window=20, threshold=0.05)
+    engine = _build_engine(
+        conviction_strategies=[(mr, 1.0)],
+        enable_split=False,
+    )
+
+    start = trading_days[0]
+    end = trading_days[-1]
+    result = engine.run(portfolio, {"AAPL": prices}, start, end)
+
+    # With ~100 trading days (~140 calendar days), biweekly = ~10 infusions of $1000
+    # Final value must exceed starting holdings + multiple infusions
+    assert result.final_value > 500.0 + 10 * 100.0 + 5000.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,11 @@
 
 from datetime import date
 
+import pytest
+
 from midas.models import (
     AllocationConstraints,
+    CashInfusion,
     Direction,
     Holding,
     HoldingPeriod,
@@ -99,3 +102,30 @@ def test_strategy_config_defaults() -> None:
     cfg = StrategyConfig(name="TestStrategy")
     assert cfg.weight == 1.0
     assert cfg.veto_threshold == -0.5
+
+
+class TestCashInfusion:
+    def test_advance_biweekly(self) -> None:
+        infusion = CashInfusion(amount=1500.0, next_date=date(2025, 1, 3), frequency="biweekly")
+        infusion.advance()
+        assert infusion.next_date == date(2025, 1, 17)
+
+    def test_advance_weekly(self) -> None:
+        infusion = CashInfusion(amount=500.0, next_date=date(2025, 1, 3), frequency="weekly")
+        infusion.advance()
+        assert infusion.next_date == date(2025, 1, 10)
+
+    def test_advance_monthly(self) -> None:
+        infusion = CashInfusion(amount=2000.0, next_date=date(2025, 1, 3), frequency="monthly")
+        infusion.advance()
+        assert infusion.next_date == date(2025, 2, 2)
+
+    def test_advance_no_frequency_is_noop(self) -> None:
+        infusion = CashInfusion(amount=1500.0, next_date=date(2025, 1, 3))
+        infusion.advance()
+        assert infusion.next_date == date(2025, 1, 3)
+
+    def test_advance_unknown_frequency_raises(self) -> None:
+        infusion = CashInfusion(amount=1500.0, next_date=date(2025, 1, 3), frequency="quarterly")
+        with pytest.raises(ValueError, match="Unknown cash_infusion frequency"):
+            infusion.advance()


### PR DESCRIPTION
## Summary
- `cash_infusion` config was parsed but never consumed after the target-weight allocation refactor in #5 dropped the `SizingEngine`
- Added `CashInfusion.advance()` to bump `next_date` by frequency (weekly/biweekly/monthly)
- Backtest now credits infusion cash on its scheduled date and advances recurring infusions
- No lookahead/speculative spending — only actual cash is used for order sizing

## Test plan
- [x] Unit tests for `CashInfusion.advance()` (all frequencies + no-op + unknown)
- [x] Backtest integration test: single infusion credits cash
- [x] Backtest integration test: recurring biweekly infusions credit multiple times
- [x] All 109 existing + new tests pass
- [x] ruff, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)