### PR TITLE
Enhance backtest and walk-forward output with risk and trade metrics

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import csv
+import math
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date
@@ -28,6 +30,18 @@ from midas.strategies.base import Strategy
 
 
 @dataclass
+class StrategyStats:
+    """Per-strategy performance breakdown."""
+
+    name: str
+    trades: int
+    buys: int
+    sells: int
+    win_rate: float  # fraction of profitable sells
+    pnl: float  # total realized P&L from sells
+
+
+@dataclass
 class BacktestResult:
     trades: list[TradeRecord]
     final_value: float
@@ -41,6 +55,18 @@ class BacktestResult:
     test_bh_return: float
     split_date: date | None
     twr: float  # time-weighted return (accounts for cash infusions)
+    # New metrics
+    equity_curve: list[tuple[date, float]]  # daily (date, portfolio_value)
+    cagr: float  # compound annual growth rate
+    max_drawdown: float  # peak-to-trough percentage decline
+    sharpe_ratio: float  # annualized, risk-free=0
+    sortino_ratio: float  # annualized, downside deviation only
+    win_rate: float  # fraction of round-trip sells that were profitable
+    profit_factor: float  # gross wins / gross losses (inf if no losses)
+    avg_win: float  # average P&L of winning sells
+    avg_loss: float  # average P&L of losing sells
+    efficiency_ratio: float  # test_return / train_return (0 if no split)
+    strategy_stats: list[StrategyStats]
 
 
 @dataclass
@@ -58,6 +84,7 @@ class _SimState:
 
     positions: dict[str, float] = field(default_factory=dict)
     cost_basis: dict[str, float] = field(default_factory=dict)
+    cost_basis_at_sell: dict[tuple[date, str], float] = field(default_factory=dict)
     bh_positions: dict[str, float] = field(default_factory=dict)
     purchase_dates: dict[str, list[tuple[float, date]]] = field(default_factory=dict)
     cash: float = 0.0
@@ -70,6 +97,132 @@ class _SimState:
     twr_base_value: float = 0.0  # portfolio value after last cash infusion
     twr_periods: list[float] = field(default_factory=list)  # sub-period returns
     twr_split_idx: int | None = None  # index into twr_periods at train/test split
+    equity_curve: list[tuple[date, float]] = field(default_factory=list)
+
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+def compute_cagr(starting: float, final: float, days: int) -> float:
+    """Compound annual growth rate from total return over *days* calendar days."""
+    if starting <= 0 or final <= 0 or days <= 0:
+        return 0.0
+    years = days / 365.25
+    return float((final / starting) ** (1.0 / years) - 1.0)
+
+
+def compute_max_drawdown(equity_curve: list[tuple[date, float]]) -> float:
+    """Maximum peak-to-trough percentage decline."""
+    if len(equity_curve) < 2:
+        return 0.0
+    peak = equity_curve[0][1]
+    max_dd = 0.0
+    for _, value in equity_curve:
+        if value > peak:
+            peak = value
+        dd = (peak - value) / peak if peak > 0 else 0.0
+        if dd > max_dd:
+            max_dd = dd
+    return max_dd
+
+
+def compute_sharpe(equity_curve: list[tuple[date, float]]) -> float:
+    """Annualized Sharpe ratio (risk-free = 0) from daily returns."""
+    if len(equity_curve) < 3:
+        return 0.0
+    values = [v for _, v in equity_curve]
+    daily_returns = [(values[i] - values[i - 1]) / values[i - 1] for i in range(1, len(values)) if values[i - 1] > 0]
+    if len(daily_returns) < 2:
+        return 0.0
+    mean_r = sum(daily_returns) / len(daily_returns)
+    variance = sum((r - mean_r) ** 2 for r in daily_returns) / (len(daily_returns) - 1)
+    std_r = math.sqrt(variance) if variance > 0 else 0.0
+    if std_r == 0:
+        return 0.0
+    return (mean_r / std_r) * math.sqrt(TRADING_DAYS_PER_YEAR)
+
+
+def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
+    """Annualized Sortino ratio (risk-free = 0, downside deviation only)."""
+    if len(equity_curve) < 3:
+        return 0.0
+    values = [v for _, v in equity_curve]
+    daily_returns = [(values[i] - values[i - 1]) / values[i - 1] for i in range(1, len(values)) if values[i - 1] > 0]
+    if len(daily_returns) < 2:
+        return 0.0
+    mean_r = sum(daily_returns) / len(daily_returns)
+    downside = [r for r in daily_returns if r < 0]
+    if not downside:
+        return float("inf") if mean_r > 0 else 0.0
+    downside_var = sum(r**2 for r in downside) / len(daily_returns)
+    downside_dev = math.sqrt(downside_var) if downside_var > 0 else 0.0
+    if downside_dev == 0:
+        return 0.0
+    return (mean_r / downside_dev) * math.sqrt(TRADING_DAYS_PER_YEAR)
+
+
+def compute_trade_stats(
+    trades: list[TradeRecord],
+    cost_basis_at_sell: dict[tuple[date, str], float],
+) -> tuple[float, float, float, float]:
+    """Return (win_rate, profit_factor, avg_win, avg_loss) from sell trades."""
+    sells = [t for t in trades if t.direction == Direction.SELL]
+    if not sells:
+        return 0.0, 0.0, 0.0, 0.0
+
+    wins: list[float] = []
+    losses: list[float] = []
+    for t in sells:
+        basis = cost_basis_at_sell.get((t.date, t.ticker), t.price)
+        pnl = (t.price - basis) * t.shares
+        if pnl >= 0:
+            wins.append(pnl)
+        else:
+            losses.append(pnl)
+
+    total = len(wins) + len(losses)
+    win_rate = len(wins) / total if total > 0 else 0.0
+    gross_wins = sum(wins) if wins else 0.0
+    gross_losses = abs(sum(losses)) if losses else 0.0
+    profit_factor = gross_wins / gross_losses if gross_losses > 0 else float("inf") if gross_wins > 0 else 0.0
+    avg_win = gross_wins / len(wins) if wins else 0.0
+    avg_loss = sum(losses) / len(losses) if losses else 0.0  # negative number
+    return win_rate, profit_factor, avg_win, avg_loss
+
+
+def compute_strategy_stats(
+    trades: list[TradeRecord],
+    cost_basis_at_sell: dict[tuple[date, str], float],
+) -> list[StrategyStats]:
+    """Compute per-strategy trade breakdown."""
+    by_strategy: dict[str, list[TradeRecord]] = defaultdict(list)
+    for t in trades:
+        by_strategy[t.strategy_name].append(t)
+
+    stats: list[StrategyStats] = []
+    for name, strades in sorted(by_strategy.items()):
+        buys = [t for t in strades if t.direction == Direction.BUY]
+        sells = [t for t in strades if t.direction == Direction.SELL]
+        winning_sells = 0
+        total_pnl = 0.0
+        for t in sells:
+            basis = cost_basis_at_sell.get((t.date, t.ticker), t.price)
+            pnl = (t.price - basis) * t.shares
+            total_pnl += pnl
+            if pnl >= 0:
+                winning_sells += 1
+        win_rate = winning_sells / len(sells) if sells else 0.0
+        stats.append(
+            StrategyStats(
+                name=name,
+                trades=len(strades),
+                buys=len(buys),
+                sells=len(sells),
+                win_rate=round(win_rate, 4),
+                pnl=round(total_pnl, 2),
+            )
+        )
+    return stats
 
 
 DEFAULT_TRAIN_PCT = 0.70
@@ -301,6 +454,14 @@ class BacktestEngine:
             # Phased allocator flow
             self._run_day(state, portfolio, current_data, day)
 
+            # Record equity curve snapshot
+            day_value = state.cash + sum(
+                state.positions.get(t, 0) * float(current_data[t][-1])
+                for t in current_data
+                if state.positions.get(t, 0) > 0
+            )
+            state.equity_curve.append((day, day_value))
+
     def _activate_deferred(
         self,
         state: _SimState,
@@ -439,6 +600,9 @@ class BacktestEngine:
         for order in filtered_orders:
             if order.shares <= 0:
                 continue
+            # Snapshot cost basis before sell for P&L tracking
+            if order.direction == Direction.SELL and order.ticker in state.cost_basis:
+                state.cost_basis_at_sell[(day, order.ticker)] = state.cost_basis[order.ticker]
             trade = self._execute(order, day, state)
             if trade is not None:
                 state.trades.append(trade)
@@ -580,6 +744,17 @@ class BacktestEngine:
             (bh_value - spbh) / spbh if spbh is not None and spbh > 0 else (bh_value - sv) / sv if sv > 0 else 0.0
         )
 
+        # New metrics
+        equity_curve = state.equity_curve
+        total_days = (trading_days[-1] - trading_days[0]).days if len(trading_days) > 1 else 0
+        cagr = compute_cagr(sv, final_value, total_days)
+        max_drawdown = compute_max_drawdown(equity_curve)
+        sharpe = compute_sharpe(equity_curve)
+        sortino = compute_sortino(equity_curve)
+        win_rate, profit_factor, avg_win, avg_loss = compute_trade_stats(state.trades, state.cost_basis_at_sell)
+        efficiency = test_return / train_return if split_date and train_return != 0 else 0.0
+        strategy_stats = compute_strategy_stats(state.trades, state.cost_basis_at_sell)
+
         return BacktestResult(
             trades=state.trades,
             final_value=round(final_value, 2),
@@ -593,6 +768,17 @@ class BacktestEngine:
             test_bh_return=round(test_bh_return, 4),
             split_date=split_date,
             twr=round(twr, 4),
+            equity_curve=equity_curve,
+            cagr=round(cagr, 4),
+            max_drawdown=round(max_drawdown, 4),
+            sharpe_ratio=round(sharpe, 4),
+            sortino_ratio=round(sortino, 4),
+            win_rate=round(win_rate, 4),
+            profit_factor=round(profit_factor, 4) if not math.isinf(profit_factor) else float("inf"),
+            avg_win=round(avg_win, 2),
+            avg_loss=round(avg_loss, 2),
+            efficiency_ratio=round(efficiency, 4),
+            strategy_stats=strategy_stats,
         )
 
 
