### PR TITLE
Add architecture and strategy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Target-weight allocation engine for your portfolio. Strategies emit continuous conviction scores, an allocator blends them into target portfolio weights via sigmoid transformation, and a rebalancer diffs against current holdings to generate trades. Optimize strategy parameters with walk-forward optimization, backtest against years of historical data with train/test splits, and run it live with real-time polling.
 
-See [Architecture](docs/architecture.md) for how the engine works and [Strategies](docs/strategies.md) for a reference of all available strategies.
-
 ## Quick Start
 
 ```bash
@@ -14,6 +12,8 @@ uv run midas live -p portfolio.yaml -s strategies.yaml
 uv run midas optimize -p portfolio.yaml --start 2023-01-01 --end 2024-12-31
 uv run midas optimize -p portfolio.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward
 ```
+
+See [Architecture](docs/architecture.md) for how the engine works and [Strategies](docs/strategies.md) for a reference of all available strategies. Pre-built strategy compositions are available in [`example-strategies/`](example-strategies/).
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Midas
 
 Target-weight allocation engine for your portfolio. Strategies emit continuous conviction scores, an allocator blends them into target portfolio weights via sigmoid transformation, and a rebalancer diffs against current holdings to generate trades. Optimize strategy parameters with walk-forward optimization, backtest against years of historical data with train/test splits, and run it live with real-time polling.
+
+See [Architecture](docs/architecture.md) for how the engine works and [Strategies](docs/strategies.md) for a reference of all available strategies.
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
 # Midas
 
-Target-weight allocation engine for your portfolio. Strategies emit continuous conviction scores, an allocator blends them into target portfolio weights via sigmoid transformation, and a rebalancer diffs against current holdings to generate trades. Optimize strategy parameters with walk-forward optimization, backtest against years of historical data with train/test splits, and run it live with real-time polling.
+Target-weight allocation engine for your portfolio. Define your holdings and pick a set of strategies to fit your thesis -- Midas scores every position using technical indicators, blends those scores into target portfolio weights via a sigmoid transformation, and generates the trades needed to rebalance.
+
+- **Optimize** strategy parameters with Bayesian search and walk-forward validation
+- **Backtest** against years of historical data with train/test splits
+- **Live** poll real-time prices and get trade alerts
 
 ## Quick Start
 
 ```bash
 uv sync
+
+# list available strategies
 uv run midas strategies
-uv run midas backtest -p portfolio.yaml -s strategies.yaml --start 2023-01-01 --end 2024-12-31 -o results.csv
+
+# find optimal parameters
+uv run midas optimize -p portfolio.yaml -s strategies.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward -o optimized.yaml
+
+# validate performance
+uv run midas backtest -p portfolio.yaml -s strategies.yaml --start 2020-01-01 --end 2025-01-01
+
+# real-time alerts
 uv run midas live -p portfolio.yaml -s strategies.yaml
-uv run midas optimize -p portfolio.yaml --start 2023-01-01 --end 2024-12-31
-uv run midas optimize -p portfolio.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward
 ```
 
-See [Architecture](docs/architecture.md) for how the engine works and [Strategies](docs/strategies.md) for a reference of all available strategies. Pre-built strategy compositions are available in [`example-strategies/`](example-strategies/).
+## Configuration
 
-## Config
+Midas takes two YAML files: a portfolio (what you own) and a strategies file (how to trade it).
 
 ### Portfolio
 
 ```yaml
-# portfolio.yaml
 portfolio:
   - ticker: VOO
     shares: 5
@@ -32,7 +42,7 @@ portfolio:
 available_cash: 2000.00
 
 trading_restrictions:
-  round_trip_days: 30  # can't buy then sell (or vice versa) the same ticker within 30 days
+  round_trip_days: 30
 
 cash_infusion:
   amount: 1500.00
@@ -43,42 +53,38 @@ cash_infusion:
 ### Strategies
 
 ```yaml
-# strategies.yaml
-sigmoid_steepness: 2.0        # how aggressively the allocator responds to conviction
-rebalance_threshold: 0.02     # ignore weight diffs smaller than 2%
-min_cash_pct: 0.05            # always keep 5% cash
-# max_position_pct: 0.20      # omit to auto-compute from portfolio size
+sigmoid_steepness: 2.0
+rebalance_threshold: 0.02
+min_cash_pct: 0.05
 
 strategies:
-  - name: MeanReversion
-    weight: 1.5              # blending influence (conviction strategies only)
+  - name: BollingerBand
+    weight: 1.0
     params:
-      window: 30
-      threshold: 0.10
+      window: 20
+      num_std: 2.0
+  - name: RSIOversold
+    weight: 1.0
+    params:
+      window: 14
+      oversold_threshold: 30.0
   - name: StopLoss
-    veto_threshold: -0.5     # score at or below which position is force-liquidated
+    veto_threshold: -0.5
     params:
       loss_threshold: 0.10
-  - name: DollarCostAveraging
-    params:
-      frequency_days: 14
-      amount: 500.00        # dollar amount per DCA buy
 ```
 
-See [Strategies](docs/strategies.md) for all available strategies, their parameters, and how to compose them. Pre-built configurations are in [`example-strategies/`](example-strategies/).
+Don't want to build your own? Start with one of the [pre-built compositions](example-strategies/).
 
-## Optimizer
+## Docs
 
-The optimizer uses Bayesian optimization to search over all tunable parameters jointly -- strategy params, weights, veto thresholds, and global allocator settings. It outputs a strategies YAML with optimized values.
-
-```bash
-uv run midas optimize -p portfolio.yaml --start 2015-01-01 --end 2024-12-31 -o optimized.yaml
-uv run midas optimize -p portfolio.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward -n 200
-```
-
-See [Architecture](docs/architecture.md#optimizer) for details on standard vs. walk-forward optimization.
+- [Architecture](docs/architecture.md) -- how the engine works: strategies, allocator, rebalancer, and execution modes
+- [Strategies](docs/strategies.md) -- all 13 strategies, how to compose them, and how they interact
+- [CLI Reference](docs/cli.md) -- every command and option
 
 ## Development
+
+Requires [uv](https://docs.astral.sh/uv/) and Python 3.14+.
 
 ```bash
 uv sync                     # install all deps
@@ -87,5 +93,3 @@ uv run ruff check . --fix   # lint
 uv run ruff format .        # format
 uv run mypy src             # type check
 ```
-
-Requires [uv](https://docs.astral.sh/uv/) and Python 3.14+.

--- a/README.md
+++ b/README.md
@@ -65,76 +65,18 @@ strategies:
       amount: 500.00        # dollar amount per DCA buy
 ```
 
