### PR TITLE
Prefetch strategy warmup so signals are valid from day one

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,10 @@ Each strategy belongs to one of three tiers that determine how it participates i
 
 For backtest performance, strategies can optionally compute scores for every day of the price series in a single vectorized pass. The allocator caches these results and looks them up by day index during simulation, avoiding per-day function calls. Strategies that need runtime context like cost basis (ProfitTaking, StopLoss, TrailingStop) cannot precompute and fall back to per-day evaluation.
 
+#### Warmup
+
+Each strategy declares a `warmup_period` — the bars of price history it needs before it produces a valid score. The CLI fetches a lookback buffer equal to the maximum warmup across configured strategies (plus slack for weekends/holidays) so signals are valid from day one of the simulation rather than spending the first N days in cold start. For recursive indicators (RSI, MACD), the nominal period is multiplied by a TA-Lib-style unstable-period factor so the indicator has room to converge. Live mode derives the same history window, and the walk-forward optimizer prefetches a single buffer sized for the upper bound of its parameter search space.
+
 See [Strategies](strategies.md) for a reference of all available strategies.
 
 ### Allocator

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -84,10 +84,10 @@ class Allocator:
                     equal_weight,
                 )
 
-    def max_warmup_period(self) -> int:
-        """Largest ``warmup_period`` across all conviction and protective strategies."""
-        strategies = [s.strategy for s in self._conviction] + [e.strategy for e in self._protective]
-        return max((s.warmup_period for s in strategies), default=0)
+    @property
+    def strategies(self) -> list[Strategy]:
+        """All strategies the allocator owns (conviction + protective)."""
+        return [s.strategy for s in self._conviction] + [e.strategy for e in self._protective]
 
     def precompute_signals(self, price_data: dict[str, np.ndarray]) -> None:
         """Precompute strategy scores for all tickers over the full price arrays.

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -84,6 +84,11 @@ class Allocator:
                     equal_weight,
                 )
 
+    def max_warmup_period(self) -> int:
+        """Largest ``warmup_period`` across all conviction and protective strategies."""
+        strategies = [s.strategy for s in self._conviction] + [e.strategy for e in self._protective]
+        return max((s.warmup_period for s in strategies), default=0)
+
     def precompute_signals(self, price_data: dict[str, np.ndarray]) -> None:
         """Precompute strategy scores for all tickers over the full price arrays.
 

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -26,7 +26,7 @@ from midas.models import (
 )
 from midas.rebalancer import Rebalancer
 from midas.restrictions import RestrictionTracker
-from midas.strategies.base import Strategy
+from midas.strategies.base import Strategy, max_warmup
 
 
 @dataclass
@@ -384,10 +384,7 @@ class BacktestEngine:
 
     def _warmup_bars(self) -> int:
         """Max warmup required across allocator + mechanical strategies."""
-        return max(
-            self._allocator.max_warmup_period(),
-            max((s.warmup_period for s in self._mechanical), default=0),
-        )
+        return max_warmup([*self._allocator.strategies, *self._mechanical])
 
     def _first_data_dates(
         self,

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -347,15 +347,47 @@ class BacktestEngine:
         start: date,
         end: date,
     ) -> dict[str, _TickerIndex]:
+        """Build per-ticker arrays keeping the warmup prefix intact.
+
+        The returned array spans ``[max(first_available, start - warmup_bars), end]``
+        so ``precompute_signals`` and the per-day pointer advance see a prefix
+        of history before the user's ``start``. The simulation loop iterates
+        over ``trading_days`` (which are already filtered to ``start..end``),
+        so the pointer walks through warmup dates on day one of the sim.
+        """
+        warmup_bars = self._warmup_bars()
         index: dict[str, _TickerIndex] = {}
         for ticker, series in price_data.items():