@@ -635,10 +821,27 @@ def write_backtest_csv(result: BacktestResult, path: Path) -> None:
         writer.writerow(["Starting Value", f"${sv:.2f}"])
         writer.writerow(["Final Value", f"${result.final_value:.2f}"])
         writer.writerow(["Total Return", f"{total_return:.2%}"])
+        writer.writerow(["CAGR", f"{result.cagr:.2%}"])
         writer.writerow(["Time-Weighted Return", f"{result.twr:.2%}"])
         writer.writerow(["Buy & Hold Value", f"${result.buy_and_hold_value:.2f}"])
         writer.writerow(["Buy & Hold Return", f"{bh_return:.2%}"])
         writer.writerow(["Total Trades", len(result.trades)])
+
+        writer.writerow([])
+        writer.writerow(["=== RISK METRICS ==="])
+        writer.writerow(["Max Drawdown", f"{result.max_drawdown:.2%}"])
+        writer.writerow(["Sharpe Ratio", f"{result.sharpe_ratio:.4f}"])
+        writer.writerow(["Sortino Ratio", f"{result.sortino_ratio:.4f}"])
+
+        sells = [t for t in result.trades if t.direction == Direction.SELL]
+        if sells:
+            writer.writerow([])
+            writer.writerow(["=== TRADE QUALITY ==="])
+            writer.writerow(["Win Rate", f"{result.win_rate:.2%}"])
+            pf = f"{result.profit_factor:.4f}" if not math.isinf(result.profit_factor) else "inf"
+            writer.writerow(["Profit Factor", pf])
+            writer.writerow(["Avg Win", f"${result.avg_win:.2f}"])
+            writer.writerow(["Avg Loss", f"${result.avg_loss:.2f}"])
 
         if result.split_date:
             writer.writerow([])
@@ -650,3 +853,20 @@ def write_backtest_csv(result: BacktestResult, path: Path) -> None:
             writer.writerow(["Test Return", f"{result.test_return:.2%}"])
             writer.writerow(["Test B&H Return", f"{result.test_bh_return:.2%}"])
             writer.writerow(["Test Trades", len(result.test_trades)])
+            writer.writerow(["Efficiency Ratio", f"{result.efficiency_ratio:.2%}"])
+
+        if result.strategy_stats:
+            writer.writerow([])
+            writer.writerow(["=== STRATEGY BREAKDOWN ==="])
+            writer.writerow(["Strategy", "Trades", "Buys", "Sells", "Win Rate", "P&L"])
+            for s in result.strategy_stats:
+                writer.writerow(
+                    [
+                        s.name,
+                        s.trades,
+                        s.buys,
+                        s.sells,
+                        f"{s.win_rate:.2%}" if s.sells > 0 else "",
+                        f"${s.pnl:.2f}" if s.sells > 0 else "",
+                    ]
+                )

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -84,7 +84,12 @@ class _SimState:
 
     positions: dict[str, float] = field(default_factory=dict)
     cost_basis: dict[str, float] = field(default_factory=dict)
-    cost_basis_at_sell: dict[tuple[date, str], float] = field(default_factory=dict)
+    # Cost basis recorded at the moment each SELL trade was executed, in the
+    # same order as SELL entries in `trades`. A parallel list (rather than a
+    # (date, ticker)-keyed dict) is required so that multiple sells of the
+    # same ticker on the same day — e.g. from different strategies — each get
+    # their own basis snapshot instead of overwriting one another.
+    basis_per_sell: list[float] = field(default_factory=list)
     bh_positions: dict[str, float] = field(default_factory=dict)
     purchase_dates: dict[str, list[tuple[float, date]]] = field(default_factory=dict)
     cash: float = 0.0
@@ -143,7 +148,13 @@ def compute_sharpe(equity_curve: list[tuple[date, float]]) -> float:
 
 
 def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
-    """Annualized Sortino ratio (risk-free = 0, downside deviation only)."""
+    """Annualized Sortino ratio (risk-free = 0, downside deviation only).
+
+    When there is no downside (no negative daily returns) the metric is
+    undefined. We return 0.0 as a sentinel rather than `inf` so that callers
+    averaging across multiple windows (e.g. walk-forward folds) aren't
+    poisoned by a single zero-downside fold.
+    """
     if len(equity_curve) < 3:
         return 0.0
     values = [v for _, v in equity_curve]
@@ -153,7 +164,7 @@ def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
     mean_r = sum(daily_returns) / len(daily_returns)
     downside = [r for r in daily_returns if r < 0]
     if not downside:
-        return float("inf") if mean_r > 0 else 0.0
+        return 0.0
     downside_var = sum(r**2 for r in downside) / len(daily_returns)
     downside_dev = math.sqrt(downside_var) if downside_var > 0 else 0.0
     if downside_dev == 0:
@@ -161,19 +172,38 @@ def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
     return (mean_r / downside_dev) * math.sqrt(TRADING_DAYS_PER_YEAR)
 
 
+def _pair_sells_with_basis(
+    trades: list[TradeRecord],
+    basis_per_sell: list[float],
+) -> list[tuple[TradeRecord, float]]:
+    """Zip SELL trades with their recorded cost basis (parallel-list order).
+
+    Falls back to the trade price (zero P&L) for any sell beyond the recorded
+    basis list — defensive only; the lists should always be the same length.
+    """
+    sells = [t for t in trades if t.direction == Direction.SELL]
+    paired: list[tuple[TradeRecord, float]] = []
+    for i, t in enumerate(sells):
+        basis = basis_per_sell[i] if i < len(basis_per_sell) else t.price
+        paired.append((t, basis))
+    return paired
+
+
 def compute_trade_stats(
     trades: list[TradeRecord],
-    cost_basis_at_sell: dict[tuple[date, str], float],
+    basis_per_sell: list[float],
 ) -> tuple[float, float, float, float]:
-    """Return (win_rate, profit_factor, avg_win, avg_loss) from sell trades."""
-    sells = [t for t in trades if t.direction == Direction.SELL]
-    if not sells:
+    """Return (win_rate, profit_factor, avg_win, avg_loss) from sell trades.
+
+    Breakeven sells (`pnl == 0`) are counted as wins by convention.
+    """
+    paired = _pair_sells_with_basis(trades, basis_per_sell)
+    if not paired:
         return 0.0, 0.0, 0.0, 0.0
 
     wins: list[float] = []
     losses: list[float] = []
-    for t in sells:
-        basis = cost_basis_at_sell.get((t.date, t.ticker), t.price)
+    for t, basis in paired:
         pnl = (t.price - basis) * t.shares
         if pnl >= 0:
             wins.append(pnl)