-Each strategy has an intrinsic tier determined by its class:
-
-| Tier | Behavior | Strategies |
-|------|----------|------------|
-| CONVICTION | Scores blended via weighted average into target weights | MeanReversion, Momentum, RSIOversold, RSIOverbought, BollingerBand, MACDCrossover, VWAPReversion, MovingAverageCrossover, GapDownRecovery, ProfitTaking |
-| PROTECTIVE | Evaluated after blending; vetoes position (forces weight to 0) if score <= `veto_threshold` | StopLoss, TrailingStop |
-| MECHANICAL | Bypasses allocator entirely; generates independent order intents | DollarCostAveraging |
-
-**Strategy knobs:**
-
-| Field | Scope | Default | Description |
-|-------|-------|---------|-------------|
-| `sigmoid_steepness` | Global | 2.0 | Controls how aggressively the allocator responds to conviction scores. Higher = more extreme position sizes |
-| `rebalance_threshold` | Global | 0.02 | Minimum weight diff to trigger a rebalance trade. Higher = fewer, larger trades |
-| `min_cash_pct` | Global | 0.05 | Minimum cash allocation as a fraction of portfolio value. Higher = more conservative |
-| `max_position_pct` | Global | auto | Maximum weight for any single position. Omit to auto-compute from portfolio size |
-| `weight` | CONVICTION only | 1.0 | How much influence this strategy has in the blended score. Higher = more influence relative to other strategies. Ignored for PROTECTIVE and MECHANICAL strategies |
-| `veto_threshold` | PROTECTIVE only | -0.5 | Score at or below which the strategy forces target weight to 0.0. Lower (e.g. -0.8) = only veto on extreme conviction. Higher (e.g. -0.3) = veto more easily. Ignored for CONVICTION and MECHANICAL strategies |
-| `params` | All | `{}` | Strategy-specific parameters (window sizes, thresholds, etc.) |
-
-All knobs except `min_cash_pct` are tunable by the optimizer. `min_cash_pct` is a user risk preference.
-
-To add a strategy: implement the `Strategy` base class and register it in `strategies/__init__.py`.
+See [Strategies](docs/strategies.md) for all available strategies, their parameters, and how to compose them. Pre-built configurations are in [`example-strategies/`](example-strategies/).
 
 ## Optimizer
 
