### PR TITLE
Fix strategy attribution picker + flag P&L caveat

### DIFF
--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -199,3 +199,15 @@ def print_backtest_summary(result: BacktestResult) -> None:
             )
 
         print_centered(strat_table)
+        # Per-strategy P&L is currently credited to whichever strategy
+        # triggered the *exit*, not the strategy that found the entry.
+        # Exit strategies (e.g. ProfitTaking, TrailingStop) therefore
+        # capture gains that entry strategies (e.g. Momentum) actually
+        # sourced. Trust the activity counts; take the P&L column with
+        # a grain of salt until the tier redesign lands. See #26.
+        console.print(
+            "[dim italic]Note: P&L is credited to the exit strategy, not the "
+            "entry strategy. Activity counts are accurate; P&L attribution is "
+            "known to be misleading. See issue #26.[/dim italic]",
+            justify="center",
+        )

--- a/src/midas/rebalancer.py
+++ b/src/midas/rebalancer.py
@@ -234,15 +234,17 @@ class Rebalancer:
             f"{action} {ticker}: target {target_weight:.1%} vs "
             f"current {current_weight:.1%} (blended score {blended:+.3f})"
         )
-        # Primary strategy = largest contributor in the order's direction.
-        # For buys, pick the most positive score; for sells, the most negative.
-        if contribs:
-            if direction == Direction.BUY:
-                source = max(contribs, key=lambda k: contribs[k])
-            else:
-                source = min(contribs, key=lambda k: contribs[k])
+        # Primary strategy = largest contributor whose score is actually
+        # directionally aligned with the order. Buys need a positive score;
+        # sells need a negative score. Picking min/max without this filter
+        # blames buy-only strategies for sells (and vice versa) whenever no
+        # strategy truly drove the order — the allocator just rebalanced.
+        if direction == Direction.BUY:
+            aligned = {k: v for k, v in contribs.items() if v > 0}
+            source = max(aligned, key=lambda k: aligned[k]) if aligned else "Rebalancer"
         else:
-            source = "Rebalancer"
+            aligned = {k: v for k, v in contribs.items() if v < 0}
+            source = min(aligned, key=lambda k: aligned[k]) if aligned else "Rebalancer"
         return OrderContext(
             contributions=contribs,
             blended_score=blended,


### PR DESCRIPTION
## Summary

- Fix the rebalancer's strategy attribution picker so orders are only credited to strategies whose score is directionally aligned with the order. Buy-only strategies like Momentum no longer accumulate phantom sells, and sell-only strategies like ProfitTaking no longer accumulate phantom buys.
- Add a caveat note under the Strategy Breakdown table pointing users at #26 for the deeper P&L attribution issue (which isn't fixed here on purpose — see below).

## What was wrong

The rebalancer's `_build_context` picked the \"primary strategy\" for each order via `max(contribs, ...)` for buys and `min(contribs, ...)` for sells, with no sign check. When no strategy actually signaled in the order's direction (e.g. the allocator generated a drift-correction trade), the picker still blamed whichever contributor had the least-positive or least-negative score. As a result:

- **Momentum** (buy-only, returns 0 for bearish conditions) showed **49 phantom sells** in a 10-year backtest — orders it never wanted.
- **ProfitTaking** (sell-only) showed **5 phantom buys** for the same reason.
- The Strategy Breakdown table told a story that contradicted the actual strategy logic, making it useless for evaluating which strategies were pulling their weight.

## What this PR does

**Commit 1 — `56f44af` Fix strategy attribution picker to require directional alignment**

Filter `contribs` by sign before picking a primary strategy. Buys need a positive score; sells need a negative score. When no strategy is directionally aligned, fall back to `\"Rebalancer\"` to correctly label the order as allocator-driven.

Trade execution is unchanged — only the `source` label on `OrderContext` (and therefore `TradeRecord.strategy_name`). Verified by diffing the full trade log against master: every trade has the same date, ticker, direction, shares, and price; only `strategy_name` differs.

**Commit 2 — `7446aca` Flag P&L attribution caveat in strategy breakdown table**

Adds a dim italic note under the breakdown table warning that the P&L column is credited to the exit strategy, not the entry strategy, and pointing users to #26 for the structural fix.

## Before / after (10-year backtest, sample-portfolio.yaml + optimized-strategy.yaml)

Before:

| Strategy | Trades | Buys | Sells |
|---|---|---|---|
| Momentum | 177 | 128 | **49** (phantom) |
| ProfitTaking | 82 | **5** (phantom) | 77 |
| RSIOversold | 137 | 99 | **38** (phantom) |
| TrailingStop | 17 | 0 | 17 |

After:

| Strategy | Trades | Buys | Sells |
|---|---|---|---|
| Momentum | 196 | 196 | 0 |
| ProfitTaking | 14 | 0 | 14 |
| RSIOversold | 68 | 68 | 0 |
| TrailingStop | 14 | 0 | 14 |
| **Rebalancer** | 202 | 17 | 185 |

Buy-only and sell-only strategies stay in their lane. The new \"Rebalancer\" row captures the 202 orders where no strategy had a directionally-aligned score — these are allocator-driven drift corrections the old picker was silently blaming on random strategies.

## What this PR does NOT do

- **Does not fix P&L attribution.** The P&L column still credits exit strategies with gains that entry strategies sourced. That's being deferred to #26 (tier redesign) because any tactical attribution model picked now would bias the structural fix. The caveat note in commit 2 makes this explicit for users.
- **Does not touch the \"Rebalancer\" drift-correction behavior.** Tracked separately in #25.
- **Does not fix strategy warmup** (no lookback prefetch). Tracked in #24.

## Context and related issues

Originally planned as a 4-commit PR that would have also fixed P&L attribution. While investigating, we discovered the P&L bug is a symptom of a deeper taxonomy problem: sell-side rules like ProfitTaking shouldn't live in the CONVICTION tier at all. The real fix is a redesign of the tier system (entry signals / exit rules / scheduled orders). That redesign is scoped in #26 and will obsolete any tactical attribution model we could pick here. Rather than bake in a compromise, this PR ships just the picker fix — which is unambiguously correct and defense-in-depth under any future design — and punts the structural work.

- #24 — Backtest/optimize don't prefetch lookback for strategy warmup
- #25 — Allocator treats equal-weight as neutral, forcing drift-correction trades
- #26 — Redesign strategy tier taxonomy (supersedes the deferred P&L attribution work)

## Test plan

- [x] `uv run pytest` — 142 passed
- [x] `ruff check` / `ruff format` / `mypy` — clean (pre-commit hooks pass)
- [x] `uv run midas backtest -p sample-portfolio.yaml -s optimized-strategy.yaml --start 2016-01-01 --end 2026-03-24 -o output.csv` — runs, shows corrected Strategy Breakdown table with the caveat note
- [x] Diff trade log against master — identical date/ticker/direction/shares/price on every trade; only `strategy_name` differs
- [ ] Reviewer check: does the caveat note render correctly in the reviewer's terminal width?

🤖 Generated with [Claude Code](https://claude.com/claude-code)