@@ -192,9 +222,11 @@ def compute_trade_stats(
 
 def compute_strategy_stats(
     trades: list[TradeRecord],
-    cost_basis_at_sell: dict[tuple[date, str], float],
+    basis_per_sell: list[float],
 ) -> list[StrategyStats]:
     """Compute per-strategy trade breakdown."""
+    sell_basis: dict[int, float] = {id(t): b for t, b in _pair_sells_with_basis(trades, basis_per_sell)}
+
     by_strategy: dict[str, list[TradeRecord]] = defaultdict(list)
     for t in trades:
         by_strategy[t.strategy_name].append(t)
@@ -206,7 +238,7 @@ def compute_strategy_stats(
         winning_sells = 0
         total_pnl = 0.0
         for t in sells:
-            basis = cost_basis_at_sell.get((t.date, t.ticker), t.price)
+            basis = sell_basis.get(id(t), t.price)
             pnl = (t.price - basis) * t.shares
             total_pnl += pnl
             if pnl >= 0:
@@ -600,12 +632,16 @@ class BacktestEngine:
         for order in filtered_orders:
             if order.shares <= 0:
                 continue
-            # Snapshot cost basis before sell for P&L tracking
-            if order.direction == Direction.SELL and order.ticker in state.cost_basis:
-                state.cost_basis_at_sell[(day, order.ticker)] = state.cost_basis[order.ticker]
+            # Snapshot cost basis before _execute / cash update; the position
+            # may close inside _execute and have its basis popped below.
+            sell_basis: float | None = None
+            if order.direction == Direction.SELL:
+                sell_basis = state.cost_basis.get(order.ticker, order.price)
             trade = self._execute(order, day, state)
             if trade is not None:
                 state.trades.append(trade)
+                if sell_basis is not None:
+                    state.basis_per_sell.append(sell_basis)
                 if state.restriction_tracker:
                     state.restriction_tracker.record_trade(
                         order.ticker,
@@ -751,9 +787,9 @@ class BacktestEngine:
         max_drawdown = compute_max_drawdown(equity_curve)
         sharpe = compute_sharpe(equity_curve)
         sortino = compute_sortino(equity_curve)
-        win_rate, profit_factor, avg_win, avg_loss = compute_trade_stats(state.trades, state.cost_basis_at_sell)
+        win_rate, profit_factor, avg_win, avg_loss = compute_trade_stats(state.trades, state.basis_per_sell)
         efficiency = test_return / train_return if split_date and train_return != 0 else 0.0
-        strategy_stats = compute_strategy_stats(state.trades, state.cost_basis_at_sell)
+        strategy_stats = compute_strategy_stats(state.trades, state.basis_per_sell)
 
         return BacktestResult(
             trades=state.trades,

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -331,25 +331,35 @@ def optimize(
 
         console.print()
 
+        from midas.output import BACKTEST_TABLE_WIDTH
+
         # Per-fold results
         fold_table = Table(
             title="Walk-Forward Analysis",
             title_style="bold",
             show_lines=True,
+            width=BACKTEST_TABLE_WIDTH,
         )
         fold_table.add_column("Fold", justify="center", style="bold")
         fold_table.add_column("Train Period")
         fold_table.add_column("Test Period")
         fold_table.add_column("Train Return", justify="right")
-        fold_table.add_column("Out-of-Sample Return", justify="right")
+        fold_table.add_column("OOS Return", justify="right")
+        fold_table.add_column("Max DD", justify="right")
+        fold_table.add_column("Sharpe", justify="right")
+        fold_table.add_column("Win Rate", justify="right")
         for f in wf_result.folds:
             test_style = "green" if f.test_return >= 0 else "red"
+            sharpe_style = "green" if f.sharpe_ratio >= 0 else "red"
             fold_table.add_row(
                 str(f.fold),
                 f"{f.train_start} → {f.train_end}",
                 f"{f.test_start} → {f.test_end}",
                 f"{f.train_return:.2%}",
                 f"[{test_style}]{f.test_return:.2%}[/{test_style}]",
+                f"[red]{f.max_drawdown:.2%}[/red]",
+                f"[{sharpe_style}]{f.sharpe_ratio:.2f}[/{sharpe_style}]",
+                f"{f.win_rate:.0%}" if f.win_rate > 0 else "—",
             )
         console.print(fold_table)
 
@@ -364,6 +374,7 @@ def optimize(
             show_header=False,
             box=None,
             padding=(0, 2),
+            width=BACKTEST_TABLE_WIDTH,
         )
         summary.add_column("Metric", style="bold")
         summary.add_column("Value", justify="right")
@@ -387,6 +398,20 @@ def optimize(
             "Efficiency Ratio",
             f"{wf_result.efficiency_ratio:.0%}",
         )
+        dd_style = "red" if wf_result.mean_max_drawdown > 0 else "dim"
+        summary.add_row(
+            "Mean Max Drawdown",
+            f"[{dd_style}]{wf_result.mean_max_drawdown:.2%}[/{dd_style}]",
+        )
+        sharpe_style = "green" if wf_result.mean_sharpe >= 0 else "red"
+        summary.add_row(
+            "Mean Sharpe Ratio",
+            f"[{sharpe_style}]{wf_result.mean_sharpe:.2f}[/{sharpe_style}]",
+        )
+        summary.add_row(
+            "Mean Win Rate",
+            f"{wf_result.mean_win_rate:.0%}" if wf_result.mean_win_rate > 0 else "—",
+        )
         summary.add_row("Total Trials", str(wf_result.total_trials))
         summary.add_row("Output", output)
         console.print(summary)
@@ -396,6 +421,7 @@ def optimize(
         param_table = Table(
             title="Deployed Parameters (from latest fold)",
             title_style="bold",
+            width=BACKTEST_TABLE_WIDTH,
         )
         param_table.add_column("Strategy", style="bold")
         param_table.add_column("Parameters")

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -316,17 +316,9 @@ def optimize(
         make_wide_table,
         print_backtest_summary,
         print_centered,
+        print_params_table,
         print_run_info,
     )
-
-    def _print_params_table(title: str, params: dict[str, dict[str, float]]) -> None:
-        table = make_wide_table(title)
-        table.add_column("Strategy", style="bold")
-        table.add_column("Parameters")
-        for name, p in params.items():
-            display = name if name != ALLOCATION_KEY else "Global"
-            table.add_row(display, ", ".join(f"{k}={v}" for k, v in p.items()))
-        print_centered(table)
 
     if walk_forward:
         wf_result = walk_forward_optimize(
@@ -395,7 +387,11 @@ def optimize(
         print_centered(agg)
 
         print_run_info([("Total Trials", str(wf_result.total_trials)), ("Output", output)])
-        _print_params_table("Deployed Parameters (from latest fold)", wf_result.best_params)
+        print_params_table(
+            "Deployed Parameters (from latest fold)",
+            wf_result.best_params,
+            global_key=ALLOCATION_KEY,
+        )
 
     else:
         result = run_optimize(
@@ -425,7 +421,7 @@ def optimize(
                 ("Output", output),
             ]
         )
-        _print_params_table("Optimized Parameters", result.best_params)
+        print_params_table("Optimized Parameters", result.best_params, global_key=ALLOCATION_KEY)
 
 
 @cli.command(name="strategies")

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -331,7 +331,7 @@ def optimize(
 
         console.print()
 
-        from midas.output import BACKTEST_TABLE_WIDTH
+        from midas.output import BACKTEST_TABLE_WIDTH, color_signed
 
         # Per-fold results
         fold_table = Table(
@@ -349,25 +349,20 @@ def optimize(
         fold_table.add_column("Sharpe", justify="right")
         fold_table.add_column("Win Rate", justify="right")
         for f in wf_result.folds:
-            test_style = "green" if f.test_return >= 0 else "red"
-            sharpe_style = "green" if f.sharpe_ratio >= 0 else "red"
             fold_table.add_row(
                 str(f.fold),
                 f"{f.train_start} → {f.train_end}",
                 f"{f.test_start} → {f.test_end}",
                 f"{f.train_return:.2%}",
-                f"[{test_style}]{f.test_return:.2%}[/{test_style}]",
+                color_signed(f.test_return),
                 f"[red]{f.max_drawdown:.2%}[/red]",
-                f"[{sharpe_style}]{f.sharpe_ratio:.2f}[/{sharpe_style}]",
+                color_signed(f.sharpe_ratio, fmt=".2f"),
                 f"{f.win_rate:.0%}" if f.win_rate > 0 else "—",
             )
         console.print(fold_table)
 
         # Summary
-        cagr_style = "green" if wf_result.annualized_return >= 0 else "red"
-        worst_style = "green" if wf_result.worst_fold_return >= 0 else "red"
         n_folds = len(wf_result.folds)
-
         summary = Table(
             title="Summary",
             title_style="bold",
@@ -378,36 +373,19 @@ def optimize(
         )
         summary.add_column("Metric", style="bold")
         summary.add_column("Value", justify="right")
-        summary.add_row(
-            "Annualized OOS Return (CAGR)",
-            f"[{cagr_style}]{wf_result.annualized_return:.2%}[/{cagr_style}]",
-        )
+        summary.add_row("Annualized OOS Return (CAGR)", color_signed(wf_result.annualized_return))
         summary.add_row(
             "Per-Fold OOS Mean ± Std",
             f"{wf_result.mean_test_return:.2%} ± {wf_result.std_test_return:.2%}",
         )
+        summary.add_row("Winning Folds", f"{wf_result.winning_folds}/{n_folds}")
         summary.add_row(
-            "Winning Folds",
-            f"{wf_result.winning_folds}/{n_folds}",
+            "Best / Worst Fold",
+            f"{color_signed(wf_result.best_fold_return)} / {color_signed(wf_result.worst_fold_return)}",
         )
-        best_style = "green" if wf_result.best_fold_return >= 0 else "red"
-        best_val = f"[{best_style}]{wf_result.best_fold_return:.2%}[/{best_style}]"
-        worst_val = f"[{worst_style}]{wf_result.worst_fold_return:.2%}[/{worst_style}]"
-        summary.add_row("Best / Worst Fold", f"{best_val} / {worst_val}")
-        summary.add_row(
-            "Efficiency Ratio",
-            f"{wf_result.efficiency_ratio:.0%}",
-        )
-        dd_style = "red" if wf_result.mean_max_drawdown > 0 else "dim"
-        summary.add_row(
-            "Mean Max Drawdown",
-            f"[{dd_style}]{wf_result.mean_max_drawdown:.2%}[/{dd_style}]",
-        )
-        sharpe_style = "green" if wf_result.mean_sharpe >= 0 else "red"
-        summary.add_row(
-            "Mean Sharpe Ratio",
-            f"[{sharpe_style}]{wf_result.mean_sharpe:.2f}[/{sharpe_style}]",
-        )
+        summary.add_row("Efficiency Ratio", f"{wf_result.efficiency_ratio:.0%}")
+        summary.add_row("Mean Max Drawdown", f"[red]{wf_result.mean_max_drawdown:.2%}[/red]")
+        summary.add_row("Mean Sharpe Ratio", color_signed(wf_result.mean_sharpe, fmt=".2f"))
         summary.add_row(
             "Mean Win Rate",
             f"{wf_result.mean_win_rate:.0%}" if wf_result.mean_win_rate > 0 else "—",
@@ -448,24 +426,25 @@ def optimize(
 
         console.print()
 
-        # Results
-        train_style = "green" if result.best_train_return >= 0 else "red"
-        test_style = "green" if result.best_test_return >= 0 else "red"
-        bh_style = "green" if result.best_bh_return >= 0 else "red"
+        from midas.output import BACKTEST_TABLE_WIDTH, color_signed
 
-        table = Table(title="Optimization Results", title_style="bold", show_lines=True)
+        table = Table(title="Optimization Results", title_style="bold", show_lines=True, width=BACKTEST_TABLE_WIDTH)
         table.add_column("Metric", style="bold")
         table.add_column("Value", justify="right")
-        table.add_row("Train Return (70%)", f"[{train_style}]{result.best_train_return:.2%}[/{train_style}]")
-        table.add_row("Test Return (30%)", f"[{test_style}]{result.best_test_return:.2%}[/{test_style}]")
-        table.add_row("Buy & Hold Return", f"[{bh_style}]{result.best_bh_return:.2%}[/{bh_style}]")
+        test_pct = 1.0 if train_pct >= 1.0 else 1 - train_pct
+        table.add_row(f"Train Return ({train_pct:.0%})", color_signed(result.best_train_return))
+        table.add_row(f"Test Return ({test_pct:.0%})", color_signed(result.best_test_return))
+        table.add_row("Buy & Hold Return", color_signed(result.best_bh_return))
+        table.add_row("Max Drawdown", f"[red]{result.max_drawdown:.2%}[/red]")
+        table.add_row("Sharpe Ratio", color_signed(result.sharpe_ratio, fmt=".2f"))
+        table.add_row("Win Rate", f"{result.win_rate:.0%}" if result.win_rate > 0 else "—")
         table.add_row("Trials", str(result.trials_run))
         table.add_row("Output", output)
         console.print(table)
 
         # Params
         console.print()
-        param_table = Table(title="Optimized Parameters", title_style="bold")
+        param_table = Table(title="Optimized Parameters", title_style="bold", width=BACKTEST_TABLE_WIDTH)
         param_table.add_column("Strategy", style="bold")
         param_table.add_column("Parameters")
         for name, params in result.best_params.items():

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -309,9 +309,24 @@ def optimize(
     start_d, end_d = _to_date(start), _to_date(end)
     price_data = _fetch_prices(port, start_d, end_d)
 
-    from rich.table import Table
+    from midas.output import (
+        color_signed,
+        console,
+        make_metric_table,
+        make_wide_table,
+        print_backtest_summary,
+        print_centered,
+        print_run_info,
+    )
 
-    from midas.output import console
+    def _print_params_table(title: str, params: dict[str, dict[str, float]]) -> None:
+        table = make_wide_table(title)
+        table.add_column("Strategy", style="bold")
+        table.add_column("Parameters")
+        for name, p in params.items():
+            display = name if name != ALLOCATION_KEY else "Global"
+            table.add_row(display, ", ".join(f"{k}={v}" for k, v in p.items()))
+        print_centered(table)
 
     if walk_forward:
         wf_result = walk_forward_optimize(
@@ -331,22 +346,16 @@ def optimize(
 
         console.print()
 
-        from midas.output import BACKTEST_TABLE_WIDTH, color_signed
-
-        # Per-fold results
-        fold_table = Table(
-            title="Walk-Forward Analysis",
-            title_style="bold",
-            show_lines=True,
-            width=BACKTEST_TABLE_WIDTH,
-        )
+        # Per-fold results — wider since this table has 9 columns.
+        fold_table = make_wide_table("Walk-Forward Analysis", width=140)
         fold_table.add_column("Fold", justify="center", style="bold")
-        fold_table.add_column("Train Period")
-        fold_table.add_column("Test Period")
-        fold_table.add_column("Train Return", justify="right")
+        fold_table.add_column("IS Period")
+        fold_table.add_column("OOS Period")
+        fold_table.add_column("IS Return", justify="right")
         fold_table.add_column("OOS Return", justify="right")
         fold_table.add_column("Max DD", justify="right")
         fold_table.add_column("Sharpe", justify="right")
+        fold_table.add_column("Sortino", justify="right")
         fold_table.add_column("Win Rate", justify="right")
         for f in wf_result.folds:
             fold_table.add_row(
@@ -357,57 +366,36 @@ def optimize(
                 color_signed(f.test_return),
                 f"[red]{f.max_drawdown:.2%}[/red]",
                 color_signed(f.sharpe_ratio, fmt=".2f"),
+                color_signed(f.sortino_ratio, fmt=".2f"),
                 f"{f.win_rate:.0%}" if f.win_rate > 0 else "—",
             )
-        console.print(fold_table)
+        print_centered(fold_table)
 
-        # Summary
+        # Aggregate metrics — same layout as the backtest summary tables.
         n_folds = len(wf_result.folds)
-        summary = Table(
-            title="Summary",
-            title_style="bold",
-            show_header=False,
-            box=None,
-            padding=(0, 2),
-            width=BACKTEST_TABLE_WIDTH,
-        )
-        summary.add_column("Metric", style="bold")
-        summary.add_column("Value", justify="right")
-        summary.add_row("Annualized OOS Return (CAGR)", color_signed(wf_result.annualized_return))
-        summary.add_row(
+        agg = make_metric_table("Walk-Forward Aggregate")
+        agg.add_row("Annualized OOS Return (CAGR)", color_signed(wf_result.annualized_return))
+        agg.add_row(
             "Per-Fold OOS Mean ± Std",
             f"{wf_result.mean_test_return:.2%} ± {wf_result.std_test_return:.2%}",
         )
-        summary.add_row("Winning Folds", f"{wf_result.winning_folds}/{n_folds}")
-        summary.add_row(
+        agg.add_row("Winning Folds", f"{wf_result.winning_folds}/{n_folds}")
+        agg.add_row(
             "Best / Worst Fold",
             f"{color_signed(wf_result.best_fold_return)} / {color_signed(wf_result.worst_fold_return)}",
         )
-        summary.add_row("Efficiency Ratio", f"{wf_result.efficiency_ratio:.0%}")
-        summary.add_row("Mean Max Drawdown", f"[red]{wf_result.mean_max_drawdown:.2%}[/red]")
-        summary.add_row("Mean Sharpe Ratio", color_signed(wf_result.mean_sharpe, fmt=".2f"))
-        summary.add_row(
+        agg.add_row("Efficiency Ratio", f"{wf_result.efficiency_ratio:.0%}")
+        agg.add_row("Mean Max Drawdown", f"[red]{wf_result.mean_max_drawdown:.2%}[/red]")
+        agg.add_row("Mean Sharpe Ratio", color_signed(wf_result.mean_sharpe, fmt=".2f"))
+        agg.add_row("Mean Sortino Ratio", color_signed(wf_result.mean_sortino, fmt=".2f"))
+        agg.add_row(
             "Mean Win Rate",
             f"{wf_result.mean_win_rate:.0%}" if wf_result.mean_win_rate > 0 else "—",
         )
-        summary.add_row("Total Trials", str(wf_result.total_trials))
-        summary.add_row("Output", output)
-        console.print(summary)
+        print_centered(agg)
 
-        # Best params
-        console.print()
-        param_table = Table(
-            title="Deployed Parameters (from latest fold)",
-            title_style="bold",
-            width=BACKTEST_TABLE_WIDTH,
-        )
-        param_table.add_column("Strategy", style="bold")
-        param_table.add_column("Parameters")
-        for name, params in wf_result.best_params.items():
-            display = name if name != ALLOCATION_KEY else "Global"
-            param_str = ", ".join(f"{k}={v}" for k, v in params.items())
-            param_table.add_row(display, param_str)
-        console.print(param_table)
+        print_run_info([("Total Trials", str(wf_result.total_trials)), ("Output", output)])
+        _print_params_table("Deployed Parameters (from latest fold)", wf_result.best_params)
 
     else:
         result = run_optimize(
@@ -426,32 +414,18 @@ def optimize(
 
         console.print()
 
-        from midas.output import BACKTEST_TABLE_WIDTH, color_signed
+        # Reuse the backtest summary tables for the optimized strategy.
+        assert result.best_result is not None
+        print_backtest_summary(result.best_result)
 
-        table = Table(title="Optimization Results", title_style="bold", show_lines=True, width=BACKTEST_TABLE_WIDTH)
-        table.add_column("Metric", style="bold")
-        table.add_column("Value", justify="right")
-        test_pct = 1.0 if train_pct >= 1.0 else 1 - train_pct
-        table.add_row(f"Train Return ({train_pct:.0%})", color_signed(result.best_train_return))
-        table.add_row(f"Test Return ({test_pct:.0%})", color_signed(result.best_test_return))
-        table.add_row("Buy & Hold Return", color_signed(result.best_bh_return))
-        table.add_row("Max Drawdown", f"[red]{result.max_drawdown:.2%}[/red]")
-        table.add_row("Sharpe Ratio", color_signed(result.sharpe_ratio, fmt=".2f"))
-        table.add_row("Win Rate", f"{result.win_rate:.0%}" if result.win_rate > 0 else "—")
-        table.add_row("Trials", str(result.trials_run))
-        table.add_row("Output", output)
-        console.print(table)
-
-        # Params
-        console.print()
-        param_table = Table(title="Optimized Parameters", title_style="bold", width=BACKTEST_TABLE_WIDTH)
-        param_table.add_column("Strategy", style="bold")
-        param_table.add_column("Parameters")
-        for name, params in result.best_params.items():
-            display = name if name != ALLOCATION_KEY else "Global"
-            param_str = ", ".join(f"{k}={v}" for k, v in params.items())
-            param_table.add_row(display, param_str)
-        console.print(param_table)
+        print_run_info(
+            [
+                ("Trials", str(result.trials_run)),
+                ("Train/Test Split", f"{train_pct:.0%} / {1 - train_pct:.0%}" if train_pct < 1.0 else "100% / 0%"),
+                ("Output", output),
+            ]
+        )
+        _print_params_table("Optimized Parameters", result.best_params)
 
 
 @cli.command(name="strategies")

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -136,9 +136,7 @@ class OptimizeResult:
     best_train_return: float
     best_test_return: float
     trials_run: int
-    max_drawdown: float = 0.0
-    sharpe_ratio: float = 0.0
-    win_rate: float = 0.0
+    best_result: BacktestResult | None = None
 
 
 @dataclass
@@ -156,6 +154,7 @@ class FoldResult:
     trials_run: int
     max_drawdown: float = 0.0
     sharpe_ratio: float = 0.0
+    sortino_ratio: float = 0.0
     win_rate: float = 0.0
 
 
@@ -175,6 +174,7 @@ class WalkForwardResult:
     total_trials: int
     mean_max_drawdown: float = 0.0
     mean_sharpe: float = 0.0
+    mean_sortino: float = 0.0
     mean_win_rate: float = 0.0
 
 
@@ -467,9 +467,7 @@ def optimize(
         best_train_return=round(best.user_attrs["train_return"], 4),
         best_test_return=round(best.user_attrs["test_return"], 4),
         trials_run=len(study.trials),
-        max_drawdown=round(best_result.max_drawdown, 4),
-        sharpe_ratio=round(best_result.sharpe_ratio, 4),
-        win_rate=round(best_result.win_rate, 4),
+        best_result=best_result,
     )
 
 
@@ -629,6 +627,7 @@ def walk_forward_optimize(
                     trials_run=len(study.trials),
                     max_drawdown=round(test_result.max_drawdown, 4),
                     sharpe_ratio=round(test_result.sharpe_ratio, 4),
+                    sortino_ratio=round(test_result.sortino_ratio, 4),
                     win_rate=round(test_result.win_rate, 4),
                 )
             )
@@ -654,6 +653,8 @@ def walk_forward_optimize(
     worst_fold = min(test_returns)
 
     # Efficiency ratio: how much in-sample performance survives out-of-sample.
+    # Anchored IS windows overlap so we can't annualize them apples-to-apples
+    # with OOS — only the ratio of mean raw returns is reported.
     train_returns = [f.train_return for f in fold_results]
     mean_train = sum(train_returns) / len(train_returns)
     efficiency = mean_test / mean_train if mean_train != 0 else 0.0
@@ -661,6 +662,7 @@ def walk_forward_optimize(
     n = len(fold_results)
     mean_dd = sum(f.max_drawdown for f in fold_results) / n
     mean_sharpe = sum(f.sharpe_ratio for f in fold_results) / n
+    mean_sortino = sum(f.sortino_ratio for f in fold_results) / n
     mean_wr = sum(f.win_rate for f in fold_results) / n
 
     log("")
@@ -684,6 +686,7 @@ def walk_forward_optimize(
         total_trials=sum(f.trials_run for f in fold_results),
         mean_max_drawdown=round(mean_dd, 4),
         mean_sharpe=round(mean_sharpe, 4),
+        mean_sortino=round(mean_sortino, 4),
         mean_win_rate=round(mean_wr, 4),
     )
 

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -17,7 +17,7 @@ import pandas as pd
 import yaml
 
 from midas.allocator import Allocator
-from midas.backtest import DEFAULT_TRAIN_PCT, BacktestEngine
+from midas.backtest import DEFAULT_TRAIN_PCT, BacktestEngine, BacktestResult
 from midas.models import (
     DEFAULT_MIN_CASH_PCT,
     AllocationConstraints,
@@ -151,6 +151,9 @@ class FoldResult:
     train_return: float
     test_return: float
     trials_run: int
+    max_drawdown: float = 0.0
+    sharpe_ratio: float = 0.0
+    win_rate: float = 0.0
 
 
 @dataclass
@@ -167,6 +170,9 @@ class WalkForwardResult:
     efficiency_ratio: float  # mean OOS return / mean train return
     best_params: dict[str, dict[str, float]]  # from last fold (most recent data)
     total_trials: int
+    mean_max_drawdown: float = 0.0
+    mean_sharpe: float = 0.0
+    mean_win_rate: float = 0.0
 
 
 def _suggest_params(
@@ -198,10 +204,10 @@ def _run_trial(
     min_cash_pct: float = DEFAULT_MIN_CASH_PCT,
     train_pct: float = DEFAULT_TRAIN_PCT,
     enable_split: bool = True,
-) -> tuple[float, float, float, float, float]:
+) -> tuple[float, float, float, float, float, BacktestResult]:
     """Run a single backtest trial with the allocator+rebalancer system.
 
-    Returns (total_return, bh_return, train_return, test_return, twr).
+    Returns (total_return, bh_return, train_return, test_return, twr, result).
     """
     # Suppress allocator warnings during optimization — the optimizer explores
     # boundary values that trigger heuristic warnings but are fine to evaluate.
@@ -253,11 +259,11 @@ def _run_trial(
     result = engine.run(portfolio, price_data, start, end)
 
     if result.starting_value <= 0:
-        return 0.0, 0.0, 0.0, 0.0, 0.0
+        return 0.0, 0.0, 0.0, 0.0, 0.0, result
 
     total_return = (result.final_value - result.starting_value) / result.starting_value
     bh_return = (result.buy_and_hold_value - result.starting_value) / result.starting_value
-    return total_return, bh_return, result.train_return, result.test_return, result.twr
+    return total_return, bh_return, result.train_return, result.test_return, result.twr, result
 
 
 _worker_state: dict[str, Any] = {}
@@ -284,7 +290,8 @@ def _init_worker(
 
 
 def _trial_worker(strategy_params: dict[str, dict[str, float]]) -> tuple[float, ...]:
-    return _run_trial(strategy_params, **_worker_state)
+    total_ret, bh_ret, train_ret, test_ret, twr, _result = _run_trial(strategy_params, **_worker_state)
+    return total_ret, bh_ret, train_ret, test_ret, twr
 
 
 def _wf_init_worker(
@@ -305,7 +312,7 @@ def _wf_trial_worker(
     start: date,
     end: date,
 ) -> tuple[float, ...]:
-    return _run_trial(
+    total_ret, bh_ret, train_ret, test_ret, twr, _result = _run_trial(
         strategy_params,
         _worker_state["portfolio"],
         _worker_state["price_data"],
@@ -314,6 +321,7 @@ def _wf_trial_worker(
         _worker_state["min_cash_pct"],
         enable_split=False,
     )
+    return total_ret, bh_ret, train_ret, test_ret, twr
 
 
 def _prepare_names_and_ranges(
@@ -572,7 +580,7 @@ def walk_forward_optimize(
             prev_best_flat = dict(study.best_trial.params)
 
             # --- Evaluate best params on test window ---
-            _test_total, _bh, _train, _test, test_twr = _run_trial(
+            _test_total, _bh, _train, _test, test_twr, test_result = _run_trial(
                 best_params,
                 portfolio,
                 price_data,
@@ -595,6 +603,9 @@ def walk_forward_optimize(
                     train_return=round(train_return, 4),
                     test_return=round(test_twr, 4),
                     trials_run=len(study.trials),
+                    max_drawdown=round(test_result.max_drawdown, 4),
+                    sharpe_ratio=round(test_result.sharpe_ratio, 4),
+                    win_rate=round(test_result.win_rate, 4),
                 )
             )
     finally:
@@ -623,12 +634,18 @@ def walk_forward_optimize(
     mean_train = sum(train_returns) / len(train_returns)
     efficiency = mean_test / mean_train if mean_train != 0 else 0.0
 
+    n = len(fold_results)
+    mean_dd = sum(f.max_drawdown for f in fold_results) / n
+    mean_sharpe = sum(f.sharpe_ratio for f in fold_results) / n
+    mean_wr = sum(f.win_rate for f in fold_results) / n
+
     log("")
     log("Walk-forward complete")
     log(f"  Annualized OOS return (CAGR): {annualized:.2%}")
     log(f"  Per-fold mean: {mean_test:.2%} ± {std_test:.2%}")
-    log(f"  Winning folds: {winning_folds}/{len(fold_results)} | Best: {best_fold:.2%} | Worst: {worst_fold:.2%}")
+    log(f"  Winning folds: {winning_folds}/{n} | Best: {best_fold:.2%} | Worst: {worst_fold:.2%}")
     log(f"  Efficiency ratio: {efficiency:.0%}")
+    log(f"  Mean max drawdown: {mean_dd:.2%} | Mean Sharpe: {mean_sharpe:.2f}")
 
     return WalkForwardResult(
         folds=fold_results,
@@ -641,6 +658,9 @@ def walk_forward_optimize(
         efficiency_ratio=round(efficiency, 4),
         best_params=fold_results[-1].best_params,
         total_trials=sum(f.trials_run for f in fold_results),
+        mean_max_drawdown=round(mean_dd, 4),
+        mean_sharpe=round(mean_sharpe, 4),
+        mean_win_rate=round(mean_wr, 4),
     )
 
 

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -136,6 +136,9 @@ class OptimizeResult:
     best_train_return: float
     best_test_return: float
     trials_run: int
+    max_drawdown: float = 0.0
+    sharpe_ratio: float = 0.0
+    win_rate: float = 0.0
 
 
 @dataclass
@@ -439,6 +442,24 @@ def optimize(
 
     log(f"Optimization complete — best train return: {best.value:.2%}")
 
+    # Re-run best params in the main process to capture the full BacktestResult
+    # (risk/trade metrics aren't serialised through the worker pool).
+    _total, _bh, _train, _test, _twr, best_result = _run_trial(
+        best_params,
+        portfolio,
+        price_data,
+        start,
+        end,
+        min_cash_pct=min_cash_pct,
+        train_pct=train_pct,
+    )
+
+    log(
+        f"  Max drawdown: {best_result.max_drawdown:.2%} | "
+        f"Sharpe: {best_result.sharpe_ratio:.2f} | "
+        f"Win rate: {best_result.win_rate:.2%}"
+    )
+
     return OptimizeResult(
         best_params=best_params,
         best_return=round(best.value or 0.0, 4),
@@ -446,6 +467,9 @@ def optimize(
         best_train_return=round(best.user_attrs["train_return"], 4),
         best_test_return=round(best.user_attrs["test_return"], 4),
         trials_run=len(study.trials),
+        max_drawdown=round(best_result.max_drawdown, 4),
+        sharpe_ratio=round(best_result.sharpe_ratio, 4),
+        win_rate=round(best_result.win_rate, 4),
     )
 
 

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -84,6 +84,32 @@ def color_signed(value: float, fmt: str = ".2%") -> str:
     return f"[{style}]{value:{fmt}}[/{style}]"
 
 
+def make_metric_table(title: str) -> Table:
+    """2-column metric/value table — the canonical layout for summary outputs."""
+    table = Table(title=title, show_lines=True, width=BACKTEST_TABLE_WIDTH)
+    table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
+    table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
+    return table
+
+
+def make_wide_table(title: str, width: int = BACKTEST_TABLE_WIDTH) -> Table:
+    """Multi-column table at the standard width (caller adds columns)."""
+    return Table(title=title, title_style="bold", show_lines=True, width=width)
+
+
+def print_centered(table: Table) -> None:
+    """Centered render — used by all summary tables for visual consistency."""
+    console.print(table, justify="center")
+
+
+def print_run_info(rows: list[tuple[str, str]], title: str = "Run Info") -> None:
+    """Render a small key/value table for run metadata (trials, output path, etc)."""
+    table = make_metric_table(title)
+    for k, v in rows:
+        table.add_row(k, v)
+    print_centered(table)
+
+
 def print_backtest_summary(result: BacktestResult) -> None:
     import math
 
@@ -91,62 +117,51 @@ def print_backtest_summary(result: BacktestResult) -> None:
     total_return = (fv - sv) / sv if sv > 0 else 0
     bh_return = (bhv - sv) / sv if sv > 0 else 0
 
-    # --- Returns ---
-    table = Table(title="Backtest Summary", show_lines=True, width=BACKTEST_TABLE_WIDTH)
-    table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
-    table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
+    # --- Performance ---
+    perf = make_metric_table("Performance")
+    perf.add_row("Starting Value", f"${sv:,.2f}")
+    perf.add_row("Final Value", f"${fv:,.2f}")
+    perf.add_row("Total Return", color_signed(total_return))
+    perf.add_row("CAGR", color_signed(result.cagr))
+    perf.add_row("Time-Weighted Return", color_signed(result.twr))
+    perf.add_row("Buy & Hold Value", f"${bhv:,.2f}")
+    perf.add_row("Buy & Hold Return", color_signed(bh_return))
+    perf.add_row("Total Trades", str(len(result.trades)))
+    print_centered(perf)
 
-    table.add_row("Starting Value", f"${sv:,.2f}")
-    table.add_row("Final Value", f"${fv:,.2f}")
-    table.add_row("Total Return", color_signed(total_return))
-    table.add_row("CAGR", color_signed(result.cagr))
-    table.add_row("Time-Weighted Return", color_signed(result.twr))
-    table.add_row("Buy & Hold Value", f"${bhv:,.2f}")
-    table.add_row("Buy & Hold Return", color_signed(bh_return))
-    table.add_row("Total Trades", str(len(result.trades)))
-
+    # --- Train / Test Split ---
     if result.split_date:
-        table.add_section()
-        table.add_row("Split Date", result.split_date.isoformat())
-        table.add_row("Train Return", color_signed(result.train_return))
-        table.add_row("Train B&H Return", color_signed(result.train_bh_return))
-        table.add_row("Train Trades", str(len(result.train_trades)))
-        table.add_row("Test Return", color_signed(result.test_return))
-        table.add_row("Test B&H Return", color_signed(result.test_bh_return))
-        table.add_row("Test Trades", str(len(result.test_trades)))
-        table.add_row("Efficiency Ratio", f"{result.efficiency_ratio:.0%}")
-
-    console.print(table, justify="center")
+        split = make_metric_table("Train / Test Split")
+        split.add_row("Split Date", result.split_date.isoformat())
+        split.add_row("Train Return", color_signed(result.train_return))
+        split.add_row("Train B&H Return", color_signed(result.train_bh_return))
+        split.add_row("Train Trades", str(len(result.train_trades)))
+        split.add_row("Test Return", color_signed(result.test_return))
+        split.add_row("Test B&H Return", color_signed(result.test_bh_return))
+        split.add_row("Test Trades", str(len(result.test_trades)))
+        split.add_row("Efficiency Ratio", f"{result.efficiency_ratio:.0%}")
+        print_centered(split)
 
     # --- Risk Metrics ---
-    risk_table = Table(title="Risk Metrics", show_lines=True, width=BACKTEST_TABLE_WIDTH)
-    risk_table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
-    risk_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
-
+    risk_table = make_metric_table("Risk Metrics")
     risk_table.add_row("Max Drawdown", f"[red]{result.max_drawdown:.2%}[/red]")
     risk_table.add_row("Sharpe Ratio", color_signed(result.sharpe_ratio, fmt=".2f"))
     risk_table.add_row("Sortino Ratio", color_signed(result.sortino_ratio, fmt=".2f"))
-
-    console.print(risk_table, justify="center")
+    print_centered(risk_table)
 
     # --- Trade Quality ---
-    sells = [t for t in result.trades if t.direction == Direction.SELL]
-    if sells:
-        trade_table = Table(title="Trade Quality", show_lines=True, width=BACKTEST_TABLE_WIDTH)
-        trade_table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
-        trade_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
-
+    if any(t.direction == Direction.SELL for t in result.trades):
+        trade_table = make_metric_table("Trade Quality")
         trade_table.add_row("Win Rate", color_signed(result.win_rate))
         pf_str = f"{result.profit_factor:.2f}" if not math.isinf(result.profit_factor) else "∞"
         trade_table.add_row("Profit Factor", pf_str)
         trade_table.add_row("Avg Win", f"[green]${result.avg_win:,.2f}[/green]")
         trade_table.add_row("Avg Loss", f"[red]${result.avg_loss:,.2f}[/red]")
-
-        console.print(trade_table, justify="center")
+        print_centered(trade_table)
 
     # --- Per-Strategy Breakdown ---
     if result.strategy_stats:
-        strat_table = Table(title="Strategy Breakdown", show_lines=True, width=BACKTEST_TABLE_WIDTH)
+        strat_table = make_wide_table("Strategy Breakdown")
         strat_table.add_column("Strategy", style="bold")
         strat_table.add_column("Trades", justify="right")
         strat_table.add_column("Buys", justify="right")
@@ -165,4 +180,4 @@ def print_backtest_summary(result: BacktestResult) -> None:
                 f"[{pnl_style}]${s.pnl:,.2f}[/{pnl_style}]" if s.sells > 0 else "—",
             )
 
-        console.print(strat_table, justify="center")
+        print_centered(strat_table)

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -78,7 +78,7 @@ METRIC_COL_WIDTH = (BACKTEST_TABLE_WIDTH - 4) // 2
 VALUE_COL_WIDTH = BACKTEST_TABLE_WIDTH - 4 - METRIC_COL_WIDTH
 
 
-def _color(value: float, fmt: str = ".2%") -> str:
+def color_signed(value: float, fmt: str = ".2%") -> str:
     """Color-code a numeric value green/red based on sign."""
     style = "green" if value >= 0 else "red"
     return f"[{style}]{value:{fmt}}[/{style}]"
@@ -98,21 +98,21 @@ def print_backtest_summary(result: BacktestResult) -> None:
 
     table.add_row("Starting Value", f"${sv:,.2f}")
     table.add_row("Final Value", f"${fv:,.2f}")
-    table.add_row("Total Return", _color(total_return))
-    table.add_row("CAGR", _color(result.cagr))
-    table.add_row("Time-Weighted Return", _color(result.twr))
+    table.add_row("Total Return", color_signed(total_return))
+    table.add_row("CAGR", color_signed(result.cagr))
+    table.add_row("Time-Weighted Return", color_signed(result.twr))
     table.add_row("Buy & Hold Value", f"${bhv:,.2f}")
-    table.add_row("Buy & Hold Return", _color(bh_return))
+    table.add_row("Buy & Hold Return", color_signed(bh_return))
     table.add_row("Total Trades", str(len(result.trades)))
 
     if result.split_date:
         table.add_section()
         table.add_row("Split Date", result.split_date.isoformat())
-        table.add_row("Train Return", _color(result.train_return))
-        table.add_row("Train B&H Return", _color(result.train_bh_return))
+        table.add_row("Train Return", color_signed(result.train_return))
+        table.add_row("Train B&H Return", color_signed(result.train_bh_return))
         table.add_row("Train Trades", str(len(result.train_trades)))
-        table.add_row("Test Return", _color(result.test_return))
-        table.add_row("Test B&H Return", _color(result.test_bh_return))
+        table.add_row("Test Return", color_signed(result.test_return))
+        table.add_row("Test B&H Return", color_signed(result.test_bh_return))
         table.add_row("Test Trades", str(len(result.test_trades)))
         table.add_row("Efficiency Ratio", f"{result.efficiency_ratio:.0%}")
 
@@ -124,8 +124,8 @@ def print_backtest_summary(result: BacktestResult) -> None:
     risk_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
 
     risk_table.add_row("Max Drawdown", f"[red]{result.max_drawdown:.2%}[/red]")
-    risk_table.add_row("Sharpe Ratio", _color(result.sharpe_ratio, fmt=".2f"))
-    risk_table.add_row("Sortino Ratio", _color(result.sortino_ratio, fmt=".2f"))
+    risk_table.add_row("Sharpe Ratio", color_signed(result.sharpe_ratio, fmt=".2f"))
+    risk_table.add_row("Sortino Ratio", color_signed(result.sortino_ratio, fmt=".2f"))
 
     console.print(risk_table, justify="center")
 
@@ -136,7 +136,7 @@ def print_backtest_summary(result: BacktestResult) -> None:
         trade_table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
         trade_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
 
-        trade_table.add_row("Win Rate", _color(result.win_rate))
+        trade_table.add_row("Win Rate", color_signed(result.win_rate))
         pf_str = f"{result.profit_factor:.2f}" if not math.isinf(result.profit_factor) else "∞"
         trade_table.add_row("Profit Factor", pf_str)
         trade_table.add_row("Avg Win", f"[green]${result.avg_win:,.2f}[/green]")

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -110,9 +111,26 @@ def print_run_info(rows: list[tuple[str, str]], title: str = "Run Info") -> None
     print_centered(table)
 
 
-def print_backtest_summary(result: BacktestResult) -> None:
-    import math
+def print_params_table(
+    title: str,
+    params: dict[str, dict[str, float]],
+    global_key: str | None = None,
+) -> None:
+    """Render an optimizer's per-strategy parameter table.
 
+    `global_key`, if supplied, is the synthetic strategy name used to hold
+    portfolio-wide allocation knobs; it's relabeled as "Global" for display.
+    """
+    table = make_wide_table(title)
+    table.add_column("Strategy", style="bold")
+    table.add_column("Parameters")
+    for name, p in params.items():
+        display = "Global" if global_key is not None and name == global_key else name
+        table.add_row(display, ", ".join(f"{k}={v}" for k, v in p.items()))
+    print_centered(table)
+
+
+def print_backtest_summary(result: BacktestResult) -> None:
     sv, fv, bhv = result.starting_value, result.final_value, result.buy_and_hold_value
     total_return = (fv - sv) / sv if sv > 0 else 0
     bh_return = (bhv - sv) / sv if sv > 0 else 0

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -68,34 +68,101 @@ def print_strategy_table(strategies: list[Strategy]) -> None:
         tags = ", ".join(t.value for t in s.suitability)
         table.add_row(s.name, s.tier.value, s.description, tags)
 
-    console.print(table)
+    console.print(table, justify="center")
+
+
+BACKTEST_TABLE_WIDTH = 100
+# Split table in half so the column divider is centered.
+# Account for 4 chars of box borders/separator (outer borders + center separator).
+METRIC_COL_WIDTH = (BACKTEST_TABLE_WIDTH - 4) // 2
+VALUE_COL_WIDTH = BACKTEST_TABLE_WIDTH - 4 - METRIC_COL_WIDTH
+
+
+def _color(value: float, fmt: str = ".2%") -> str:
+    """Color-code a numeric value green/red based on sign."""
+    style = "green" if value >= 0 else "red"
+    return f"[{style}]{value:{fmt}}[/{style}]"
 
 
 def print_backtest_summary(result: BacktestResult) -> None:
+    import math
+
     sv, fv, bhv = result.starting_value, result.final_value, result.buy_and_hold_value
     total_return = (fv - sv) / sv if sv > 0 else 0
     bh_return = (bhv - sv) / sv if sv > 0 else 0
 
-    table = Table(title="Backtest Summary")
-    table.add_column("Metric", style="bold")
-    table.add_column("Value", justify="right")
+    # --- Returns ---
+    table = Table(title="Backtest Summary", show_lines=True, width=BACKTEST_TABLE_WIDTH)
+    table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
+    table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
 
     table.add_row("Starting Value", f"${sv:,.2f}")
     table.add_row("Final Value", f"${fv:,.2f}")
-    table.add_row("Total Return", f"{total_return:.2%}")
-    table.add_row("Time-Weighted Return", f"{result.twr:.2%}")
+    table.add_row("Total Return", _color(total_return))
+    table.add_row("CAGR", _color(result.cagr))
+    table.add_row("Time-Weighted Return", _color(result.twr))
     table.add_row("Buy & Hold Value", f"${bhv:,.2f}")
-    table.add_row("Buy & Hold Return", f"{bh_return:.2%}")
+    table.add_row("Buy & Hold Return", _color(bh_return))
     table.add_row("Total Trades", str(len(result.trades)))
 
     if result.split_date:
         table.add_section()
         table.add_row("Split Date", result.split_date.isoformat())
-        table.add_row("Train Return", f"{result.train_return:.2%}")
-        table.add_row("Train B&H Return", f"{result.train_bh_return:.2%}")
+        table.add_row("Train Return", _color(result.train_return))
+        table.add_row("Train B&H Return", _color(result.train_bh_return))
         table.add_row("Train Trades", str(len(result.train_trades)))
-        table.add_row("Test Return", f"{result.test_return:.2%}")
-        table.add_row("Test B&H Return", f"{result.test_bh_return:.2%}")
+        table.add_row("Test Return", _color(result.test_return))
+        table.add_row("Test B&H Return", _color(result.test_bh_return))
         table.add_row("Test Trades", str(len(result.test_trades)))
+        table.add_row("Efficiency Ratio", f"{result.efficiency_ratio:.0%}")
 
-    console.print(table)
+    console.print(table, justify="center")
+
+    # --- Risk Metrics ---
+    risk_table = Table(title="Risk Metrics", show_lines=True, width=BACKTEST_TABLE_WIDTH)
+    risk_table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
+    risk_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
+
+    risk_table.add_row("Max Drawdown", f"[red]{result.max_drawdown:.2%}[/red]")
+    risk_table.add_row("Sharpe Ratio", _color(result.sharpe_ratio, fmt=".2f"))
+    risk_table.add_row("Sortino Ratio", _color(result.sortino_ratio, fmt=".2f"))
+
+    console.print(risk_table, justify="center")
+
+    # --- Trade Quality ---
+    sells = [t for t in result.trades if t.direction == Direction.SELL]
+    if sells:
+        trade_table = Table(title="Trade Quality", show_lines=True, width=BACKTEST_TABLE_WIDTH)
+        trade_table.add_column("Metric", style="bold", width=METRIC_COL_WIDTH)
+        trade_table.add_column("Value", justify="right", width=VALUE_COL_WIDTH)
+
+        trade_table.add_row("Win Rate", _color(result.win_rate))
+        pf_str = f"{result.profit_factor:.2f}" if not math.isinf(result.profit_factor) else "∞"
+        trade_table.add_row("Profit Factor", pf_str)
+        trade_table.add_row("Avg Win", f"[green]${result.avg_win:,.2f}[/green]")
+        trade_table.add_row("Avg Loss", f"[red]${result.avg_loss:,.2f}[/red]")
+
+        console.print(trade_table, justify="center")
+
+    # --- Per-Strategy Breakdown ---
+    if result.strategy_stats:
+        strat_table = Table(title="Strategy Breakdown", show_lines=True, width=BACKTEST_TABLE_WIDTH)
+        strat_table.add_column("Strategy", style="bold")
+        strat_table.add_column("Trades", justify="right")
+        strat_table.add_column("Buys", justify="right")
+        strat_table.add_column("Sells", justify="right")
+        strat_table.add_column("Win Rate", justify="right")
+        strat_table.add_column("P&L", justify="right")
+
+        for s in result.strategy_stats:
+            pnl_style = "green" if s.pnl >= 0 else "red"
+            strat_table.add_row(
+                s.name,
+                str(s.trades),
+                str(s.buys),
+                str(s.sells),
+                f"{s.win_rate:.0%}" if s.sells > 0 else "—",
+                f"[{pnl_style}]${s.pnl:,.2f}[/{pnl_style}]" if s.sells > 0 else "—",
+            )
+
+        console.print(strat_table, justify="center")

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,5 +1,6 @@
 """Tests for the backtest engine."""
 
+import math
 from datetime import date
 from pathlib import Path
 
@@ -7,8 +8,18 @@ import pandas as pd
 from conftest import make_price_series
 
 from midas.allocator import Allocator
-from midas.backtest import BacktestEngine, write_backtest_csv
-from midas.models import AllocationConstraints, CashInfusion, Direction, Holding, PortfolioConfig
+from midas.backtest import (
+    TRADING_DAYS_PER_YEAR,
+    BacktestEngine,
+    compute_cagr,
+    compute_max_drawdown,
+    compute_sharpe,
+    compute_sortino,
+    compute_strategy_stats,
+    compute_trade_stats,
+    write_backtest_csv,
+)
+from midas.models import AllocationConstraints, CashInfusion, Direction, Holding, PortfolioConfig, TradeRecord
 from midas.rebalancer import Rebalancer
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.profit_taking import ProfitTaking
@@ -268,3 +279,269 @@ def test_backtest_recurring_cash_infusion() -> None:
     # With ~100 trading days (~140 calendar days), biweekly = ~10 infusions of $1000
     # Final value must exceed starting holdings + multiple infusions
     assert result.final_value > 500.0 + 10 * 100.0 + 5000.0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the metric helpers
+# ---------------------------------------------------------------------------
+
+
+def _curve(values: list[float], start: date = date(2024, 1, 1)) -> list[tuple[date, float]]:
+    """Build an equity curve from a list of daily values."""
+    return [(date.fromordinal(start.toordinal() + i), v) for i, v in enumerate(values)]
+
+
+def _sell(d: date, ticker: str, shares: float, price: float, strategy: str = "S1") -> TradeRecord:
+    return TradeRecord(
+        date=d, ticker=ticker, direction=Direction.SELL, shares=shares, price=price, strategy_name=strategy
+    )
+
+
+def _buy(d: date, ticker: str, shares: float, price: float, strategy: str = "S1") -> TradeRecord:
+    return TradeRecord(
+        date=d, ticker=ticker, direction=Direction.BUY, shares=shares, price=price, strategy_name=strategy
+    )
+
+
+# --- compute_cagr ---
+
+
+def test_cagr_one_year_double() -> None:
+    # 100 → 200 over ~one year ≈ 100% CAGR.
+    # `days` is an int and the function divides by 365.25, so use a slightly
+    # larger window to clear the rounding gap.
+    cagr = compute_cagr(100.0, 200.0, 366)
+    assert math.isclose(cagr, 1.0, abs_tol=1e-2)
+
+
+def test_cagr_two_year_quadruple() -> None:
+    # 100 → 400 over 2 years = 100% CAGR
+    cagr = compute_cagr(100.0, 400.0, 731)
+    assert math.isclose(cagr, 1.0, abs_tol=1e-2)
+
+
+def test_cagr_zero_days_returns_zero() -> None:
+    assert compute_cagr(100.0, 200.0, 0) == 0.0
+
+
+def test_cagr_invalid_starting_returns_zero() -> None:
+    assert compute_cagr(0.0, 200.0, 365) == 0.0
+    assert compute_cagr(-10.0, 200.0, 365) == 0.0
+
+
+def test_cagr_loss() -> None:
+    # 100 → 50 over ~1 year = -50% CAGR
+    cagr = compute_cagr(100.0, 50.0, 366)
+    assert math.isclose(cagr, -0.5, abs_tol=1e-2)
+
+
+# --- compute_max_drawdown ---
+
+
+def test_max_drawdown_monotone_up_is_zero() -> None:
+    assert compute_max_drawdown(_curve([100, 110, 120, 130])) == 0.0
+
+
+def test_max_drawdown_monotone_down() -> None:
+    # 100 → 50 = 50% drawdown
+    assert compute_max_drawdown(_curve([100, 90, 75, 50])) == 0.5
+
+
+def test_max_drawdown_peak_then_recover() -> None:
+    # peak 120 → trough 60 = 50%
+    dd = compute_max_drawdown(_curve([100, 120, 90, 60, 80, 110]))
+    assert math.isclose(dd, 0.5, abs_tol=1e-9)
+
+
+def test_max_drawdown_single_point() -> None:
+    assert compute_max_drawdown(_curve([100])) == 0.0
+
+
+def test_max_drawdown_empty() -> None:
+    assert compute_max_drawdown([]) == 0.0
+
+
+# --- compute_sharpe ---
+
+
+def test_sharpe_flat_curve_is_zero() -> None:
+    assert compute_sharpe(_curve([100, 100, 100, 100])) == 0.0
+
+
+def test_sharpe_too_few_points() -> None:
+    assert compute_sharpe(_curve([100, 101])) == 0.0
+    assert compute_sharpe([]) == 0.0
+
+
+def test_sharpe_positive_when_mean_positive() -> None:
+    # Mix of up and down days with positive bias
+    curve = _curve([100, 102, 101, 103, 102, 104, 103, 105])
+    s = compute_sharpe(curve)
+    assert s > 0
+
+
+def test_sharpe_negative_when_mean_negative() -> None:
+    curve = _curve([100, 98, 99, 97, 98, 96, 97, 95])
+    assert compute_sharpe(curve) < 0
+
+
+def test_sharpe_annualization_factor() -> None:
+    # Returns with positive mean & nonzero std should scale by sqrt(252).
+    curve = _curve([100, 101, 102, 103])  # roughly +1%/day with shrinking returns
+    s = compute_sharpe(curve)
+    # mean ≈ 0.0099, std small but nonzero — annualized factor present
+    assert s > math.sqrt(TRADING_DAYS_PER_YEAR) * 0.5
+
+
+# --- compute_sortino ---
+
+
+def test_sortino_no_downside_returns_zero_not_inf() -> None:
+    # All-up curve → no negative returns → undefined → 0.0 (NOT inf)
+    curve = _curve([100, 101, 102, 103, 104])
+    result = compute_sortino(curve)
+    assert result == 0.0
+    assert not math.isinf(result)
+
+
+def test_sortino_flat_returns_zero() -> None:
+    assert compute_sortino(_curve([100, 100, 100, 100])) == 0.0
+
+
+def test_sortino_too_few_points() -> None:
+    assert compute_sortino(_curve([100, 101])) == 0.0
+    assert compute_sortino([]) == 0.0
+
+
+def test_sortino_negative_when_mean_negative() -> None:
+    curve = _curve([100, 98, 99, 97, 98, 96, 97, 95])
+    assert compute_sortino(curve) < 0
+
+
+def test_sortino_positive_when_mean_positive_with_some_downside() -> None:
+    curve = _curve([100, 102, 101, 103, 102, 104, 103, 105])
+    assert compute_sortino(curve) > 0
+
+
+# --- compute_trade_stats ---
+
+
+def test_trade_stats_no_sells() -> None:
+    trades = [_buy(date(2024, 1, 1), "AAPL", 10, 100.0)]
+    win_rate, pf, avg_win, avg_loss = compute_trade_stats(trades, [])
+    assert (win_rate, pf, avg_win, avg_loss) == (0.0, 0.0, 0.0, 0.0)
+
+
+def test_trade_stats_all_wins() -> None:
+    trades = [
+        _sell(date(2024, 1, 2), "AAPL", 10, 110.0),
+        _sell(date(2024, 1, 3), "AAPL", 5, 120.0),
+    ]
+    basis = [100.0, 100.0]  # gains: +100, +100
+    win_rate, pf, avg_win, avg_loss = compute_trade_stats(trades, basis)
+    assert win_rate == 1.0
+    assert math.isinf(pf)
+    assert avg_win == 100.0
+    assert avg_loss == 0.0
+
+
+def test_trade_stats_all_losses() -> None:
+    trades = [_sell(date(2024, 1, 2), "AAPL", 10, 90.0)]
+    basis = [100.0]  # loss: -100
+    win_rate, pf, avg_win, avg_loss = compute_trade_stats(trades, basis)
+    assert win_rate == 0.0
+    assert pf == 0.0
+    assert avg_win == 0.0
+    assert avg_loss == -100.0
+
+
+def test_trade_stats_mixed() -> None:
+    trades = [
+        _sell(date(2024, 1, 2), "AAPL", 10, 110.0),  # +100
+        _sell(date(2024, 1, 3), "AAPL", 10, 90.0),  # -100
+        _sell(date(2024, 1, 4), "AAPL", 10, 120.0),  # +200
+    ]
+    basis = [100.0, 100.0, 100.0]
+    win_rate, pf, avg_win, avg_loss = compute_trade_stats(trades, basis)
+    assert math.isclose(win_rate, 2 / 3, abs_tol=1e-9)
+    assert math.isclose(pf, 300.0 / 100.0, abs_tol=1e-9)
+    assert math.isclose(avg_win, 150.0, abs_tol=1e-9)
+    assert math.isclose(avg_loss, -100.0, abs_tol=1e-9)
+
+
+def test_trade_stats_same_day_same_ticker_no_collision() -> None:
+    """Two sells of the same ticker on the same day must each see their own basis."""
+    day = date(2024, 1, 2)
+    trades = [
+        _sell(day, "AAPL", 5, 110.0, strategy="A"),  # basis 100 → +50
+        _sell(day, "AAPL", 5, 110.0, strategy="B"),  # basis 80 → +150
+    ]
+    basis = [100.0, 80.0]
+    win_rate, pf, avg_win, _avg_loss = compute_trade_stats(trades, basis)
+    assert win_rate == 1.0
+    # Both wins: 50 + 150 = 200; avg = 100
+    assert math.isclose(avg_win, 100.0, abs_tol=1e-9)
+    assert math.isinf(pf)
+
+
+def test_trade_stats_breakeven_counts_as_win() -> None:
+    trades = [_sell(date(2024, 1, 2), "AAPL", 10, 100.0)]
+    basis = [100.0]
+    win_rate, _pf, _avg_win, _avg_loss = compute_trade_stats(trades, basis)
+    assert win_rate == 1.0
+
+
+# --- compute_strategy_stats ---
+
+
+def test_strategy_stats_groups_by_strategy() -> None:
+    trades = [
+        _buy(date(2024, 1, 1), "AAPL", 10, 100.0, strategy="A"),
+        _sell(date(2024, 1, 2), "AAPL", 10, 110.0, strategy="A"),  # +100
+        _buy(date(2024, 1, 1), "MSFT", 5, 200.0, strategy="B"),
+        _sell(date(2024, 1, 3), "MSFT", 5, 190.0, strategy="B"),  # -50
+    ]
+    basis = [100.0, 200.0]  # parallel to sells in trade order
+    stats = compute_strategy_stats(trades, basis)
+    by_name = {s.name: s for s in stats}
+    assert by_name["A"].buys == 1
+    assert by_name["A"].sells == 1
+    assert by_name["A"].pnl == 100.0
+    assert by_name["A"].win_rate == 1.0
+    assert by_name["B"].pnl == -50.0
+    assert by_name["B"].win_rate == 0.0
+
+
+def test_strategy_stats_same_day_collision() -> None:
+    """Two strategies sell the same ticker on the same day with different bases."""
+    day = date(2024, 1, 2)
+    trades = [
+        _sell(day, "AAPL", 5, 110.0, strategy="A"),  # basis 100 → +50
+        _sell(day, "AAPL", 5, 110.0, strategy="B"),  # basis 80  → +150
+    ]
+    basis = [100.0, 80.0]
+    stats = compute_strategy_stats(trades, basis)
+    by_name = {s.name: s for s in stats}
+    assert by_name["A"].pnl == 50.0
+    assert by_name["B"].pnl == 150.0
+
+
+def test_strategy_stats_empty() -> None:
+    assert compute_strategy_stats([], []) == []
+
+
+# --- end-to-end check that BacktestResult populates new metrics ---
+
+
+def test_backtest_populates_new_metrics() -> None:
+    portfolio, price_data = _make_backtest_data()
+    mr = MeanReversion(window=10, threshold=-0.05)
+    engine = _build_engine(conviction_strategies=[(mr, 1.0)], enable_split=False)
+    idx = list(price_data["AAPL"].index)
+    start, end = idx[0], idx[-1]
+    result = engine.run(portfolio, price_data, start, end)
+    assert len(result.equity_curve) > 0
+    assert result.equity_curve[-1][0] == end
+    assert result.max_drawdown >= 0.0
+    # Sortino must never be inf — even on a perfect run we cap to 0.
+    assert not math.isinf(result.sortino_ratio)


### PR DESCRIPTION
## Summary
- Adds equity-curve tracking to the backtest engine and surfaces risk metrics (max drawdown, Sharpe, Sortino), trade quality (win rate, profit factor, avg win/loss), CAGR, and a per-strategy P&L breakdown
- Standard `optimize` now re-runs the best parameters in-process and reuses `print_backtest_summary`, so it shows the same risk/trade tables as `backtest`
- Walk-forward `optimize` per-fold table gains Max DD / Sharpe / Sortino / Win Rate columns; aggregate table adds Mean DD / Mean Sharpe / Mean Sortino / Mean Win Rate
- All three command outputs (`backtest`, `optimize`, `optimize --walk-forward`) now share a single visual language: same width, borders, column widths, centered tables, and a common Run Info footer

## Output formatting refactor
- New helpers in `output.py`: `make_metric_table`, `make_wide_table`, `print_centered`, `print_run_info`, `print_params_table`, `color_signed`
- `print_backtest_summary` split into separate **Performance**, **Train / Test Split**, **Risk Metrics**, **Trade Quality**, and **Strategy Breakdown** tables instead of one oversized summary
- Walk-forward replaces the borderless Summary block with a regular metric table built from the same factory; per-fold table widened to 140 cols to fit the new Sortino column
- Walk-forward labels standardized on **IS / OOS** terminology (was a mix of Train/Test and OOS)

## Implementation notes
- `BacktestResult` gains risk/trade fields and a `StrategyStats` breakdown
- Per-sell cost basis is recorded into a parallel `basis_per_sell` list (in trade order) so multiple strategies selling the same ticker on the same day each get their own snapshot — a `(date, ticker)` dict would have collided
- `OptimizeResult` now carries the full `BacktestResult` (best run is re-executed in-process after the Optuna study completes; worker pool still only serializes scalars)
- `FoldResult` and `WalkForwardResult` carry the new aggregate fields (`sortino_ratio`, `mean_sortino`)
- `compute_sortino` returns `0.0` (sentinel) instead of `inf` when there is no downside, so walk-forward `mean_sortino` can't be poisoned by a single zero-downside fold
- Train/test split bug fix: `cli.py` Test Return label now reflects the user-supplied `--train-pct` (was hard-coded to 30%)
- New helpers: `compute_cagr`, `compute_max_drawdown`, `compute_sharpe`, `compute_sortino`, `compute_trade_stats`, `compute_strategy_stats`

## Review follow-ups (commit 1453f16)
- Replaced same-day-collision-prone `cost_basis_at_sell` dict with the `basis_per_sell` parallel list described above
- Capped `compute_sortino` at `0.0` instead of `inf` so averaging across folds is well-defined
- Moved `import math` to the top of `output.py`
- Promoted `_print_params_table` out of the `cli.optimize` closure into `output.print_params_table` (takes the synthetic global key as a parameter so `output.py` doesn't depend on `optimizer.ALLOCATION_KEY`)
- Added 30 unit tests covering the six new `compute_*` helpers — degenerate inputs (empty / single point / flat / too-few-points), same-day same-ticker collisions for both stat helpers, the Sortino inf-guard, and an end-to-end check that `BacktestResult` populates the new fields

## Test plan
- [x] Existing tests pass — full suite now 142 passing (was 112; 30 new metric tests added)
- [ ] Run a standard backtest and confirm the new Performance / Risk / Trade Quality / Strategy Breakdown tables render
- [x] Run a standard optimize and confirm it produces the same metric tables plus a Run Info + Optimized Parameters footer
- [ ] Run a walk-forward optimization and confirm the per-fold table includes Sortino and the aggregate table is bordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)