-The optimizer uses Bayesian optimisation (Optuna TPE) to search over all tunable parameters. It tunes the following layers jointly:
-
-| Layer | What it controls | Examples |
-|-------|-----------------|----------|
-| Strategy parameters | When a strategy fires and how strong | `window`, `threshold`, `loss_threshold` |
-| Strategy weights | How much influence each conviction strategy has in the blend | `_weight: 0.5` to `3.0` |
-| Veto thresholds | When a protective strategy overrides the blend | `_veto_threshold: -0.8` to `-0.2` |
-| Sigmoid steepness | How aggressively the allocator responds to conviction | `sigmoid_steepness: 1.0` to `5.0` |
-| Rebalance threshold | Minimum weight diff to trigger a trade | `rebalance_threshold: 0.01` to `0.05` |
-| Max position % | Maximum weight for any single position | `max_position_pct: 0.15` to `0.50` |
-
-Default search ranges are defined in `PARAM_RANGES` in `optimizer.py`. The optimizer outputs a `strategies.yaml` with optimized `params`, `weight`, and `veto_threshold` per strategy.
-
-MECHANICAL strategies (DCA) are excluded from optimization — their parameters are user preferences, not performance parameters.
+The optimizer uses Bayesian optimization to search over all tunable parameters jointly -- strategy params, weights, veto thresholds, and global allocator settings. It outputs a strategies YAML with optimized values.
 
 ```bash
 uv run midas optimize -p portfolio.yaml --start 2015-01-01 --end 2024-12-31 -o optimized.yaml
-```
-
-### Walk-Forward Optimization
-
-[Walk-forward optimization](https://en.wikipedia.org/wiki/Walk_forward_optimization) is considered the gold standard for validating trading strategies. It determines optimal parameters while testing their robustness against overfitting.
-
-Standard optimization can overfit — parameters that look great on historical data may not work going forward. Walk-forward fixes this by repeatedly optimizing on in-sample data, then testing on out-of-sample data that was never used during optimization. The time window rolls forward and the process repeats until all available data is used.
-
-```
-Fold 1: train [2020───2023.01]  test [2023.01───2023.04]  → 4.3%
-Fold 2: train [2020───2023.04]  test [2023.04───2023.07]  → 2.1%
-Fold 3: train [2020───2023.07]  test [2023.07───2023.10]  → 3.8%
-```
-
-The optimizer only sees training data when picking parameters — it has no access to the test window. So when you evaluate those parameters on the test window, the results tell you how the strategy would have performed on data it wasn't tuned for. A robust strategy shows consistent positive out-of-sample results across multiple folds. The summary reports annualized CAGR, per-fold OOS mean/std, best/worst fold, and an efficiency ratio (how much of the training performance holds up out-of-sample).
-
-Parameters written to the output YAML come from the last fold (trained on the most data).
-
-```bash
 uv run midas optimize -p portfolio.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward -n 200
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--walk-forward` | off | Enable walk-forward optimization |
-| `--wf-min-train-pct` | 0.60 | Minimum initial training window as fraction of data |
-| `--wf-min-test-days` | 63 | Minimum trading days per test fold (~3 months) |
+See [Architecture](docs/architecture.md#optimizer) for details on standard vs. walk-forward optimization.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,15 +90,42 @@ The core engine doesn't run itself -- it needs a driver that feeds it price data
 
 The optimizer is usually the starting point. Rather than hand-tuning strategy parameters, you let the optimizer search for a combination that performs well on historical data. It outputs a strategies YAML that you can then feed into backtest or live mode.
 
-The optimizer uses Bayesian optimization (Optuna's TPE sampler) to search over all tunable parameters jointly. This includes strategy-specific parameters (lookback windows, thresholds), strategy weights, protective veto thresholds, and global allocator settings (sigmoid steepness, rebalance threshold, max position size). MECHANICAL strategies are excluded since their parameters are user preferences, not performance-tunable.
+The optimizer uses Bayesian optimization (Optuna's TPE sampler) to search over all tunable parameters. It tunes the following layers jointly:
+
+| Layer | What it controls | Search range |
+|-------|-----------------|--------------|
+| Strategy parameters | When a strategy fires and how strong | `window`, `threshold`, `loss_threshold`, etc. |
+| Strategy weights | How much influence each conviction strategy has in the blend | 0.5 to 3.0 |
+| Veto thresholds | When a protective strategy overrides the blend | -0.8 to -0.2 |
+| Sigmoid steepness | How aggressively the allocator responds to conviction | 1.0 to 5.0 |
+| Rebalance threshold | Minimum weight diff to trigger a trade | 0.01 to 0.05 |
+| Max position % | Maximum weight for any single position | 0.15 to 0.50 |
+
+Default search ranges are defined in `PARAM_RANGES` in `optimizer.py`. The optimizer outputs a strategies YAML with optimized `params`, `weight`, and `veto_threshold` per strategy. MECHANICAL strategies (DCA) are excluded -- their parameters are user preferences, not performance parameters.
 
 **Standard Mode** -- Runs a configurable number of trials (default 200). Each trial suggests a parameter combination, runs a full backtest with train/test split, and returns the training return as the optimization objective. Trials are distributed across CPU cores via multiprocessing for parallel evaluation.
 
-**Walk-Forward Mode** -- Standard optimization can overfit -- parameters that look great on historical data may fail going forward. Walk-forward optimization addresses this by repeatedly expanding the training window and testing on the next unseen slice of data.
+#### Walk-Forward Optimization
 
-The training window starts at 60% of the data and grows with each fold. Each fold re-optimizes parameters on its training data, then evaluates on the subsequent test window (minimum ~3 months). The test window rolls forward until all data is used. Each fold is warm-started with the previous fold's best parameters to exploit correlation between adjacent time periods.
+[Walk-forward optimization](https://en.wikipedia.org/wiki/Walk_forward_optimization) is considered the gold standard for validating trading strategies. It determines optimal parameters while testing their robustness against overfitting.
 
-The summary reports annualized CAGR across all out-of-sample windows, per-fold mean and standard deviation, best/worst fold, and an efficiency ratio measuring how much of the training performance holds up out-of-sample. A robust strategy shows consistent positive out-of-sample results across folds. The final output YAML uses parameters from the last fold, which was trained on the most data.
+Standard optimization can overfit -- parameters that look great on historical data may not work going forward. Walk-forward fixes this by repeatedly optimizing on in-sample data, then testing on out-of-sample data that was never used during optimization. The time window rolls forward and the process repeats until all available data is used.
+
+```
+Fold 1: train [2020───2023.01]  test [2023.01───2023.04]  → 4.3%
+Fold 2: train [2020───2023.04]  test [2023.04───2023.07]  → 2.1%
+Fold 3: train [2020───2023.07]  test [2023.07───2023.10]  → 3.8%
+```
+
+The optimizer only sees training data when picking parameters -- it has no access to the test window. So when you evaluate those parameters on the test window, the results tell you how the strategy would have performed on data it wasn't tuned for. A robust strategy shows consistent positive out-of-sample results across multiple folds. The summary reports annualized CAGR, per-fold OOS mean/std, best/worst fold, and an efficiency ratio (how much of the training performance holds up out-of-sample).
+
+Parameters written to the output YAML come from the last fold (trained on the most data). Each fold is warm-started with the previous fold's best parameters to exploit correlation between adjacent time periods.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--walk-forward` | off | Enable walk-forward optimization |
+| `--wf-min-train-pct` | 0.60 | Minimum initial training window as fraction of data |
+| `--wf-min-test-days` | 63 | Minimum trading days per test fold (~3 months) |
 
 ### Backtest
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,19 +36,7 @@ See [Strategies](strategies.md) for a reference of all available strategies.
 
 ### Allocator
 
-The allocator takes conviction scores and produces target portfolio weights. It runs in four phases, governed by the following knobs (all configurable in the strategies YAML):
-
-| Field | Scope | Default | Description |
-|-------|-------|---------|-------------|
-| `sigmoid_steepness` | Global | 2.0 | Controls how aggressively the allocator responds to conviction scores. Higher = more extreme position sizes |
-| `rebalance_threshold` | Global | 0.02 | Minimum weight diff to trigger a rebalance trade. Higher = fewer, larger trades |
-| `min_cash_pct` | Global | 0.05 | Minimum cash allocation as a fraction of portfolio value. Higher = more conservative |
-| `max_position_pct` | Global | auto | Maximum weight for any single position. Omit to auto-compute from portfolio size |
-| `weight` | CONVICTION only | 1.0 | How much influence this strategy has in the blended score. Ignored for PROTECTIVE and MECHANICAL strategies |
-| `veto_threshold` | PROTECTIVE only | -0.5 | Score at or below which the strategy forces target weight to 0. Ignored for CONVICTION and MECHANICAL strategies |
-| `params` | All | `{}` | Strategy-specific parameters (window sizes, thresholds, etc.) |
-
-All knobs except `min_cash_pct` are tunable by the optimizer. `min_cash_pct` is a user risk preference.
+The allocator takes conviction scores and produces target portfolio weights. It runs in four phases.
 
 #### Phase 1: Score and Blend
 
@@ -133,11 +121,7 @@ The optimizer only sees training data when picking parameters -- it has no acces
 
 Parameters written to the output YAML come from the last fold (trained on the most data). Each fold is warm-started with the previous fold's best parameters to exploit correlation between adjacent time periods.
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--walk-forward` | off | Enable walk-forward optimization |
-| `--wf-min-train-pct` | 0.60 | Minimum initial training window as fraction of data |
-| `--wf-min-test-days` | 63 | Minimum trading days per test fold (~3 months) |
+See [CLI Reference](cli.md#optimize) for all optimizer options.
 
 ### Backtest
 
@@ -153,6 +137,8 @@ The backtest engine simulates the full pipeline over historical data, stepping t
 
 **Deferred Holdings** -- If a portfolio ticker has no price data at the backtest start date (e.g., the company IPO'd mid-backtest), the position is deferred and automatically activated when data becomes available.
 
+See [CLI Reference](cli.md#backtest) for all backtest options.
+
 ### Live
 
 After optimizing and backtesting, live mode puts the strategy to work on real-time market data. It polls current prices and tells you what trades to make right now based on your portfolio's actual holdings.
@@ -160,3 +146,5 @@ After optimizing and backtesting, live mode puts the strategy to work on real-ti
 The live engine polls real-time prices on a configurable interval (default 60 seconds) and emits order alerts for manual execution. On each tick, it fetches the last 120 days of price history, runs the full allocation and rebalancing pipeline, and compares the resulting order set to the previous tick. If nothing changed, it stays quiet. If new orders appear or existing ones change, it emits an alert with the ticker, price, reason, strategy scores, and suggested share count.
 
 The live engine is fully stateless -- it reads current holdings from the portfolio config each tick and re-derives everything from scratch. It does not execute trades; it's designed for operators who want signal alerts and execute manually through their broker.
+
+See [CLI Reference](cli.md#live) for all live options.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,19 @@ See [Strategies](strategies.md) for a reference of all available strategies.
 
 ### Allocator
 
-The allocator takes conviction scores and produces target portfolio weights. It runs in four phases.
+The allocator takes conviction scores and produces target portfolio weights. It runs in four phases, governed by the following knobs (all configurable in the strategies YAML):
+
+| Field | Scope | Default | Description |
+|-------|-------|---------|-------------|
+| `sigmoid_steepness` | Global | 2.0 | Controls how aggressively the allocator responds to conviction scores. Higher = more extreme position sizes |
+| `rebalance_threshold` | Global | 0.02 | Minimum weight diff to trigger a rebalance trade. Higher = fewer, larger trades |
+| `min_cash_pct` | Global | 0.05 | Minimum cash allocation as a fraction of portfolio value. Higher = more conservative |
+| `max_position_pct` | Global | auto | Maximum weight for any single position. Omit to auto-compute from portfolio size |
+| `weight` | CONVICTION only | 1.0 | How much influence this strategy has in the blended score. Ignored for PROTECTIVE and MECHANICAL strategies |
+| `veto_threshold` | PROTECTIVE only | -0.5 | Score at or below which the strategy forces target weight to 0. Ignored for CONVICTION and MECHANICAL strategies |
+| `params` | All | `{}` | Strategy-specific parameters (window sizes, thresholds, etc.) |
+
+All knobs except `min_cash_pct` are tunable by the optimizer. `min_cash_pct` is a user risk preference.
 
 #### Phase 1: Score and Blend
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# Architecture
+
+Midas is a target-weight portfolio allocation engine. Strategies emit continuous conviction scores, an allocator blends them into target portfolio weights, and a rebalancer diffs against current holdings to generate trades.
+
+## Core Engine
+
+The engine follows a linear pipeline on every tick (one simulated day in backtesting, one poll interval in live mode):
+
+1. **Strategies** evaluate price history and emit conviction scores between -1 (bearish) and +1 (bullish)
+2. **Allocator** blends those scores into a target weight for each ticker in the portfolio
+3. **Rebalancer** compares target weights to current holdings and generates buy/sell orders
+
+Every component is stateless within a single tick. State management (positions, cash, trade log) is the responsibility of whichever execution mode is driving the engine.
+
+### Strategies
+
+Strategies are stateless, ticker-agnostic scorers. Each receives a price history array and returns a conviction score in [-1, +1], where positive is bullish, negative is bearish, and None means abstain (insufficient data, missing context, etc.).
+
+All strategies inherit from a common base class and are registered by name in a central registry. The CLI, optimizer, and config loader all use this registry to instantiate strategies by name from YAML configuration.
+
+#### Tiers
+
+Each strategy belongs to one of three tiers that determine how it participates in the pipeline:
+
+**CONVICTION** strategies are the core signal generators. Their scores are blended together via weighted average into a single conviction per ticker, which is then transformed into a target weight. Most strategies (10 of 13) are conviction-tier.
+
+**PROTECTIVE** strategies act as safety valves. They are evaluated after conviction blending. If a protective strategy's score falls at or below its configured veto threshold, the target weight for that ticker is forced to zero -- a hard liquidation override regardless of what conviction strategies say.
+
+**MECHANICAL** strategies bypass the allocator entirely. They generate independent order intents on a fixed schedule (e.g., dollar-cost averaging buys). The rebalancer sizes these intents into concrete orders separately from the conviction/allocation flow.
+
+#### Precomputation
+
+For backtest performance, strategies can optionally compute scores for every day of the price series in a single vectorized pass. The allocator caches these results and looks them up by day index during simulation, avoiding per-day function calls. Strategies that need runtime context like cost basis (ProfitTaking, StopLoss, TrailingStop) cannot precompute and fall back to per-day evaluation.
+
+See [Strategies](strategies.md) for a reference of all available strategies.
+
+### Allocator
+
+The allocator takes conviction scores and produces target portfolio weights. It runs in four phases.
+
+#### Phase 1: Score and Blend
+
+For each ticker, the allocator collects scores from all CONVICTION strategies and computes a weighted average. Each strategy has a configurable weight (default 1.0) that controls its influence. A strategy returning None is excluded entirely -- it doesn't pull the average toward zero, it simply doesn't participate.
+
+#### Phase 2: Sigmoid Transform
+
+The blended score (a number between -1 and +1) needs to become a target portfolio weight. A raw linear mapping would work but produces extreme allocations -- a blended score of +1 would mean "put everything in this ticker." Instead, the allocator uses a sigmoid function to smoothly map scores to weights.
+
+The sigmoid is centered so that a blended score of 0 produces the equal-weight baseline (total investable weight divided evenly across tickers). Positive scores push above the baseline (overweight), negative scores push below (underweight). The `sigmoid_steepness` parameter controls how aggressively the curve responds -- higher values mean small conviction differences produce larger weight swings.
+
+#### Phase 3: Protective Vetoes
+
+Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below its veto threshold, the target weight is forced to zero. This is a hard override -- no amount of bullish conviction can prevent a protective liquidation. This is how stop-losses and trailing stops work: they don't reduce the position, they eliminate it.
+
+#### Phase 4: Constraints
+
+Finally, the allocator enforces portfolio-level constraints. Each ticker's weight is capped at `max_position_pct` to prevent excessive concentration. If `max_position_pct` is not configured, it's auto-computed as 2.5x the equal-weight baseline (capped at 25%), which allows meaningful overweighting without extreme concentration. Then all weights are normalized so their sum doesn't exceed the investable portion of the portfolio (1 minus the minimum cash reserve).
+
+### Rebalancer
+
+The rebalancer compares target weights from the allocator against the portfolio's current holdings and generates concrete buy/sell orders to close the gap.
+
+#### Order Generation
+
+The rebalancer computes the current weight of each ticker (its market value as a fraction of total portfolio value) and diffs it against the target weight. If the difference is smaller than the `rebalance_threshold` (default 2%), it's ignored -- this prevents excessive trading on tiny weight fluctuations.
+
+Sells are processed before buys. This is intentional: sell proceeds become available cash for subsequent buy orders. Each sell is capped at the actual shares held, and each buy is constrained by available cash.
+
+#### Slippage
+
+All orders include a slippage estimate (default 0.05%) to model realistic execution costs. Buy prices are adjusted slightly upward, sell prices slightly downward. Share counts are floored to whole numbers since fractional shares aren't supported.
+
+#### Circuit Breaker
+
+A daily deployment cap limits total buy value to 25% of portfolio value per day. This prevents the engine from going all-in during a single volatile session. If the allocator says "buy everything," the circuit breaker spreads that deployment across multiple days.
+
+#### Mechanical Order Sizing
+
+MECHANICAL strategy intents are sized separately. Each intent specifies a target dollar amount (e.g., "buy $500 of VOO"). The rebalancer converts this to a share count at the current price, constrained by available cash. Mechanical orders run after rebalancing orders, using whatever cash remains.
+
+### Trading Restrictions
+
+The restriction tracker enforces round-trip rules. When `round_trip_days` is configured (e.g., 30 days), you cannot buy then sell (or sell then buy) the same ticker within that window. This prevents wash sales and models real-world brokerage restrictions. Orders violating this constraint are filtered out before execution.
+
+## Execution Modes
+
+The core engine doesn't run itself -- it needs a driver that feeds it price data, manages portfolio state, and decides what to do with the resulting orders. Midas provides three execution modes, and the typical workflow follows them in order: optimize to find good parameters, backtest to validate performance, and live to act on real-time signals.
+
+### Optimizer
+
+The optimizer is usually the starting point. Rather than hand-tuning strategy parameters, you let the optimizer search for a combination that performs well on historical data. It outputs a strategies YAML that you can then feed into backtest or live mode.
+
+The optimizer uses Bayesian optimization (Optuna's TPE sampler) to search over all tunable parameters jointly. This includes strategy-specific parameters (lookback windows, thresholds), strategy weights, protective veto thresholds, and global allocator settings (sigmoid steepness, rebalance threshold, max position size). MECHANICAL strategies are excluded since their parameters are user preferences, not performance-tunable.
+
+**Standard Mode** -- Runs a configurable number of trials (default 200). Each trial suggests a parameter combination, runs a full backtest with train/test split, and returns the training return as the optimization objective. Trials are distributed across CPU cores via multiprocessing for parallel evaluation.
+
+**Walk-Forward Mode** -- Standard optimization can overfit -- parameters that look great on historical data may fail going forward. Walk-forward optimization addresses this by repeatedly expanding the training window and testing on the next unseen slice of data.
+
+The training window starts at 60% of the data and grows with each fold. Each fold re-optimizes parameters on its training data, then evaluates on the subsequent test window (minimum ~3 months). The test window rolls forward until all data is used. Each fold is warm-started with the previous fold's best parameters to exploit correlation between adjacent time periods.
+
+The summary reports annualized CAGR across all out-of-sample windows, per-fold mean and standard deviation, best/worst fold, and an efficiency ratio measuring how much of the training performance holds up out-of-sample. A robust strategy shows consistent positive out-of-sample results across folds. The final output YAML uses parameters from the last fold, which was trained on the most data.
+
+### Backtest
+
+Once you have a set of parameters (from the optimizer or hand-tuned), backtesting lets you see exactly how they would have performed over a historical period. It produces a detailed trade log, return metrics, and a comparison against a buy-and-hold baseline.
+
+The backtest engine simulates the full pipeline over historical data, stepping through one trading day at a time. On each trading day, the engine runs the complete pipeline: cash infusion (if scheduled), allocation, rebalancing, mechanical strategies, restriction filtering, and order execution. After execution, it updates positions, cost basis, cash balance, and the trade log.
+
+**Train/Test Split** -- By default, the backtest splits the date range 70/30 into training and test periods. Returns are reported separately for each. The optimizer uses train return as its objective and test return to measure how well the parameters generalize to unseen data.
+
+**Time-Weighted Return** -- TWR accounts for external cash infusions (e.g., biweekly contributions) by breaking the simulation into sub-periods at each infusion point and compounding the sub-period returns. This gives an accurate measure of strategy performance independent of when cash enters the portfolio. Without TWR, a large cash infusion right before a market rally would inflate the apparent return.
+
+**Holding Period Tracking** -- The engine tracks individual purchase lots using FIFO (first-in, first-out) matching. When shares are sold, the earliest lots are consumed first. Each trade is classified as short-term (held less than 365 days) or long-term for tax awareness.
+
+**Deferred Holdings** -- If a portfolio ticker has no price data at the backtest start date (e.g., the company IPO'd mid-backtest), the position is deferred and automatically activated when data becomes available.
+
+### Live
+
+After optimizing and backtesting, live mode puts the strategy to work on real-time market data. It polls current prices and tells you what trades to make right now based on your portfolio's actual holdings.
+
+The live engine polls real-time prices on a configurable interval (default 60 seconds) and emits order alerts for manual execution. On each tick, it fetches the last 120 days of price history, runs the full allocation and rebalancing pipeline, and compares the resulting order set to the previous tick. If nothing changed, it stays quiet. If new orders appear or existing ones change, it emits an alert with the ticker, price, reason, strategy scores, and suggested share count.
+
+The live engine is fully stateless -- it reads current holdings from the portfolio config each tick and re-derives everything from scratch. It does not execute trades; it's designed for operators who want signal alerts and execute manually through their broker.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,69 @@
+# CLI Reference
+
+Midas is invoked as `uv run midas <command>`. All commands accept `--help` for full usage.
+
+## strategies
+
+List all available strategies with their tier, description, and asset suitability.
+
+```bash
+uv run midas strategies
+```
+
+No options. Useful for discovering what strategies exist before building a strategy file.
+
+## optimize
+
+Find optimal strategy parameters via Bayesian optimization. This is typically the first step -- run the optimizer, then backtest or go live with the resulting parameters.
+
+```bash
+uv run midas optimize -p portfolio.yaml --start 2015-01-01 --end 2024-12-31 -o optimized.yaml
+uv run midas optimize -p portfolio.yaml --start 2020-01-01 --end 2025-01-01 --walk-forward -n 200
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-p`, `--portfolio` | required | Path to portfolio YAML |
+| `-s`, `--strategies` | all strategies | Path to strategies YAML. Controls which strategies are optimized and sets `min_cash_pct` |
+| `--start` | required | Start date (YYYY-MM-DD) |
+| `--end` | required | End date (YYYY-MM-DD) |
+| `-o`, `--output` | `optimized_strategies.yaml` | Output YAML path for optimized parameters |
+| `-n`, `--n-trials` | 200 | Number of Optuna optimization trials |
+| `--train-pct` | 0.70 | Train/test split ratio. Cannot be used with `--walk-forward` |
+| `--walk-forward` | off | Enable walk-forward optimization |
+| `--wf-min-train-pct` | 0.60 | Minimum initial training window as fraction of data. Requires `--walk-forward` |
+| `--wf-min-test-days` | 63 | Minimum trading days per test fold (~3 months). Requires `--walk-forward` |
+
+## backtest
+
+Simulate the strategy over historical data and produce a trade log, return metrics, and buy-and-hold comparison.
+
+```bash
+uv run midas backtest -p portfolio.yaml -s strategies.yaml --start 2023-01-01 --end 2024-12-31 -o results.csv
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-p`, `--portfolio` | required | Path to portfolio YAML |
+| `-s`, `--strategies` | all strategies | Path to strategies YAML |
+| `--start` | required | Start date (YYYY-MM-DD) |
+| `--end` | required | End date (YYYY-MM-DD) |
+| `-o`, `--output` | `backtest_results.csv` | Output CSV path for trade log and summary |
+| `--train-pct` | 0.70 | Train/test split ratio |
+| `--no-split` | off | Disable train/test split entirely |
+
+## live
+
+Poll real-time prices and emit order alerts for manual execution.
+
+```bash
+uv run midas live -p portfolio.yaml -s strategies.yaml
+uv run midas live -p portfolio.yaml -s strategies.yaml --interval 30 --dry-run
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-p`, `--portfolio` | required | Path to portfolio YAML |
+| `-s`, `--strategies` | all strategies | Path to strategies YAML |
+| `--interval` | 60 | Poll interval in seconds |
+| `--dry-run` | off | Log signals without emitting alerts |

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -2,7 +2,7 @@
 
 All strategies are stateless and ticker-agnostic. They receive a price history array and return a conviction score between -1 (bearish) and +1 (bullish), or None to abstain.
 
-Strategies are registered by name in `strategies/__init__.py`. To add a new strategy, implement the `Strategy` base class and add it to `STRATEGY_REGISTRY`.
+Strategies are registered by name in `strategies/__init__.py`. To add a new strategy: implement the `Strategy` base class in a new file under `strategies/`, register it in `strategies/__init__.py`, and optionally add param ranges in `PARAM_RANGES` in `optimizer.py` to make it optimizable.
 
 ## Summary
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,310 @@
+# Strategies
+
+All strategies are stateless and ticker-agnostic. They receive a price history array and return a conviction score between -1 (bearish) and +1 (bullish), or None to abstain.
+
+Strategies are registered by name in `strategies/__init__.py`. To add a new strategy, implement the `Strategy` base class and add it to `STRATEGY_REGISTRY`.
+
+## Summary
+
+| Strategy | Tier | Direction | Score Range | What it does |
+|----------|------|-----------|-------------|--------------|
+| MeanReversion | CONVICTION | Bidirectional | [-1, +1] | Buys below MA, sells above |
+| Momentum | CONVICTION | Buy-only | [0, +1] | Buys when price trends above MA |
+| ProfitTaking | CONVICTION | Sell-only | [-1, 0] | Sells when unrealized gains exceed threshold |
+| RSIOversold | CONVICTION | Buy-only | [0, +1] | Buys when RSI indicates oversold conditions |
+| RSIOverbought | CONVICTION | Sell-only | [-1, 0] | Sells when RSI indicates overbought conditions |
+| BollingerBand | CONVICTION | Bidirectional | [-1, +1] | Buys/sells based on volatility-adjusted distance from MA |
+| MACDCrossover | CONVICTION | Bidirectional | [-1, +1] | Follows trend via MACD/signal line relationship |
+| VWAPReversion | CONVICTION | Bidirectional | [-1, +1] | Mean reversion around average price |
+| MovingAverageCrossover | CONVICTION | Bidirectional | [-1, +1] | Golden cross / death cross signals |
+| GapDownRecovery | CONVICTION | Buy-only | [0, +1] | Buys gap-down events that start recovering |
+| StopLoss | PROTECTIVE | -- | -- | Vetoes position when loss exceeds threshold |
+| TrailingStop | PROTECTIVE | -- | -- | Vetoes position when drawdown from peak exceeds threshold |
+| DollarCostAveraging | MECHANICAL | Buy-only | -- | Buys on a fixed schedule regardless of price |
+
+## Composing Strategy Files
+
+A strategy file doesn't need every strategy -- it needs a coherent combination where the pieces complement each other. The best compositions pair entry signals with exit signals, use strategies that measure different things, and include at least one protective strategy as a safety net.
+
+**Principles for picking strategies:**
+
+- **Pair entries with exits.** Buy-only strategies (Momentum, RSIOversold, GapDownRecovery) need sell-side counterparts (RSIOverbought, ProfitTaking) or protective strategies (StopLoss, TrailingStop) to close positions. Without exits, the engine accumulates positions indefinitely.
+
+- **Mix signal types.** Strategies that measure the same thing (e.g., MeanReversion and VWAPReversion both compare price to a moving average) provide redundant signals. Strategies that measure different things (e.g., BollingerBand measures distance from MA in volatility units, RSIOversold measures the ratio of up-days to down-days) provide independent confirmation. When two independent signals agree, the conviction is more trustworthy.
+
+- **Match your market thesis.** Trend-following strategies (Momentum, MovingAverageCrossover, MACDCrossover) and mean-reversion strategies (MeanReversion, BollingerBand, VWAPReversion) have opposing views of how markets work. Using both isn't wrong -- their signals will partially cancel, producing more moderate positions -- but you should be intentional about it.
+
+- **Always include protection.** StopLoss and TrailingStop serve different purposes. StopLoss caps absolute losses from cost basis. TrailingStop protects accumulated profits from drawdowns. Using both gives you a floor on losses and a ratchet on gains.
+
+**Pre-built examples** in `example-strategies/` demonstrate these principles:
+
+- **[Trend-Following](../example-strategies/trend-following.yaml)** -- Rides sustained price trends and exits when momentum fades. Uses MovingAverageCrossover and MACDCrossover for two independent trend signals that confirm each other on different timescales, RSIOverbought to detect overextended rallies, and ProfitTaking as a fixed exit target.
+
+- **[Dip-Buying](../example-strategies/dip-buying.yaml)** -- Buys when prices are statistically cheap relative to recent history. Pairs BollingerBand (volatility-adjusted cheapness) with RSIOversold (selling exhaustion) for independent confirmation that an asset is oversold, protected by a StopLoss floor to limit damage when dips keep dipping.
+
+- **[Balanced Growth](../example-strategies/balanced-growth.yaml)** -- Two entry strategies and two exit strategies for a balanced risk profile. Momentum buys strength while RSIOversold buys exhaustion, giving entries in both trending and recovering markets. ProfitTaking harvests gains at a fixed target while TrailingStop dynamically protects profits that have accumulated beyond that target.
+
+## Conviction Strategies
+
+Conviction strategies contribute scores that are blended via weighted average and transformed into target portfolio weights. Each has a configurable `weight` (default 1.0) that controls its influence in the blend.
+
+Some conviction strategies are intentionally unidirectional -- they only produce bullish or bearish signals, never both. This prevents double-counting when complementary strategies (e.g., RSIOversold and RSIOverbought) are both active. If both sides of an indicator contributed to the blend, the signal would be counted twice.
+
+---
+
+### MeanReversion
+
+**Tier**: CONVICTION | **Direction**: Bidirectional | **Score range**: [-1, +1]
+
+Buys when price drops below its moving average, expecting it to revert back up. Sells when price stretches above the average, expecting it to come back down. The score ramps linearly with distance from the MA, reaching full conviction at the `threshold` percentage. This is a contrarian strategy -- it bets against recent price movement.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 30 | Moving average lookback period (trading days) |
+| `threshold` | 0.10 | Percentage distance from MA at which score reaches full conviction |
+
+**Suited for**: Broad market ETFs, large caps
+
+**Interactions**: Natural counterweight to Momentum -- MeanReversion buys dips while Momentum buys strength, so using both produces more moderate positions. Overlaps significantly with VWAPReversion and BollingerBand since all three compare price to a moving average; using MeanReversion alongside either provides redundant rather than independent signals. Pairs well with RSIOversold, which measures a different dimension (up-day/down-day ratio vs. price distance from average).
+
+---
+
+### Momentum
+
+**Tier**: CONVICTION | **Direction**: Buy-only | **Score range**: [0, +1]
+
+The opposite of mean reversion -- bullish when price is above its moving average, riding the trend. Returns 0 when price is below the MA rather than going bearish, since bearish-below-MA signals are handled by dedicated strategies like MeanReversion and RSIOverbought. The score scales with how far above the MA the price has moved, reaching +1 at `momentum_scale` distance.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 20 | Moving average lookback period (trading days) |
+| `momentum_scale` | 0.05 | Distance above MA at which score reaches +1 |
+
+**Suited for**: All asset classes
+
+**Interactions**: Works well with RSIOversold as a complementary entry pair -- Momentum buys trending assets while RSIOversold buys beaten-down ones, covering both market conditions. Conflicts with MeanReversion since they have opposing theses (trend continuation vs. trend reversal). Aligns with MovingAverageCrossover and MACDCrossover, which are also trend-following but measure trend on different timescales.
+
+---
+
+### ProfitTaking
+
+**Tier**: CONVICTION | **Direction**: Sell-only | **Score range**: [-1, 0]
+
+Encourages trimming positions that have appreciated significantly. Once unrealized gains exceed the threshold, the strategy generates a bearish score that increases with further gains. This is a conviction strategy, not a protective one -- it nudges the allocator toward reducing the position rather than forcing a liquidation. Requires cost basis context to compute unrealized gain.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `gain_threshold` | 0.20 | Unrealized gain percentage at which selling pressure begins |
+
+**Suited for**: All asset classes
+
+**Interactions**: Complements TrailingStop -- ProfitTaking provides a fixed exit target while TrailingStop provides a dynamic one. They work on different triggers (absolute gain vs. drawdown from peak) so there's no redundancy. Pairs naturally with any buy-side strategy as the exit mechanism. Works alongside RSIOverbought, which sells based on momentum exhaustion rather than unrealized gain.
+
+---
+
+### RSIOversold
+
+**Tier**: CONVICTION | **Direction**: Buy-only | **Score range**: [0, +1]
+
+Uses the Relative Strength Index to detect oversold conditions. Bullish when RSI is below 50, with the score increasing as RSI drops toward the oversold threshold. Neutral when RSI is at or above 50 -- the overbought side is handled separately by RSIOverbought.
+
+The split at 50 (rather than at the threshold) means this strategy starts contributing a mild bullish signal as soon as selling pressure outweighs buying pressure, not just in extreme oversold territory.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 14 | RSI calculation period (trading days) |
+| `oversold_threshold` | 30.0 | RSI level at which the score reaches +1 |
+
+**Suited for**: All asset classes
+
+**Interactions**: Designed as a pair with RSIOverbought -- they split the RSI indicator into buy-only and sell-only halves to avoid double-counting. Provides independent confirmation alongside BollingerBand since they measure different things (up-day/down-day ratio vs. volatility-adjusted distance from MA). Good complement to Momentum since they buy in different scenarios (trending vs. oversold).
+
+---
+
+### RSIOverbought
+
+**Tier**: CONVICTION | **Direction**: Sell-only | **Score range**: [-1, 0]
+
+The bearish counterpart to RSIOversold. Generates a sell signal when RSI is above 50, becoming more bearish as RSI approaches the overbought threshold. Neutral when RSI is at or below 50.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 14 | RSI calculation period (trading days) |
+| `overbought_threshold` | 70.0 | RSI level at which the score reaches -1 |
+
+**Suited for**: All asset classes
+
+**Interactions**: Designed as a pair with RSIOversold. Works well alongside trend-following entry strategies (MovingAverageCrossover, MACDCrossover) as an exit signal that detects when a rally is overextended. Complements ProfitTaking since they sell on different triggers (momentum exhaustion vs. unrealized gain).
+
+---
+
+### BollingerBand
+
+**Tier**: CONVICTION | **Direction**: Bidirectional | **Score range**: [-1, +1]
+
+A volatility-aware mean reversion strategy. Computes how many standard deviations the current price is from its moving average (the z-score) and maps that to a conviction score. When price touches the lower band (negative z-score), the strategy is bullish -- it expects a bounce. When price touches the upper band (positive z-score), it's bearish. The `num_std` parameter controls band width; at exactly +/- `num_std` standard deviations, the score reaches full conviction.
+
+Unlike plain MeanReversion, BollingerBand adapts to the stock's recent volatility. In calm markets the bands are narrow and small moves trigger conviction; in volatile markets the bands widen and it takes a larger move to reach the same score.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 20 | Moving average and standard deviation lookback (trading days) |
+| `num_std` | 2.0 | Number of standard deviations defining the band width |
+
+**Suited for**: Broad market ETFs, large caps
+
+**Interactions**: Overlaps with MeanReversion and VWAPReversion (all are MA-based mean reversion); prefer one of the three rather than stacking them. Provides strong independent confirmation when paired with RSIOversold, since they measure fundamentally different things. Conflicts with trend-following strategies (Momentum, MovingAverageCrossover) -- BollingerBand sells rallies while trend-followers buy them.
+
+---
+
+### MACDCrossover
+
+**Tier**: CONVICTION | **Direction**: Bidirectional | **Score range**: [-1, +1]
+
+A trend-following strategy based on the convergence and divergence of two exponential moving averages. The MACD line (fast EMA minus slow EMA) measures the trend's strength and direction. The signal line (an EMA of the MACD line itself) smooths out noise. When the MACD line is above the signal line, momentum is bullish; when below, bearish.
+
+The raw difference between MACD and signal is normalized by the current price so the score is comparable across tickers at different price levels.
+
+Requires more historical data than most strategies -- at minimum `slow_period + signal_period` trading days (default 35).
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `fast_period` | 12 | Fast EMA period |
+| `slow_period` | 26 | Slow EMA period |
+| `signal_period` | 9 | Signal line EMA period |
+
+**Suited for**: All asset classes
+
+**Interactions**: Confirms MovingAverageCrossover on a different timescale -- both are trend-following but MACD uses exponential averages and a signal line, making it more sensitive to recent price changes. Using both together gives higher confidence when they agree. Conflicts with mean-reversion strategies (MeanReversion, BollingerBand). Pairs well with RSIOverbought as an exit signal for overextended trends.
+
+---
+
+### VWAPReversion
+
+**Tier**: CONVICTION | **Direction**: Bidirectional | **Score range**: [-1, +1]
+
+Mean reversion around the average price over a lookback window. Bullish when price is below the average (expecting reversion up), bearish when above. Functionally similar to MeanReversion but uses a different threshold scale and is intended to approximate volume-weighted average price behavior.
+
+Currently uses a simple moving average as a VWAP proxy since volume data is not available from the data provider.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 20 | Average price lookback (trading days) |
+| `threshold` | 0.02 | Deviation from average at which score reaches full conviction |
+
+**Suited for**: Large caps, broad market ETFs
+
+**Interactions**: Highly redundant with MeanReversion and BollingerBand -- all three compare price to a moving average. Choose one rather than stacking. The tighter default threshold (2% vs. 10% for MeanReversion) makes it more sensitive to small deviations, which suits stable large caps but may generate excessive signals on volatile assets.
+
+---
+
+### MovingAverageCrossover
+
+**Tier**: CONVICTION | **Direction**: Bidirectional | **Score range**: [-1, +1]
+
+The classic golden cross / death cross strategy. Tracks two moving averages of different lengths. When the short-term MA crosses above the long-term MA (golden cross), it signals an uptrend and the score goes bullish. When the short-term crosses below (death cross), it signals a downtrend.
+
+The score doesn't just capture the crossover moment -- it scales continuously with the spread between the two averages. A wider spread means stronger trend conviction.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `short_window` | 20 | Short-term moving average period (trading days) |
+| `long_window` | 50 | Long-term moving average period (trading days) |
+| `spread_scale` | 0.05 | Spread between MAs at which score reaches full conviction |
+
+**Suited for**: All asset classes
+
+**Interactions**: Confirms MACDCrossover on a different timescale -- both measure trend but with different calculation methods (simple vs. exponential averages), so agreement between them is meaningful. Aligns with Momentum (all trend-following). Conflicts with mean-reversion strategies. Pairs well with RSIOverbought or ProfitTaking as exit mechanisms.
+
+---
+
+### GapDownRecovery
+
+**Tier**: CONVICTION | **Direction**: Buy-only | **Score range**: [0, +1]
+
+A short-term opportunistic strategy that looks for gap-down events followed by recovery. When a stock opens significantly below the previous close (a gap-down) and then starts recovering, it generates a bullish signal. The score reflects how much of the gap has been recovered -- partial recovery produces a partial score.
+
+Requires at least 3 days of price data to evaluate the pattern (previous close, gap open, current price). Returns 0 when there's no qualifying gap-down or no recovery.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `gap_threshold` | 0.03 | Minimum gap-down size (as fraction of previous close) to trigger |
+
+**Suited for**: Individual equities, high-volatility stocks
+
+**Interactions**: Fires rarely and on specific events, so it doesn't conflict with any other strategy. Pairs well with StopLoss since gap-down buying is inherently risky -- a stop loss provides a safety net if the recovery doesn't materialize. Independent from all other strategies since no other strategy measures gap patterns.
+
+---
+
+## Protective Strategies
+
+Protective strategies act as safety valves. They are evaluated after conviction blending, and if their score drops to or below the configured `veto_threshold`, they force the target weight to zero -- a hard liquidation regardless of what conviction strategies say.
+
+Both protective strategies require cost basis context to compute losses or drawdowns. They return None (abstain) when cost basis is unavailable.
+
+The key difference between protective and conviction strategies: conviction strategies *nudge* the allocator (e.g., ProfitTaking reduces weight gradually), while protective strategies *override* it (StopLoss eliminates the position entirely).
+
+---
+
+### StopLoss
+
+**Tier**: PROTECTIVE | **Default veto threshold**: -0.5
+
+A fixed-percentage loss limiter. Computes the unrealized loss relative to cost basis. Once the loss exceeds `loss_threshold`, the score goes negative and continues dropping as the loss deepens. If the score reaches the veto threshold, the position is liquidated.
+
+For example, with the defaults (loss_threshold=0.10, veto_threshold=-0.5), a 10% loss starts generating a negative score. The veto triggers when the loss is severe enough that the score hits -0.5, which happens at a 15% loss.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `loss_threshold` | 0.10 | Unrealized loss percentage at which the score starts going negative |
+
+**Suited for**: All asset classes
+
+**Interactions**: Complements TrailingStop -- StopLoss caps absolute losses while TrailingStop protects accumulated gains. They don't overlap: StopLoss fires on losing positions, TrailingStop only fires on profitable ones (it checks that current price is above cost basis). Using both gives a floor on losses and a ratchet on gains. Essential alongside dip-buying strategies (BollingerBand, RSIOversold, MeanReversion) where you're buying into price declines.
+
+---
+
+### TrailingStop
+
+**Tier**: PROTECTIVE | **Default veto threshold**: -0.5
+
+A drawdown-based exit strategy. Tracks the high-water mark (the highest price seen since purchase, or the cost basis if higher) and measures the current drawdown from that peak. Once the drawdown exceeds `trail_pct`, the score goes negative.
+
+Unlike StopLoss which measures loss from cost basis, TrailingStop measures decline from the peak. This protects profits that have accumulated -- if a stock rallies 50% then drops 10% from the peak, TrailingStop can trigger even though the position is still profitable overall.
+
+TrailingStop only fires when the current price is above cost basis (the position is profitable). This prevents it from compounding with StopLoss on losing positions, which would make both strategies trigger simultaneously.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `trail_pct` | 0.10 | Drawdown from high-water mark at which the score starts going negative |
+
+**Suited for**: All asset classes
+
+**Interactions**: Complements StopLoss (see above) and ProfitTaking. ProfitTaking nudges toward selling at a fixed gain threshold; TrailingStop dynamically protects whatever gains have accumulated, even beyond the ProfitTaking threshold. Together they create layered exits: ProfitTaking gradually reduces the position, and TrailingStop catches sharp reversals that ProfitTaking's gradual pressure can't handle.
+
+---
+
+## Mechanical Strategies
+
+Mechanical strategies bypass the allocator entirely. They don't produce conviction scores -- instead they generate independent order intents on a fixed schedule. The rebalancer sizes these intents into concrete orders using available cash.
+
+Mechanical strategy parameters are user preferences (how much to invest, how often), not performance parameters. The optimizer excludes them.
+
+---
+
+### DollarCostAveraging
+
+**Tier**: MECHANICAL
+
+Generates buy intents on a fixed trading-day interval regardless of market conditions. Each intent specifies a target dollar amount, and the rebalancer converts it to shares at the current price, constrained by available cash.
+
+DCA fires when the number of trading days in the price history is evenly divisible by `frequency_days`. This means it triggers based on how many trading days have elapsed, not calendar dates.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `frequency_days` | 14 | Buy interval in trading days |
+| `amount` | 500.0 | Dollar amount per buy |
+
+**Suited for**: Broad market ETFs, large caps
+
+**Interactions**: Fully independent from all other strategies since it bypasses the allocator. Can be added to any strategy composition without affecting conviction-based signals. Pairs well with protective strategies (StopLoss, TrailingStop) that can exit positions DCA builds if they go wrong.


### PR DESCRIPTION
## Summary
- Added `docs/architecture.md` covering the core engine (strategies, allocator, rebalancer, trading restrictions) and execution modes (optimizer, backtest, live)
- Added `docs/strategies.md` with a summary table, strategy composition guide linking to `example-strategies/`, per-strategy reference with interaction notes
- Added doc links to README

## Test plan
- [x] Verify docs render correctly on GitHub
- [x] Verify relative links to `example-strategies/` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)