-            in_range = series[(series.index >= start) & (series.index <= end)]
-            if len(in_range) > 0:
-                index[ticker] = _TickerIndex(
-                    dates=list(in_range.index),
-                    values=np.asarray(in_range.values),
+            bounded = series[series.index <= end]
+            if len(bounded) == 0:
+                continue
+            # Identify the first trading day inside the sim window.
+            sim_mask = np.asarray(bounded.index >= start)
+            if not sim_mask.any():
+                continue
+            sim_first_idx = int(np.argmax(sim_mask))
+            # Keep up to ``warmup_bars`` prior bars for precompute.
+            warmup_first_idx = max(0, sim_first_idx - warmup_bars)
+            available_warmup = sim_first_idx - warmup_first_idx
+            if warmup_bars > 0 and available_warmup < warmup_bars:
+                self._log(
+                    f"{ticker}: only {available_warmup} warmup bars available "
+                    f"(requested {warmup_bars}) — strategies will score on "
+                    f"partial history until enough bars accumulate"
                 )
+            sliced = bounded.iloc[warmup_first_idx:]
+            index[ticker] = _TickerIndex(
+                dates=list(sliced.index),
+                values=np.asarray(sliced.values),
+            )
         return index
+
+    def _warmup_bars(self) -> int:
+        """Max warmup required across allocator + mechanical strategies."""
+        return max(
+            self._allocator.max_warmup_period(),
+            max((s.warmup_period for s in self._mechanical), default=0),
+        )
 
     def _first_data_dates(
         self,

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -21,7 +21,7 @@ from midas.models import (
 from midas.output import print_backtest_summary, print_status, print_strategy_table
 from midas.rebalancer import Rebalancer
 from midas.strategies import STRATEGY_REGISTRY, Strategy
-from midas.strategies.base import warmup_bars_to_calendar_days
+from midas.strategies.base import max_warmup, warmup_bars_to_calendar_days
 
 
 def _build_strategy(cfg: StrategyConfig) -> Strategy:
@@ -82,13 +82,8 @@ def _fetch_prices(
     price_data: dict[str, pd.Series] = {}
     tickers = [h.ticker for h in portfolio.holdings]
     buffer_days = warmup_bars_to_calendar_days(warmup_bars)
-    fetch_start = start - timedelta(days=buffer_days) if buffer_days else start
-    if buffer_days:
-        print_status(
-            f"Fetching data for {', '.join(tickers)} (with {buffer_days}-day warmup buffer from {fetch_start})..."
-        )
-    else:
-        print_status(f"Fetching data for {', '.join(tickers)}...")
+    fetch_start = start - timedelta(days=buffer_days)
+    print_status(f"Fetching data for {', '.join(tickers)} (with {buffer_days}-day warmup buffer from {fetch_start})...")
     for ticker in tickers:
         try:
             price_data[ticker] = provider.get_history(ticker, fetch_start, end)
@@ -153,10 +148,7 @@ def backtest(
         n_tickers,
     )
 
-    warmup_bars = max(
-        allocator.max_warmup_period(),
-        max((s.warmup_period for s in mechanical), default=0),
-    )
+    warmup_bars = max_warmup([*allocator.strategies, *mechanical])
     price_data = _fetch_prices(port, start_d, end_d, warmup_bars=warmup_bars)
 
     engine = BacktestEngine(

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import click
@@ -21,6 +21,7 @@ from midas.models import (
 from midas.output import print_backtest_summary, print_status, print_strategy_table
 from midas.rebalancer import Rebalancer
 from midas.strategies import STRATEGY_REGISTRY, Strategy
+from midas.strategies.base import warmup_bars_to_calendar_days
 
 
 def _build_strategy(cfg: StrategyConfig) -> Strategy:
@@ -68,14 +69,29 @@ def _fetch_prices(
     portfolio: PortfolioConfig,
     start: date,
     end: date,
+    warmup_bars: int = 0,
 ) -> dict[str, pd.Series]:
+    """Fetch price history from ``start - warmup_buffer`` through ``end``.
+
+    ``warmup_bars`` is the maximum number of trading days any configured
+    strategy needs before it can emit valid scores. The fetch start is
+    shifted backward by an equivalent calendar-day buffer so strategies
+    have history available on day one of the simulation.
+    """
     provider = CachedYFinanceProvider()
     price_data: dict[str, pd.Series] = {}
     tickers = [h.ticker for h in portfolio.holdings]
-    print_status(f"Fetching data for {', '.join(tickers)}...")
+    buffer_days = warmup_bars_to_calendar_days(warmup_bars)
+    fetch_start = start - timedelta(days=buffer_days) if buffer_days else start
+    if buffer_days:
+        print_status(
+            f"Fetching data for {', '.join(tickers)} (with {buffer_days}-day warmup buffer from {fetch_start})..."
+        )
+    else:
+        print_status(f"Fetching data for {', '.join(tickers)}...")
     for ticker in tickers:
         try:
-            price_data[ticker] = provider.get_history(ticker, start, end)
+            price_data[ticker] = provider.get_history(ticker, fetch_start, end)
         except Exception as e:
             print_status(f"Skipping {ticker}: {e}")
     return price_data
@@ -129,7 +145,6 @@ def backtest(
     strat_configs, constraints = load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints())
 
     start_d, end_d = _to_date(start), _to_date(end)
-    price_data = _fetch_prices(port, start_d, end_d)
 
     n_tickers = sum(1 for h in port.holdings if h.shares > 0)
     allocator, rebalancer, mechanical = _build_components(
@@ -137,6 +152,12 @@ def backtest(
         constraints,
         n_tickers,
     )
+
+    warmup_bars = max(
+        allocator.max_warmup_period(),
+        max((s.warmup_period for s in mechanical), default=0),
+    )
+    price_data = _fetch_prices(port, start_d, end_d, warmup_bars=warmup_bars)
 
     engine = BacktestEngine(
         allocator=allocator,
@@ -278,6 +299,7 @@ def optimize(
         ALLOCATION_KEY,
         WF_MIN_TEST_DAYS,
         WF_MIN_TRAIN_PCT,
+        max_warmup_for_search,
         walk_forward_optimize,
         write_strategies_yaml,
     )
@@ -307,7 +329,9 @@ def optimize(
         min_cash_pct = strat_constraints.min_cash_pct
 
     start_d, end_d = _to_date(start), _to_date(end)
-    price_data = _fetch_prices(port, start_d, end_d)
+    n_tickers = sum(1 for h in port.holdings if h.shares > 0)
+    warmup_bars = max_warmup_for_search(strategy_names, min_cash_pct, n_tickers)
+    price_data = _fetch_prices(port, start_d, end_d, warmup_bars=warmup_bars)
 
     from midas.output import (
         color_signed,

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -20,7 +20,7 @@ from midas.models import (
 from midas.output import print_alert, print_status
 from midas.rebalancer import Rebalancer
 from midas.restrictions import RestrictionTracker
-from midas.strategies.base import Strategy
+from midas.strategies.base import Strategy, warmup_bars_to_calendar_days
 
 
 class LiveEngine:
@@ -34,7 +34,7 @@ class LiveEngine:
         constraints: AllocationConstraints | None = None,
         poll_interval: int = 60,
         dry_run: bool = False,
-        history_days: int = 120,
+        history_days: int | None = None,
     ) -> None:
         self._portfolio = portfolio
         self._allocator = allocator
@@ -44,7 +44,17 @@ class LiveEngine:
         self._provider = provider
         self._poll_interval = poll_interval
         self._dry_run = dry_run
-        self._history_days = history_days
+        # Derive the history window from the largest warmup required across
+        # configured strategies (plus slack for weekends/holidays). An explicit
+        # ``history_days`` override is still honored for tests.
+        if history_days is not None:
+            self._history_days = history_days
+        else:
+            warmup_bars = max(
+                allocator.max_warmup_period(),
+                max((s.warmup_period for s in self._mechanical), default=0),
+            )
+            self._history_days = warmup_bars_to_calendar_days(warmup_bars)
         # Track (ticker, direction, shares) from last tick to suppress duplicate alerts
         self._last_order_keys: set[tuple[str, Direction, float]] = set()
         self._restriction_tracker: RestrictionTracker | None = None

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -20,7 +20,7 @@ from midas.models import (
 from midas.output import print_alert, print_status
 from midas.rebalancer import Rebalancer
 from midas.restrictions import RestrictionTracker
-from midas.strategies.base import Strategy, warmup_bars_to_calendar_days
+from midas.strategies.base import Strategy, max_warmup, warmup_bars_to_calendar_days
 
 
 class LiveEngine:
@@ -50,10 +50,7 @@ class LiveEngine:
         if history_days is not None:
             self._history_days = history_days
         else:
-            warmup_bars = max(
-                allocator.max_warmup_period(),
-                max((s.warmup_period for s in self._mechanical), default=0),
-            )
+            warmup_bars = max_warmup([*allocator.strategies, *self._mechanical])
             self._history_days = warmup_bars_to_calendar_days(warmup_bars)
         # Track (ticker, direction, shares) from last tick to suppress duplicate alerts
         self._last_order_keys: set[tuple[str, Direction, float]] = set()

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -327,6 +327,42 @@ def _wf_trial_worker(
     return total_ret, bh_ret, train_ret, test_ret, twr
 
 
+def max_warmup_for_search(
+    strategy_names: list[str] | None,
+    min_cash_pct: float = DEFAULT_MIN_CASH_PCT,
+    n_tickers: int = 1,
+) -> int:
+    """Upper bound on warmup bars across the optimizer's search space.
+
+    Walk-forward and standard optimizer trials sample different parameter
+    values, so the prefetched warmup buffer must cover the worst case.
+    For each optimizable strategy, instantiate it with every integer
+    parameter pinned to its search-range upper bound and take the max
+    ``warmup_period``.
+    """
+    names, ranges = _prepare_names_and_ranges(strategy_names, min_cash_pct, n_tickers)
+    max_w = 0
+    for name in names:
+        if name == ALLOCATION_KEY:
+            continue
+        cls = STRATEGY_REGISTRY[name]
+        params: dict[str, Any] = {}
+        for pname, (lo, hi, step) in ranges.get(name, {}).items():
+            if pname in META_PARAMS:
+                continue
+            # Snap hi down the same way _suggest_params does so the upper
+            # bound here matches values the optimizer actually tries.
+            d_lo, d_hi, d_step = decimal.Decimal(str(lo)), decimal.Decimal(str(hi)), decimal.Decimal(str(step))
+            snapped_hi = float((d_hi - d_lo) // d_step * d_step + d_lo)
+            params[pname] = int(snapped_hi) if pname in INT_PARAMS else snapped_hi
+        try:
+            instance = cls(**params)
+        except TypeError:
+            instance = cls()
+        max_w = max(max_w, instance.warmup_period)
+    return max_w
+
+
 def _prepare_names_and_ranges(
     strategy_names: list[str] | None,
     min_cash_pct: float,

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -355,10 +355,9 @@ def max_warmup_for_search(
             d_lo, d_hi, d_step = decimal.Decimal(str(lo)), decimal.Decimal(str(hi)), decimal.Decimal(str(step))
             snapped_hi = float((d_hi - d_lo) // d_step * d_step + d_lo)
             params[pname] = int(snapped_hi) if pname in INT_PARAMS else snapped_hi
-        try:
-            instance = cls(**params)
-        except TypeError:
-            instance = cls()
+        # Let TypeError propagate — if a search-range key doesn't match a
+        # constructor param, that's a real configuration bug we want loud.
+        instance = cls(**params)
         max_w = max(max_w, instance.warmup_period)
     return max_w
 

--- a/src/midas/strategies/base.py
+++ b/src/midas/strategies/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -25,10 +26,19 @@ WARMUP_CALENDAR_SLACK = 10
 MIN_WARMUP_CALENDAR_DAYS = 30
 
 
+def max_warmup(strategies: Iterable[Strategy]) -> int:
+    """Largest ``warmup_period`` across an iterable of strategies (0 if empty)."""
+    return max((s.warmup_period for s in strategies), default=0)
+
+
 def warmup_bars_to_calendar_days(bars: int) -> int:
-    """Convert a trading-day warmup requirement to a calendar-day buffer."""
-    if bars <= 0:
-        return 0
+    """Convert a trading-day warmup requirement to a calendar-day buffer.
+
+    Always returns at least ``MIN_WARMUP_CALENDAR_DAYS`` so callers (notably
+    ``LiveEngine``) get a sensible fetch window even when no configured
+    strategy advertises a warmup requirement.
+    """
+    bars = max(bars, 0)
     calendar = int(bars * TRADING_TO_CALENDAR_RATIO) + WARMUP_CALENDAR_SLACK
     return max(calendar, MIN_WARMUP_CALENDAR_DAYS)
 

--- a/src/midas/strategies/base.py
+++ b/src/midas/strategies/base.py
@@ -8,6 +8,30 @@ import numpy as np
 
 from midas.models import AssetSuitability, MechanicalIntent, StrategyTier
 
+# Recursive indicators (EMA, RSI, MACD) converge to their steady-state value
+# only after ~3-10x their nominal period. Following TA-Lib's "Unstable Period"
+# convention, we use 4x as the conservative default so strategies don't score
+# on numerically unstable values during warmup.
+RECURSIVE_WARMUP_MULTIPLIER = 4
+
+# Convert warmup bars (trading days) to calendar days. ~252 trading days per
+# year vs 365 calendar days gives 1.45x; rounded up to 1.5x for safety.
+TRADING_TO_CALENDAR_RATIO = 1.5
+# Extra calendar days added on top of the conversion to cover holidays and
+# weekends that would otherwise clip the warmup window.
+WARMUP_CALENDAR_SLACK = 10
+# Minimum calendar-day buffer to always fetch, so strategies with tiny windows
+# still get a sensible prefix and we don't re-derive a near-zero buffer.
+MIN_WARMUP_CALENDAR_DAYS = 30
+
+
+def warmup_bars_to_calendar_days(bars: int) -> int:
+    """Convert a trading-day warmup requirement to a calendar-day buffer."""
+    if bars <= 0:
+        return 0
+    calendar = int(bars * TRADING_TO_CALENDAR_RATIO) + WARMUP_CALENDAR_SLACK
+    return max(calendar, MIN_WARMUP_CALENDAR_DAYS)
+
 
 class Strategy(ABC):
     """Base class for all signal strategies.
@@ -34,6 +58,23 @@ class Strategy(ABC):
     def tier(self) -> StrategyTier:
         """Strategy tier — override in subclass if not CONVICTION."""
         return StrategyTier.CONVICTION
+
+    @property
+    def warmup_period(self) -> int:
+        """Bars of price history required before this strategy produces valid scores.
+
+        Backtest/optimize/live use ``max(warmup_period)`` across configured
+        strategies to prefetch a lookback buffer before the user's start date,
+        so strategies can emit valid signals from day one of the simulation
+        rather than spending the first N days in warmup.
+
+        Default is 0 (no warmup — e.g. mechanical or position-only strategies).
+        Override in subclasses that depend on a rolling window. For recursive
+        indicators (EMA/RSI/MACD) multiply the nominal period by
+        ``RECURSIVE_WARMUP_MULTIPLIER`` so the indicator has room to converge
+        to its steady-state value.
+        """
+        return 0
 
     @staticmethod
     def clamp(value: float, lo: float, hi: float) -> float:

--- a/src/midas/strategies/bollinger_band.py
+++ b/src/midas/strategies/bollinger_band.py
@@ -13,6 +13,10 @@ class BollingerBand(Strategy):
         self._window = window
         self._num_std = num_std
 
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         w = self._window

--- a/src/midas/strategies/gap_down_recovery.py
+++ b/src/midas/strategies/gap_down_recovery.py
@@ -12,6 +12,10 @@ class GapDownRecovery(Strategy):
     def __init__(self, gap_threshold: float = 0.03) -> None:
         self._gap_threshold = gap_threshold
 
+    @property
+    def warmup_period(self) -> int:
+        return 3
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         scores = np.full(n, np.nan)

--- a/src/midas/strategies/ma_crossover.py
+++ b/src/midas/strategies/ma_crossover.py
@@ -14,6 +14,10 @@ class MovingAverageCrossover(Strategy):
         self._long_window = long_window
         self._spread_scale = spread_scale
 
+    @property
+    def warmup_period(self) -> int:
+        return self._long_window
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         lw = self._long_window

--- a/src/midas/strategies/macd_crossover.py
+++ b/src/midas/strategies/macd_crossover.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 
 from midas.models import AssetSuitability
-from midas.strategies.base import Strategy
+from midas.strategies.base import RECURSIVE_WARMUP_MULTIPLIER, Strategy
 
 
 def _ema(values: np.ndarray, period: int) -> np.ndarray:
@@ -28,6 +28,13 @@ class MACDCrossover(Strategy):
         self._fast_period = fast_period
         self._slow_period = slow_period
         self._signal_period = signal_period
+
+    @property
+    def warmup_period(self) -> int:
+        # MACD chains three EMAs (fast, slow, signal). Strict min is
+        # slow + signal; give EMA room to converge with the recursive
+        # multiplier applied to the slow leg.
+        return self._slow_period * RECURSIVE_WARMUP_MULTIPLIER + self._signal_period
 
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)

--- a/src/midas/strategies/mean_reversion.py
+++ b/src/midas/strategies/mean_reversion.py
@@ -13,6 +13,10 @@ class MeanReversion(Strategy):
         self._window = window
         self._threshold = threshold
 
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         w = self._window

--- a/src/midas/strategies/momentum.py
+++ b/src/midas/strategies/momentum.py
@@ -13,6 +13,10 @@ class Momentum(Strategy):
         self._window = window
         self._momentum_scale = momentum_scale
 
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         w = self._window

--- a/src/midas/strategies/rsi_overbought.py
+++ b/src/midas/strategies/rsi_overbought.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import numpy as np
 
 from midas.models import AssetSuitability
-from midas.strategies.base import Strategy
+from midas.strategies.base import RECURSIVE_WARMUP_MULTIPLIER, Strategy
 
 
 class RSIOverbought(Strategy):
     def __init__(self, window: int = 14, overbought_threshold: float = 70.0) -> None:
         self._window = window
         self._overbought_threshold = overbought_threshold
+
+    @property
+    def warmup_period(self) -> int:
+        # RSI is recursive — see RSIOversold for rationale.
+        return self._window * RECURSIVE_WARMUP_MULTIPLIER
 
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import numpy as np
 
 from midas.models import AssetSuitability
-from midas.strategies.base import Strategy
+from midas.strategies.base import RECURSIVE_WARMUP_MULTIPLIER, Strategy
 
 
 class RSIOversold(Strategy):
     def __init__(self, window: int = 14, oversold_threshold: float = 30.0) -> None:
         self._window = window
         self._oversold_threshold = oversold_threshold
+
+    @property
+    def warmup_period(self) -> int:
+        # RSI is recursive (Wilder-style smoothing) — strict min of `window`
+        # bars gives a mathematically valid but numerically unstable value.
+        return self._window * RECURSIVE_WARMUP_MULTIPLIER
 
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)

--- a/src/midas/strategies/vwap_reversion.py
+++ b/src/midas/strategies/vwap_reversion.py
@@ -18,6 +18,10 @@ class VWAPReversion(Strategy):
         self._window = window
         self._threshold = threshold
 
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)
         w = self._window

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -188,6 +188,67 @@ def test_backtest_deferred_ticker() -> None:
     assert result.starting_value == 2000.0 + 5 * 80.0
 
 
+def test_backtest_consumes_warmup_prefix() -> None:
+    """Bars before ``start`` should prime strategy signals from day one.
+
+    Without a warmup prefix, a `window=20` strategy spends the first 20
+    days of the simulation in warmup and emits no signals. With a warmup
+    prefix fetched ahead of ``start``, the allocator can produce valid
+    conviction scores on the very first simulation day.
+    """
+    # 60 bars total: bars 0-19 are warmup, bars 20-59 are the sim window.
+    # Flat at 100 through bar 30, then drop — so the drop lands inside
+    # the sim window but needs the warmup bars to compute its 20-day MA.
+    returns = [0.0] * 30 + [-0.02] * 10 + [0.0] * 20
+    prices = make_price_series(date(2024, 1, 2), 60, 100.0, returns, name="AAPL")
+    trading_days = list(prices.index)
+    sim_start = trading_days[20]
+    sim_end = trading_days[-1]
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10, cost_basis=100.0)],
+        available_cash=5000.0,
+    )
+
+    mr = MeanReversion(window=20, threshold=0.05)
+    engine = _build_engine(
+        conviction_strategies=[(mr, 1.0)],
+        enable_split=False,
+    )
+    result = engine.run(portfolio, {"AAPL": prices}, sim_start, sim_end)
+
+    # With warmup consumed, the drop triggers a mean-reversion buy inside
+    # the sim window. Without warmup, the strategy would still be in its
+    # 20-day cold start when the drop started and miss it entirely.
+    buys = [t for t in result.trades if t.direction == Direction.BUY]
+    assert buys, "Expected at least one buy — warmup prefix was not consumed"
+    assert all(sim_start <= t.date <= sim_end for t in buys)
+
+
+def test_backtest_logs_insufficient_warmup() -> None:
+    """A ticker with less history than a strategy needs should log a warning."""
+    # Only 25 bars total, starting exactly at the sim start — no prefix.
+    prices = make_price_series(date(2024, 1, 2), 25, 100.0, name="AAPL")
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10, cost_basis=100.0)],
+        available_cash=1000.0,
+    )
+
+    # window=50 → warmup_period=50, but only ~25 bars are available.
+    mr = MeanReversion(window=50, threshold=0.05)
+    log_messages: list[str] = []
+    engine = _build_engine(
+        conviction_strategies=[(mr, 1.0)],
+        enable_split=False,
+        log_fn=log_messages.append,
+    )
+    engine.run(portfolio, {"AAPL": prices}, min(prices.index), max(prices.index))
+
+    warmup_msgs = [m for m in log_messages if "warmup" in m.lower()]
+    assert warmup_msgs, f"Expected warmup warning, got: {log_messages}"
+    assert "AAPL" in warmup_msgs[0]
+
+
 def test_backtest_excluded_ticker() -> None:
     """Tickers with no data in the range should be excluded and logged."""
     portfolio = PortfolioConfig(

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -307,3 +307,35 @@ class TestMovingAverageCrossover:
     def test_name_and_description(self) -> None:
         s = MovingAverageCrossover(short_window=15, long_window=45)
         assert s.name == "MovingAverageCrossover"
+
+
+class TestWarmupPeriod:
+    """Each strategy advertises the history it needs before scoring."""
+
+    def test_rolling_window_strategies_match_their_window(self) -> None:
+        assert Momentum(window=25).warmup_period == 25
+        assert MeanReversion(window=40).warmup_period == 40
+        assert BollingerBand(window=30).warmup_period == 30
+        assert VWAPReversion(window=15).warmup_period == 15
+
+    def test_ma_crossover_uses_long_window(self) -> None:
+        assert MovingAverageCrossover(short_window=10, long_window=60).warmup_period == 60
+
+    def test_rsi_applies_recursive_multiplier(self) -> None:
+        # Recursive indicators need 4x their nominal period to converge
+        # (TA-Lib unstable-period convention).
+        assert RSIOversold(window=14).warmup_period == 56
+        assert RSIOverbought(window=14).warmup_period == 56
+
+    def test_macd_uses_slow_period_times_multiplier_plus_signal(self) -> None:
+        assert MACDCrossover(slow_period=26, signal_period=9).warmup_period == 26 * 4 + 9
+
+    def test_stateless_exit_strategies_need_no_warmup(self) -> None:
+        # StopLoss / ProfitTaking / TrailingStop / DCA inherit the default 0.
+        assert StopLoss().warmup_period == 0
+        assert ProfitTaking().warmup_period == 0
+        assert TrailingStop().warmup_period == 0
+        assert DollarCostAveraging().warmup_period == 0
+
+    def test_gap_down_recovery_needs_three_bars(self) -> None:
+        assert GapDownRecovery().warmup_period == 3

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -3,6 +3,7 @@
 import numpy as np
 
 from midas.models import StrategyTier
+from midas.strategies.base import MIN_WARMUP_CALENDAR_DAYS, warmup_bars_to_calendar_days
 from midas.strategies.bollinger_band import BollingerBand
 from midas.strategies.dca import DollarCostAveraging
 from midas.strategies.gap_down_recovery import GapDownRecovery
@@ -339,3 +340,27 @@ class TestWarmupPeriod:
 
     def test_gap_down_recovery_needs_three_bars(self) -> None:
         assert GapDownRecovery().warmup_period == 3
+
+
+class TestWarmupBarsToCalendarDays:
+    """``warmup_bars_to_calendar_days`` floors at ``MIN_WARMUP_CALENDAR_DAYS``.
+
+    Live mode derives its history-fetch window from this helper. If a
+    mechanical-only setup (StopLoss/TrailingStop/DCA) returned 0, the
+    live engine would request a single-day price history and frequently
+    receive nothing on weekends/holidays. The floor prevents that.
+    """
+
+    def test_zero_bars_floors_to_minimum(self) -> None:
+        assert warmup_bars_to_calendar_days(0) == MIN_WARMUP_CALENDAR_DAYS
+
+    def test_negative_bars_floors_to_minimum(self) -> None:
+        assert warmup_bars_to_calendar_days(-5) == MIN_WARMUP_CALENDAR_DAYS
+
+    def test_small_warmup_floors_to_minimum(self) -> None:
+        # 3 bars * 1.5 + 10 = 14, still below the 30-day floor.
+        assert warmup_bars_to_calendar_days(3) == MIN_WARMUP_CALENDAR_DAYS
+
+    def test_large_warmup_scales_above_floor(self) -> None:
+        # 100 bars * 1.5 + 10 = 160, well above the floor.
+        assert warmup_bars_to_calendar_days(100) == 160


### PR DESCRIPTION
## Summary

- Each strategy declares a `warmup_period`; backtest/optimize/live prefetch a lookback buffer sized to the max so signals are valid from bar one instead of spending the first N simulation days in cold start.
- Recursive indicators (RSI, MACD) apply a TA-Lib-style 4× unstable-period multiplier so the EMA converges before strategies score against it.
- Walk-forward optimizer prefetches a single buffer sized for the upper bound of its parameter search space; live mode derives its history window the same way instead of hardcoding 120 days.

## Details

**`Strategy.warmup_period`** — new property on the base class (default 0), overridden per strategy: rolling-window strategies return `window`, `MovingAverageCrossover` returns `long_window`, RSI×2 return `window * RECURSIVE_WARMUP_MULTIPLIER`, `MACDCrossover` returns `slow_period * multiplier + signal_period`, `GapDownRecovery` returns 3, stateless exit strategies (`StopLoss`, `ProfitTaking`, `TrailingStop`) and `DollarCostAveraging` inherit the default 0.

**Backtest** — `_build_ticker_index` now preserves up to `warmup_bars` of pre-start history in each ticker's array. The simulation loop still iterates `trading_days` in `[start, end]`, but the per-day pointer advance walks through warmup dates on day one so `precompute_signals` and `allocate()` see the full prefix. A per-ticker warning is logged when available history is shorter than requested warmup.

**CLI** — `_fetch_prices` shifts the yfinance start date backward by `warmup_bars_to_calendar_days(max_warmup)` (1.5× trading→calendar ratio + 10-day slack, 30-day floor). Backtest command now builds allocator/mechanical strategies before fetching so it can size the buffer.

**Optimizer** — new `max_warmup_for_search()` helper instantiates each optimizable strategy with every integer param pinned to its search-range upper bound (snapped the same way `_suggest_params` snaps) and returns the worst-case warmup. Both `optimize` and `walk_forward_optimize` use this buffer for their single shared prefetch.

**Live** — `LiveEngine.__init__` derives `history_days` from `max_warmup * 1.5 + slack` instead of hardcoding 120. Explicit override still honored for tests.

Closes #24.

## Test plan

- [x] `tests/test_strategies.py::TestWarmupPeriod` — 6 tests covering all three categories (rolling window, recursive, stateless).
- [x] `tests/test_backtest.py::test_backtest_consumes_warmup_prefix` — synthetic 60-bar series with 20-bar prefix; MeanReversion(window=20) fires inside the sim window (impossible without warmup prefix being consumed).
- [x] `tests/test_backtest.py::test_backtest_logs_insufficient_warmup` — ticker with less history than requested warmup logs a per-ticker warning.
- [x] Full suite: 150 passed.
- [x] `ruff check` clean, `mypy` clean.
- [ ] Manual: re-run a representative backtest and confirm "Rebalancer"-attributed warmup trades drop out of the trade log for long-window strategies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)