### PR TITLE
Replace sigmoid+normalize allocator with softmax construct-to-budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Midas
 
-Target-weight allocation engine for your portfolio. Define your holdings and pick a set of strategies to fit your thesis -- Midas scores every position using technical indicators, blends those scores into target portfolio weights via a sigmoid transformation, and generates the trades needed to rebalance.
+Target-weight allocation engine for your portfolio. Define your holdings and pick a set of strategies to fit your thesis -- Midas scores every position using technical indicators, blends those scores into target portfolio weights via a softmax construct-to-budget allocator, and generates the trades needed to rebalance.
 
 - **Optimize** strategy parameters with Bayesian search and walk-forward validation
 - **Backtest** against years of historical data with train/test splits
@@ -53,7 +53,7 @@ cash_infusion:
 ### Strategies
 
 ```yaml
-sigmoid_steepness: 2.0
+softmax_temperature: 0.5
 rebalance_threshold: 0.02
 min_cash_pct: 0.05
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,11 @@ The allocator takes conviction scores and produces target portfolio weights. It 
 
 For each ticker, the allocator collects scores from all CONVICTION strategies and computes a weighted average. Each strategy has a configurable weight (default 1.0) that controls its influence. A strategy returning None is excluded entirely -- it doesn't pull the average toward zero, it simply doesn't participate.
 
-#### Phase 2: Softmax Budget Allocation
+#### Phase 2: Protective Vetoes
+
+Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below its veto threshold, the ticker is removed from further allocation and its target weight is forced to zero. This is a hard override -- no amount of bullish conviction can prevent a protective liquidation. This is how stop-losses and trailing stops work: they don't reduce the position, they eliminate it.
+
+#### Phase 3: Softmax Budget Allocation
 
 The blended scores need to become target portfolio weights that sum to the investable budget (1 minus the minimum cash reserve). The allocator uses softmax — the same construct-to-budget operator used by QuantConnect LEAN's `InsightWeightingPortfolioConstructionModel`, mean-variance optimizers, risk-parity libraries, and every production portfolio construction system in the literature.
 
@@ -59,10 +63,6 @@ By construction, `sum(targets) == investable_budget` exactly, always. There is n
 Compared to the older "score → sigmoid → multiply by base_weight → clip → normalize" pattern, softmax eliminates a class of phantom rebalance trades that arose whenever the sum of per-ticker targets drifted past the budget and had to be scaled back proportionally. Under softmax, relative weight shifts cleanly reflect relative conviction shifts — the allocator reallocates between tickers rather than "normalizing" them.
 
 **Neutral = hold.** When no conviction strategy produces a score for a ticker (all abstain — e.g. during warmup), the allocator holds that ticker's current weight (Option A) and excludes it from the softmax. The remaining budget `investable - sum(held)` is distributed via softmax across tickers that actually scored. This avoids churn from drift-correction trades on days when no signal is firing on a held position. On the very first allocation, with no current weights known, the allocator falls back to equal-weight as the hold target.
-
-#### Phase 3: Protective Vetoes
-
-Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below its veto threshold, the target weight is forced to zero. This is a hard override -- no amount of bullish conviction can prevent a protective liquidation. This is how stop-losses and trailing stops work: they don't reduce the position, they eliminate it.
 
 #### Phase 4: Position Cap
 
@@ -115,7 +115,7 @@ The optimizer uses Bayesian optimization (Optuna's TPE sampler) to search over a
 | Strategy parameters | When a strategy fires and how strong | `window`, `threshold`, `loss_threshold`, etc. |
 | Strategy weights | How much influence each conviction strategy has in the blend | 0.5 to 3.0 |
 | Veto thresholds | When a protective strategy overrides the blend | -0.8 to -0.2 |
-| Sigmoid steepness | How aggressively the allocator responds to conviction | 1.0 to 5.0 |
+| Softmax temperature | How aggressively the allocator concentrates budget on top conviction | 0.2 to 1.0 |
 | Rebalance threshold | Minimum weight diff to trigger a trade | 0.01 to 0.05 |
 | Max position % | Maximum weight for any single position | 0.15 to 0.50 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,23 +46,31 @@ The allocator takes conviction scores and produces target portfolio weights. It 
 
 For each ticker, the allocator collects scores from all CONVICTION strategies and computes a weighted average. Each strategy has a configurable weight (default 1.0) that controls its influence. A strategy returning None is excluded entirely -- it doesn't pull the average toward zero, it simply doesn't participate.
 
-#### Phase 2: Sigmoid Transform
+#### Phase 2: Softmax Budget Allocation
 
-The blended score (a number between -1 and +1) needs to become a target portfolio weight. A raw linear mapping would work but produces extreme allocations -- a blended score of +1 would mean "put everything in this ticker." Instead, the allocator uses a sigmoid function to smoothly map scores to weights.
+The blended scores need to become target portfolio weights that sum to the investable budget (1 minus the minimum cash reserve). The allocator uses softmax — the same construct-to-budget operator used by QuantConnect LEAN's `InsightWeightingPortfolioConstructionModel`, mean-variance optimizers, risk-parity libraries, and every production portfolio construction system in the literature.
 
-The sigmoid is centered so that a blended score of 0 produces the equal-weight baseline (total investable weight divided evenly across tickers). Positive scores push above the baseline (overweight), negative scores push below (underweight). The `sigmoid_steepness` parameter controls how aggressively the curve responds -- higher values mean small conviction differences produce larger weight swings.
+```
+target_i = investable_budget * exp(k * blended_i) / sum_j(exp(k * blended_j))
+```
 
-**Neutral = hold.** When no conviction strategy produces a score for a ticker (all abstain — e.g. during warmup or when indicators don't apply), the allocator holds the current weight instead of reverting to the equal-weight baseline. This avoids churn from drift-correction trades on days when no signal is actually firing. The allocator only falls back to equal-weight when it has no knowledge of the current portfolio (the very first allocation).
+By construction, `sum(targets) == investable_budget` exactly, always. There is no separate normalize step because oversubscription is mathematically impossible. The `sigmoid_steepness` parameter `k` acts as the softmax temperature: `k = 0` produces equal weights, large `k` concentrates on the highest-conviction ticker (winner-take-most).
+
+Compared to the older "score → sigmoid → multiply by base_weight → clip → normalize" pattern, softmax eliminates a class of phantom rebalance trades that arose whenever the sum of per-ticker targets drifted past the budget and had to be scaled back proportionally. Under softmax, relative weight shifts cleanly reflect relative conviction shifts — the allocator reallocates between tickers rather than "normalizing" them.
+
+**Neutral = hold.** When no conviction strategy produces a score for a ticker (all abstain — e.g. during warmup), the allocator holds that ticker's current weight (Option A) and excludes it from the softmax. The remaining budget `investable - sum(held)` is distributed via softmax across tickers that actually scored. This avoids churn from drift-correction trades on days when no signal is firing on a held position. On the very first allocation, with no current weights known, the allocator falls back to equal-weight as the hold target.
 
 #### Phase 3: Protective Vetoes
 
 Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below its veto threshold, the target weight is forced to zero. This is a hard override -- no amount of bullish conviction can prevent a protective liquidation. This is how stop-losses and trailing stops work: they don't reduce the position, they eliminate it.
 
-#### Phase 4: Constraints
+#### Phase 4: Position Cap
 
-Finally, the allocator enforces portfolio-level constraints. Each ticker's weight is capped at `max_position_pct` to prevent excessive concentration. If `max_position_pct` is not configured, it's auto-computed as 2.5x the equal-weight baseline (capped at 25%), which allows meaningful overweighting without extreme concentration. Then all weights are normalized so their sum doesn't exceed the investable portion of the portfolio (1 minus the minimum cash reserve).
+Softmax already enforces the budget constraint, so the only per-ticker limit the allocator enforces here is `max_position_pct`. Any ticker whose softmax target exceeds the cap is pinned at the cap, and the freed budget is redistributed to the uncapped survivors by re-running softmax over them with the reduced budget. This is mathematically equivalent to solving a quadratic program with `sum(w) = investable` as an equality constraint and `w_i <= cap` as inequality constraints — the standard approach in Markowitz-style optimizers.
 
-When either constraint trims a target, the allocator records the reason (`cap` or `normalize`) on the result. The rebalancer uses this to label trades that weren't driven by any specific strategy: a buy/sell with no aligned conviction contributor is sourced to `Rebalancer (cap)` or `Rebalancer (normalize)` instead of the bare `Rebalancer` fallback, so attribution reports can distinguish structural rebalances from unexplained drift.
+If `max_position_pct` is not configured, it's auto-computed as 2.5x the equal-weight baseline (capped at 25%), which allows meaningful overweighting without extreme concentration.
+
+When the cap trims a target, the allocator records `cap` in the trim reasons. The rebalancer uses this to label trades that have no directionally-aligned conviction contributor: a buy/sell whose only justification is the cap-redistribution (rare) is sourced to `Rebalancer (cap)` instead of to a specific strategy. Normal reallocation trades — where one ticker's target shrinks because another's grew — attribute cleanly to the strategy that pushed the winning ticker up, because softmax produces directionally-aligned contributors on every trade.
 
 ### Rebalancer
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,8 @@ The rebalancer compares target weights from the allocator against the portfolio'
 
 The rebalancer computes the current weight of each ticker (its market value as a fraction of total portfolio value) and diffs it against the target weight. If the difference is smaller than the `rebalance_threshold` (default 2%), it's ignored -- this prevents excessive trading on tiny weight fluctuations.
 
+**Justification check.** Before emitting an order, the rebalancer verifies the trade is either (a) driven by a conviction strategy directionally aligned with the trade direction, or (b) forced by a Phase 4 cap trim. Trades that fail both checks are pure drift-to-base artifacts — they serve no purpose and are suppressed entirely. With the softmax allocator in place this check rarely fires, since softmax + Option A together eliminate most unjustified targets at the source, but it acts as a belt-and-braces guard.
+
 Sells are processed before buys. This is intentional: sell proceeds become available cash for subsequent buy orders. Each sell is capped at the actual shares held, and each buy is constrained by available cash.
 
 #### Slippage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,8 @@ The blended score (a number between -1 and +1) needs to become a target portfoli
 
 The sigmoid is centered so that a blended score of 0 produces the equal-weight baseline (total investable weight divided evenly across tickers). Positive scores push above the baseline (overweight), negative scores push below (underweight). The `sigmoid_steepness` parameter controls how aggressively the curve responds -- higher values mean small conviction differences produce larger weight swings.
 
+**Neutral = hold.** When no conviction strategy produces a score for a ticker (all abstain — e.g. during warmup or when indicators don't apply), the allocator holds the current weight instead of reverting to the equal-weight baseline. This avoids churn from drift-correction trades on days when no signal is actually firing. The allocator only falls back to equal-weight when it has no knowledge of the current portfolio (the very first allocation).
+
 #### Phase 3: Protective Vetoes
 
 Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below its veto threshold, the target weight is forced to zero. This is a hard override -- no amount of bullish conviction can prevent a protective liquidation. This is how stop-losses and trailing stops work: they don't reduce the position, they eliminate it.
@@ -59,6 +61,8 @@ Each PROTECTIVE strategy is evaluated per ticker. If its score falls at or below
 #### Phase 4: Constraints
 
 Finally, the allocator enforces portfolio-level constraints. Each ticker's weight is capped at `max_position_pct` to prevent excessive concentration. If `max_position_pct` is not configured, it's auto-computed as 2.5x the equal-weight baseline (capped at 25%), which allows meaningful overweighting without extreme concentration. Then all weights are normalized so their sum doesn't exceed the investable portion of the portfolio (1 minus the minimum cash reserve).
+
+When either constraint trims a target, the allocator records the reason (`cap` or `normalize`) on the result. The rebalancer uses this to label trades that weren't driven by any specific strategy: a buy/sell with no aligned conviction contributor is sourced to `Rebalancer (cap)` or `Rebalancer (normalize)` instead of the bare `Rebalancer` fallback, so attribution reports can distinguish structural rebalances from unexplained drift.
 
 ### Rebalancer
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,10 +51,10 @@ For each ticker, the allocator collects scores from all CONVICTION strategies an
 The blended scores need to become target portfolio weights that sum to the investable budget (1 minus the minimum cash reserve). The allocator uses softmax — the same construct-to-budget operator used by QuantConnect LEAN's `InsightWeightingPortfolioConstructionModel`, mean-variance optimizers, risk-parity libraries, and every production portfolio construction system in the literature.
 
 ```
-target_i = investable_budget * exp(k * blended_i) / sum_j(exp(k * blended_j))
+target_i = investable_budget * exp(blended_i / T) / sum_j(exp(blended_j / T))
 ```
 
-By construction, `sum(targets) == investable_budget` exactly, always. There is no separate normalize step because oversubscription is mathematically impossible. The `sigmoid_steepness` parameter `k` acts as the softmax temperature: `k = 0` produces equal weights, large `k` concentrates on the highest-conviction ticker (winner-take-most).
+By construction, `sum(targets) == investable_budget` exactly, always. There is no separate normalize step because oversubscription is mathematically impossible. The `softmax_temperature` parameter `T` follows the standard ML softmax convention: low `T` concentrates budget on the highest-conviction ticker (winner-take-most, `T → 0` is argmax), `T = 1` is the unscaled softmax over raw scores, and high `T` approaches a uniform split regardless of conviction. Midas defaults to `T = 0.5`, a mild concentration bias.
 
 Compared to the older "score → sigmoid → multiply by base_weight → clip → normalize" pattern, softmax eliminates a class of phantom rebalance trades that arose whenever the sum of per-ticker targets drifted past the budget and had to be scaled back proportionally. Under softmax, relative weight shifts cleanly reflect relative conviction shifts — the allocator reallocates between tickers rather than "normalizing" them.
 

--- a/example-strategies/balanced-growth.yaml
+++ b/example-strategies/balanced-growth.yaml
@@ -1,4 +1,4 @@
-sigmoid_steepness: 2.0
+softmax_temperature: 0.5
 rebalance_threshold: 0.02
 min_cash_pct: 0.05
 

--- a/example-strategies/dip-buying.yaml
+++ b/example-strategies/dip-buying.yaml
@@ -1,4 +1,4 @@
-sigmoid_steepness: 2.0
+softmax_temperature: 0.5
 rebalance_threshold: 0.02
 min_cash_pct: 0.05
 

--- a/example-strategies/trend-following.yaml
+++ b/example-strategies/trend-following.yaml
@@ -1,4 +1,4 @@
-sigmoid_steepness: 2.0
+softmax_temperature: 0.5
 rebalance_threshold: 0.02
 min_cash_pct: 0.05
 

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -40,9 +40,9 @@ class AllocationResult:
     targets: dict[str, float]
     contributions: dict[str, dict[str, float]]  # ticker -> {strategy_name: score}
     blended_scores: dict[str, float]  # ticker -> blended score
-    # ticker -> "cap" | "normalize" when Phase 4 constraints trimmed the target.
-    # Used by the Rebalancer to label fallback attribution when no conviction
-    # strategy drove the trade.
+    # ticker -> "cap" when Phase 4 constraints trimmed the target. Used by the
+    # Rebalancer to label fallback attribution when no conviction strategy drove
+    # the trade.
     trim_reasons: dict[str, str]
 
 

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -148,7 +148,7 @@ class Allocator:
 
         investable = 1.0 - self._constraints.min_cash_pct
         base_weight = investable / n  # fallback when current_weights unknown
-        k = self._constraints.sigmoid_steepness  # softmax temperature
+        temperature = self._constraints.softmax_temperature
 
         contributions: dict[str, dict[str, float]] = {}
         blended_scores: dict[str, float] = {}
@@ -194,6 +194,17 @@ class Allocator:
 
         # Phase 2: Protective vetoes. A vetoed ticker is removed from `active`
         # (its softmax slot vanishes and its share of budget flows to peers).
+        #
+        # KNOWN LIMITATION: the vetoed score is stored in ``contributions`` and
+        # the Rebalancer's justification/attribution picker filters by sign
+        # (``v < 0`` for SELL). A protective strategy that vetoes with a score
+        # >= 0 would therefore have its forced-exit SELL either suppressed by
+        # the justification check or mislabeled as ``Rebalancer (unknown)``.
+        # All currently shipped protective strategies (StopLoss, TrailingStop)
+        # return strictly negative scores when they veto, so this is not
+        # exploitable today. The whole protective tier is slated for removal
+        # in favor of direct EXIT_RULE order intents — see #26 — at which
+        # point this pathway (and the limitation) disappears entirely.
         vetoed: set[str] = set()
         for entry in self._protective:
             for ticker in tickers:
@@ -230,32 +241,46 @@ class Allocator:
         # Phase 3: Softmax construct-to-budget over active tickers. Sum of
         # softmax weights is exactly budget_for_active by construction, so
         # there is no normalize step.
-        self._softmax_allocate(active, blended_scores, budget_for_active, k, targets)
+        self._softmax_allocate(active, blended_scores, budget_for_active, temperature, targets)
 
         # Phase 4: Position cap with redistribution (Option X). Iteratively
         # clamp any ticker exceeding max_position_pct and re-softmax the
         # survivors over the reduced remaining budget. Usually converges in
         # one pass; bounded by len(active) for safety.
-        self._apply_cap_with_redistribution(active, blended_scores, budget_for_active, k, targets, trim_reasons)
+        self._apply_cap_with_redistribution(
+            active, blended_scores, budget_for_active, temperature, targets, trim_reasons
+        )
 
         return AllocationResult(targets, contributions, blended_scores, trim_reasons)
+
+    # Temperature floor prevents division-by-zero and bounds exp() growth in the
+    # winner-take-all limit. Combined with max-subtraction below, the softmax
+    # collapses cleanly to argmax as temperature → 0.
+    _MIN_TEMPERATURE = 1e-6
 
     def _softmax_allocate(
         self,
         tickers: list[str],
         blended_scores: dict[str, float],
         budget: float,
-        k: float,
+        temperature: float,
         targets: dict[str, float],
     ) -> None:
-        """Distribute `budget` across `tickers` via softmax(k * blended_scores)."""
+        """Distribute `budget` across `tickers` via softmax(blended_scores / T).
+
+        Temperature semantics:
+            T → 0   winner-take-all (budget to the argmax ticker)
+            T = 1   standard softmax over raw scores
+            T → ∞   uniform split regardless of conviction
+        """
         if not tickers or budget <= 0:
             for t in tickers:
                 targets[t] = 0.0
             return
+        t_safe = max(temperature, self._MIN_TEMPERATURE)
         # Subtract max for numerical stability — softmax is translation-invariant.
         max_score = max(blended_scores[t] for t in tickers)
-        exps = {t: math.exp(k * (blended_scores[t] - max_score)) for t in tickers}
+        exps = {t: math.exp((blended_scores[t] - max_score) / t_safe) for t in tickers}
         z = sum(exps.values())
         if z <= 0:
             # Degenerate (shouldn't happen after max-subtraction, but be safe).
@@ -271,7 +296,7 @@ class Allocator:
         active: list[str],
         blended_scores: dict[str, float],
         initial_budget: float,
-        k: float,
+        temperature: float,
         targets: dict[str, float],
         trim_reasons: dict[str, str],
     ) -> None:
@@ -298,4 +323,4 @@ class Allocator:
                 for t in survivors:
                     targets[t] = 0.0
                 return
-            self._softmax_allocate(survivors, blended_scores, budget, k, targets)
+            self._softmax_allocate(survivors, blended_scores, budget, temperature, targets)

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -146,28 +146,27 @@ class Allocator:
         if n == 0:
             return AllocationResult({}, {}, {}, {})
 
-        base_weight = (1.0 - self._constraints.min_cash_pct) / n
-        k = self._constraints.sigmoid_steepness
+        investable = 1.0 - self._constraints.min_cash_pct
+        base_weight = investable / n  # fallback when current_weights unknown
+        k = self._constraints.sigmoid_steepness  # softmax temperature
 
-        # Phase 1+2: Score conviction strategies and blend
         contributions: dict[str, dict[str, float]] = {}
         blended_scores: dict[str, float] = {}
-        targets: dict[str, float] = {}
+        targets: dict[str, float] = dict.fromkeys(tickers, 0.0)
         trim_reasons: dict[str, str] = {}
 
-        def _neutral_target(ticker: str) -> float:
-            # Neutral = hold (Option A). Falls back to base_weight only when
-            # no current weight is known (e.g. first-ever allocation).
-            if current_weights is None:
-                return base_weight
-            return cur_w.get(ticker, 0.0)
+        # Phase 1: Score conviction strategies and compute blended scores.
+        # Partition tickers into `active` (at least one strategy scored) and
+        # `held` (all strategies abstained — Option A: hold current weight).
+        active: list[str] = []
+        held: list[str] = []
 
         for ticker in tickers:
             prices = price_data.get(ticker)
             if prices is None or len(prices) == 0:
-                targets[ticker] = _neutral_target(ticker)
                 contributions[ticker] = {}
                 blended_scores[ticker] = 0.0
+                held.append(ticker)
                 continue
 
             ticker_ctx = ctx.get(ticker, {})
@@ -187,19 +186,15 @@ class Allocator:
             contributions[ticker] = ticker_contributions
 
             if weight_total > 0:
-                blended = weighted_sum / weight_total
-                blended_scores[ticker] = blended
-                # Symmetric sigmoid transform
-                sigmoid_val = 1.0 / (1.0 + math.exp(-k * blended))
-                targets[ticker] = base_weight * 2.0 * sigmoid_val
+                blended_scores[ticker] = weighted_sum / weight_total
+                active.append(ticker)
             else:
-                # No conviction strategy scored — hold current weight rather
-                # than drifting to base_weight and forcing drift-correction
-                # trades on every rebalance.
                 blended_scores[ticker] = 0.0
-                targets[ticker] = _neutral_target(ticker)
+                held.append(ticker)
 
-        # Phase 3: PROTECTIVE vetoes
+        # Phase 2: Protective vetoes. A vetoed ticker is removed from `active`
+        # (its softmax slot vanishes and its share of budget flows to peers).
+        vetoed: set[str] = set()
         for entry in self._protective:
             for ticker in tickers:
                 prices = price_data.get(ticker)
@@ -210,26 +205,97 @@ class Allocator:
                     ticker_ctx = ctx.get(ticker, {})
                     s = entry.strategy.score(prices, **ticker_ctx)
                 if s is not None and s <= entry.veto_threshold:
-                    targets[ticker] = 0.0
-                    # Record protective strategy in contributions
+                    vetoed.add(ticker)
                     contributions.setdefault(ticker, {})[entry.strategy.name] = s
+        active = [t for t in active if t not in vetoed]
+        held = [t for t in held if t not in vetoed]
+        for t in vetoed:
+            targets[t] = 0.0
 
-        # Phase 4: Apply constraints
-        for ticker in tickers:
-            pre = targets[ticker]
-            clamped = max(0.0, min(pre, self._max_position_pct))
-            if clamped < pre:
-                trim_reasons[ticker] = "cap"
-            targets[ticker] = clamped
+        # Held tickers (Option A) consume their current weight from the
+        # investable budget. Remaining budget goes to the active softmax.
+        def _held_target(ticker: str) -> float:
+            if current_weights is None:
+                return base_weight
+            return cur_w.get(ticker, 0.0)
 
-        # Normalize so sum <= 1 - min_cash_pct
-        total = sum(targets.values())
-        max_total = 1.0 - self._constraints.min_cash_pct
-        if total > max_total and total > 0:
-            scale = max_total / total
-            for ticker in targets:
-                targets[ticker] *= scale
-                # "cap" takes precedence — it's more specific than normalize.
-                trim_reasons.setdefault(ticker, "normalize")
+        held_total = 0.0
+        for t in held:
+            w = _held_target(t)
+            targets[t] = w
+            held_total += w
+
+        budget_for_active = max(investable - held_total, 0.0)
+
+        # Phase 3: Softmax construct-to-budget over active tickers. Sum of
+        # softmax weights is exactly budget_for_active by construction, so
+        # there is no normalize step.
+        self._softmax_allocate(active, blended_scores, budget_for_active, k, targets)
+
+        # Phase 4: Position cap with redistribution (Option X). Iteratively
+        # clamp any ticker exceeding max_position_pct and re-softmax the
+        # survivors over the reduced remaining budget. Usually converges in
+        # one pass; bounded by len(active) for safety.
+        self._apply_cap_with_redistribution(active, blended_scores, budget_for_active, k, targets, trim_reasons)
 
         return AllocationResult(targets, contributions, blended_scores, trim_reasons)
+
+    def _softmax_allocate(
+        self,
+        tickers: list[str],
+        blended_scores: dict[str, float],
+        budget: float,
+        k: float,
+        targets: dict[str, float],
+    ) -> None:
+        """Distribute `budget` across `tickers` via softmax(k * blended_scores)."""
+        if not tickers or budget <= 0:
+            for t in tickers:
+                targets[t] = 0.0
+            return
+        # Subtract max for numerical stability — softmax is translation-invariant.
+        max_score = max(blended_scores[t] for t in tickers)
+        exps = {t: math.exp(k * (blended_scores[t] - max_score)) for t in tickers}
+        z = sum(exps.values())
+        if z <= 0:
+            # Degenerate (shouldn't happen after max-subtraction, but be safe).
+            equal = budget / len(tickers)
+            for t in tickers:
+                targets[t] = equal
+            return
+        for t in tickers:
+            targets[t] = budget * exps[t] / z
+
+    def _apply_cap_with_redistribution(
+        self,
+        active: list[str],
+        blended_scores: dict[str, float],
+        initial_budget: float,
+        k: float,
+        targets: dict[str, float],
+        trim_reasons: dict[str, str],
+    ) -> None:
+        """Clamp targets exceeding max_position_pct; re-softmax the survivors.
+
+        Option X: when a cap trims a ticker, the freed budget is redistributed
+        to uncapped tickers in proportion to their softmax weight (achieved by
+        re-running softmax over the survivors with the reduced budget).
+        """
+        cap = self._max_position_pct
+        survivors = list(active)
+        budget = initial_budget
+        # At most one iteration per ticker (each pass pins at least one).
+        for _ in range(len(active) + 1):
+            over = [t for t in survivors if targets[t] > cap + 1e-12]
+            if not over:
+                return
+            for t in over:
+                targets[t] = cap
+                trim_reasons[t] = "cap"
+                budget -= cap
+                survivors.remove(t)
+            if not survivors or budget <= 0:
+                for t in survivors:
+                    targets[t] = 0.0
+                return
+            self._softmax_allocate(survivors, blended_scores, budget, k, targets)

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -279,15 +279,10 @@ class Allocator:
             return
         t_safe = max(temperature, self._MIN_TEMPERATURE)
         # Subtract max for numerical stability — softmax is translation-invariant.
+        # The max-subtracted ticker contributes exp(0) = 1, so z >= 1 always.
         max_score = max(blended_scores[t] for t in tickers)
         exps = {t: math.exp((blended_scores[t] - max_score) / t_safe) for t in tickers}
         z = sum(exps.values())
-        if z <= 0:
-            # Degenerate (shouldn't happen after max-subtraction, but be safe).
-            equal = budget / len(tickers)
-            for t in tickers:
-                targets[t] = equal
-            return
         for t in tickers:
             targets[t] = budget * exps[t] / z
 
@@ -320,7 +315,13 @@ class Allocator:
                 budget -= cap
                 survivors.remove(t)
             if not survivors or budget <= 0:
+                # Caps consumed the entire investable budget. Survivors had
+                # positive contribs (they were in `active`) so the rebalancer's
+                # justification check would suppress their SELL on a bare zero
+                # target. Tag them with "cap" so the SELL fires as
+                # `Rebalancer (cap)` and the portfolio stays consistent.
                 for t in survivors:
                     targets[t] = 0.0
+                    trim_reasons[t] = "cap"
                 return
             self._softmax_allocate(survivors, blended_scores, budget, temperature, targets)

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -22,6 +22,11 @@ MAX_POSITION_MULTIPLIER = 2.5
 LOW_POSITION_MULTIPLIER = 1.5
 HIGH_POSITION_MULTIPLIER = 5.0
 
+# Temperature floor prevents division-by-zero and bounds exp() growth in the
+# winner-take-all limit. Combined with max-subtraction in _softmax_allocate,
+# the softmax collapses cleanly to argmax as temperature → 0.
+MIN_TEMPERATURE = 1e-6
+
 
 @dataclass
 class _ScoredStrategy:
@@ -253,11 +258,6 @@ class Allocator:
 
         return AllocationResult(targets, contributions, blended_scores, trim_reasons)
 
-    # Temperature floor prevents division-by-zero and bounds exp() growth in the
-    # winner-take-all limit. Combined with max-subtraction below, the softmax
-    # collapses cleanly to argmax as temperature → 0.
-    _MIN_TEMPERATURE = 1e-6
-
     def _softmax_allocate(
         self,
         tickers: list[str],
@@ -277,7 +277,7 @@ class Allocator:
             for t in tickers:
                 targets[t] = 0.0
             return
-        t_safe = max(temperature, self._MIN_TEMPERATURE)
+        t_safe = max(temperature, MIN_TEMPERATURE)
         # Subtract max for numerical stability — softmax is translation-invariant.
         # The max-subtracted ticker contributes exp(0) = 1, so z >= 1 always.
         max_score = max(blended_scores[t] for t in tickers)

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -40,6 +40,10 @@ class AllocationResult:
     targets: dict[str, float]
     contributions: dict[str, dict[str, float]]  # ticker -> {strategy_name: score}
     blended_scores: dict[str, float]  # ticker -> blended score
+    # ticker -> "cap" | "normalize" when Phase 4 constraints trimmed the target.
+    # Used by the Rebalancer to label fallback attribution when no conviction
+    # strategy drove the trade.
+    trim_reasons: dict[str, str]
 
 
 class Allocator:
@@ -119,6 +123,7 @@ class Allocator:
         tickers: list[str],
         price_data: dict[str, np.ndarray],
         context: dict[str, dict[str, Any]] | None = None,
+        current_weights: dict[str, float] | None = None,
     ) -> AllocationResult:
         """Compute target weights for all tickers.
 
@@ -126,15 +131,20 @@ class Allocator:
             tickers: Active tickers in the portfolio.
             price_data: Ticker -> price series mapping.
             context: Per-ticker context dict (e.g. {"AAPL": {"cost_basis": 150.0}}).
+            current_weights: Ticker -> current portfolio weight. When no
+                conviction strategy scores a ticker, the allocator holds the
+                current weight instead of reverting to equal-weight (Option A:
+                neutral = hold). If omitted, falls back to equal-weight base.
 
         Returns:
             AllocationResult with target weights, per-ticker contributions,
-            and blended scores.
+            blended scores, and trim reasons.
         """
         ctx = context or {}
+        cur_w = current_weights or {}
         n = len(tickers)
         if n == 0:
-            return AllocationResult({}, {}, {})
+            return AllocationResult({}, {}, {}, {})
 
         base_weight = (1.0 - self._constraints.min_cash_pct) / n
         k = self._constraints.sigmoid_steepness
@@ -143,11 +153,19 @@ class Allocator:
         contributions: dict[str, dict[str, float]] = {}
         blended_scores: dict[str, float] = {}
         targets: dict[str, float] = {}
+        trim_reasons: dict[str, str] = {}
+
+        def _neutral_target(ticker: str) -> float:
+            # Neutral = hold (Option A). Falls back to base_weight only when
+            # no current weight is known (e.g. first-ever allocation).
+            if current_weights is None:
+                return base_weight
+            return cur_w.get(ticker, 0.0)
 
         for ticker in tickers:
             prices = price_data.get(ticker)
             if prices is None or len(prices) == 0:
-                targets[ticker] = base_weight
+                targets[ticker] = _neutral_target(ticker)
                 contributions[ticker] = {}
                 blended_scores[ticker] = 0.0
                 continue
@@ -168,13 +186,18 @@ class Allocator:
 
             contributions[ticker] = ticker_contributions
 
-            blended = weighted_sum / weight_total if weight_total > 0 else 0.0
-
-            blended_scores[ticker] = blended
-
-            # Symmetric sigmoid transform
-            sigmoid_val = 1.0 / (1.0 + math.exp(-k * blended))
-            targets[ticker] = base_weight * 2.0 * sigmoid_val
+            if weight_total > 0:
+                blended = weighted_sum / weight_total
+                blended_scores[ticker] = blended
+                # Symmetric sigmoid transform
+                sigmoid_val = 1.0 / (1.0 + math.exp(-k * blended))
+                targets[ticker] = base_weight * 2.0 * sigmoid_val
+            else:
+                # No conviction strategy scored — hold current weight rather
+                # than drifting to base_weight and forcing drift-correction
+                # trades on every rebalance.
+                blended_scores[ticker] = 0.0
+                targets[ticker] = _neutral_target(ticker)
 
         # Phase 3: PROTECTIVE vetoes
         for entry in self._protective:
@@ -193,7 +216,11 @@ class Allocator:
 
         # Phase 4: Apply constraints
         for ticker in tickers:
-            targets[ticker] = max(0.0, min(targets[ticker], self._max_position_pct))
+            pre = targets[ticker]
+            clamped = max(0.0, min(pre, self._max_position_pct))
+            if clamped < pre:
+                trim_reasons[ticker] = "cap"
+            targets[ticker] = clamped
 
         # Normalize so sum <= 1 - min_cash_pct
         total = sum(targets.values())
@@ -202,5 +229,7 @@ class Allocator:
             scale = max_total / total
             for ticker in targets:
                 targets[ticker] *= scale
+                # "cap" takes precedence — it's more specific than normalize.
+                trim_reasons.setdefault(ticker, "normalize")
 
-        return AllocationResult(targets, contributions, blended_scores)
+        return AllocationResult(targets, contributions, blended_scores, trim_reasons)

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -602,11 +602,20 @@ class BacktestEngine:
                 ctx["cost_basis"] = state.cost_basis[ticker]
             context[ticker] = ctx
 
+        # Compute current portfolio weights so the allocator can hold
+        # (not drift-correct) tickers whose strategies don't score today.
+        total_value = state.cash + sum(state.positions.get(t, 0.0) * current_prices[t] for t in active_tickers)
+        current_weights: dict[str, float] = {}
+        if total_value > 0:
+            for t in active_tickers:
+                current_weights[t] = (state.positions.get(t, 0.0) * current_prices[t]) / total_value
+
         # Phase 1-3: Allocator scores, blends, and applies vetoes
         allocation = self._allocator.allocate(
             active_tickers,
             current_data,
             context,
+            current_weights=current_weights,
         )
 
         # Phase 4: Rebalancer diffs target vs current, generates orders

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -604,11 +604,15 @@ class BacktestEngine:
 
         # Compute current portfolio weights so the allocator can hold
         # (not drift-correct) tickers whose strategies don't score today.
+        # Pass None (not {}) when the denominator is zero so the allocator
+        # falls back to its equal-weight baseline rather than anchoring held
+        # tickers at 0.
         total_value = state.cash + sum(state.positions.get(t, 0.0) * current_prices[t] for t in active_tickers)
-        current_weights: dict[str, float] = {}
+        current_weights: dict[str, float] | None = None
         if total_value > 0:
-            for t in active_tickers:
-                current_weights[t] = (state.positions.get(t, 0.0) * current_prices[t]) / total_value
+            current_weights = {
+                t: (state.positions.get(t, 0.0) * current_prices[t]) / total_value for t in active_tickers
+            }
 
         # Phase 1-3: Allocator scores, blends, and applies vetoes
         allocation = self._allocator.allocate(

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -11,7 +11,7 @@ import yaml
 from midas.models import (
     DEFAULT_MIN_CASH_PCT,
     DEFAULT_REBALANCE_THRESHOLD,
-    DEFAULT_SIGMOID_STEEPNESS,
+    DEFAULT_SOFTMAX_TEMPERATURE,
     AllocationConstraints,
     CashInfusion,
     Holding,
@@ -73,7 +73,7 @@ def load_strategies(
 ) -> tuple[list[StrategyConfig], AllocationConstraints]:
     """Load strategy configs and allocation-level knobs from YAML.
 
-    Returns (strategies, constraints) tuple.  sigmoid_steepness and
+    Returns (strategies, constraints) tuple.  softmax_temperature and
     rebalance_threshold live at the top level of the strategies file
     because they are meta-strategy knobs (how scores are blended/acted on).
     """
@@ -94,8 +94,8 @@ def load_strategies(
     constraints = AllocationConstraints(
         max_position_pct=float(max_pos) if max_pos is not None else None,
         min_cash_pct=float(raw.get("min_cash_pct", DEFAULT_MIN_CASH_PCT)),
-        sigmoid_steepness=float(
-            raw.get("sigmoid_steepness", DEFAULT_SIGMOID_STEEPNESS),
+        softmax_temperature=float(
+            raw.get("softmax_temperature", DEFAULT_SOFTMAX_TEMPERATURE),
         ),
         rebalance_threshold=float(
             raw.get("rebalance_threshold", DEFAULT_REBALANCE_THRESHOLD),

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -90,6 +90,14 @@ class LiveEngine:
         if not price_data:
             return
 
+        # If any held position is missing from price_data, we can't compute an
+        # accurate portfolio denominator for current_weights — skip the tick
+        # rather than let Option A hold inflated weights based on partial info.
+        missing_held = [h.ticker for h in self._portfolio.holdings if h.shares > 0 and h.ticker not in price_data]
+        if missing_held:
+            print_status(f"Skipping tick: missing price data for held positions {missing_held}. Will retry next poll.")
+            return
+
         # Build context (cost_basis from portfolio config)
         context: dict[str, dict[str, object]] = {}
         current_prices: dict[str, float] = {}

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -108,14 +108,25 @@ class LiveEngine:
         # and the allocator operate on np.ndarray for performance.
         price_arrays: dict[str, np.ndarray] = {t: np.asarray(price_data[t]) for t in active_tickers}
 
-        # Phase 1-3: Allocate
-        allocation = self._allocator.allocate(active_tickers, price_arrays, context)
-
-        # Phase 4: Rebalance
+        # Current positions + weights (weights feed Option A: neutral=hold).
         positions = {}
         for t in active_tickers:
             holding = self._portfolio.get_holding(t)
             positions[t] = holding.shares if holding else 0.0
+
+        total_value = self._portfolio.available_cash + sum(positions[t] * current_prices[t] for t in active_tickers)
+        current_weights: dict[str, float] = {}
+        if total_value > 0:
+            for t in active_tickers:
+                current_weights[t] = (positions[t] * current_prices[t]) / total_value
+
+        # Phase 1-3: Allocate
+        allocation = self._allocator.allocate(
+            active_tickers,
+            price_arrays,
+            context,
+            current_weights=current_weights,
+        )
 
         rebalance_orders = self._rebalancer.generate_orders(
             allocation,

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -122,11 +122,12 @@ class LiveEngine:
             holding = self._portfolio.get_holding(t)
             positions[t] = holding.shares if holding else 0.0
 
+        # Pass None (not {}) when the denominator is zero so the allocator
+        # falls back to its equal-weight baseline.
         total_value = self._portfolio.available_cash + sum(positions[t] * current_prices[t] for t in active_tickers)
-        current_weights: dict[str, float] = {}
+        current_weights: dict[str, float] | None = None
         if total_value > 0:
-            for t in active_tickers:
-                current_weights[t] = (positions[t] * current_prices[t]) / total_value
+            current_weights = {t: (positions[t] * current_prices[t]) / total_value for t in active_tickers}
 
         # Phase 1-3: Allocate
         allocation = self._allocator.allocate(

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 
 DEFAULT_MIN_CASH_PCT = 0.05
 DEFAULT_REBALANCE_THRESHOLD = 0.02
-DEFAULT_SIGMOID_STEEPNESS = 2.0
+DEFAULT_SOFTMAX_TEMPERATURE = 0.5
 DEFAULT_MAX_POSITION_PCT = 0.25
 DEFAULT_CONVICTION_WEIGHT = 1
 DEFAULT_PROTECTIVE_VETO_THRESHOLD = -0.5
@@ -133,7 +133,7 @@ class AllocationConstraints:
     max_position_pct: float | None = None
     min_cash_pct: float = DEFAULT_MIN_CASH_PCT
     rebalance_threshold: float = DEFAULT_REBALANCE_THRESHOLD
-    sigmoid_steepness: float = DEFAULT_SIGMOID_STEEPNESS
+    softmax_temperature: float = DEFAULT_SOFTMAX_TEMPERATURE
 
 
 @dataclass

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -44,7 +44,7 @@ INT_PARAMS = {
 # _veto_threshold: veto threshold for protective strategies.
 META_PARAMS = {"_weight", "_veto_threshold"}
 
-# Synthetic key for global allocation knobs (sigmoid_steepness, rebalance_threshold).
+# Synthetic key for global allocation knobs (softmax_temperature, rebalance_threshold).
 ALLOCATION_KEY = "_global"
 
 # Default parameter ranges per strategy.
@@ -112,7 +112,8 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float]]] = {
         "_weight": (0.5, 3.0, 0.25),
     },
     ALLOCATION_KEY: {
-        "sigmoid_steepness": (1.0, 5.0, 0.5),
+        # softmax_temperature: low = concentrated, high = uniform split.
+        "softmax_temperature": (0.2, 1.0, 0.1),
         "rebalance_threshold": (0.01, 0.05, 0.005),
         # min_cash_pct is a user risk preference, not optimized
         # max_position_pct is computed dynamically in optimize() from n_tickers
@@ -244,7 +245,7 @@ def _run_trial(
     constraints = AllocationConstraints(
         max_position_pct=global_params.get("max_position_pct"),
         min_cash_pct=min_cash_pct,
-        sigmoid_steepness=global_params.get("sigmoid_steepness", 2.0),
+        softmax_temperature=global_params.get("softmax_temperature", 0.5),
         rebalance_threshold=global_params.get("rebalance_threshold", 0.02),
     )
 

--- a/src/midas/rebalancer.py
+++ b/src/midas/rebalancer.py
@@ -72,10 +72,10 @@ class Rebalancer:
             if abs(delta) < constraints.rebalance_threshold:
                 continue
 
-            # Skip unsupported drift-to-base trades: no conviction strategy
+            # Skip unjustified drift-correction trades: no conviction strategy
             # is directionally aligned with this trade AND no Phase 4 trim
-            # forced it. These are pure artifacts of the sigmoid centering
-            # on base_weight and serve no purpose.
+            # forced it. Belt-and-braces guard — softmax + Option A eliminate
+            # most of these at the source, but this catches any residue.
             direction = Direction.SELL if delta < 0 else Direction.BUY
             if not self._has_justification(allocation, ticker, direction):
                 continue

--- a/src/midas/rebalancer.py
+++ b/src/midas/rebalancer.py
@@ -268,8 +268,8 @@ class Rebalancer:
             aligned = {k: v for k, v in contribs.items() if v < 0}
             source = min(aligned, key=lambda k: aligned[k]) if aligned else ""
         # No aligned conviction contributor -> must be a Phase 4 constraint
-        # trim (cap or normalize). _has_justification guarantees one of these
-        # holds, so the empty-source branch should always find a trim reason.
+        # trim (currently only ``cap``). _has_justification guarantees a trim
+        # reason is present when this branch is reached.
         if not source:
             trim = allocation.trim_reasons.get(ticker, "unknown")
             source = f"Rebalancer ({trim})"

--- a/src/midas/rebalancer.py
+++ b/src/midas/rebalancer.py
@@ -72,6 +72,14 @@ class Rebalancer:
             if abs(delta) < constraints.rebalance_threshold:
                 continue
 
+            # Skip unsupported drift-to-base trades: no conviction strategy
+            # is directionally aligned with this trade AND no Phase 4 trim
+            # forced it. These are pure artifacts of the sigmoid centering
+            # on base_weight and serve no purpose.
+            direction = Direction.SELL if delta < 0 else Direction.BUY
+            if not self._has_justification(allocation, ticker, direction):
+                continue
+
             px = prices.get(ticker, 0.0)
             if px <= 0:
                 continue
@@ -220,6 +228,20 @@ class Rebalancer:
         return orders
 
     @staticmethod
+    def _has_justification(
+        allocation: AllocationResult,
+        ticker: str,
+        direction: Direction,
+    ) -> bool:
+        """Is there a conviction contributor aligned with this trade, or a trim reason?"""
+        if allocation.trim_reasons.get(ticker):
+            return True
+        contribs = allocation.contributions.get(ticker, {})
+        if direction == Direction.BUY:
+            return any(v > 0 for v in contribs.values())
+        return any(v < 0 for v in contribs.values())
+
+    @staticmethod
     def _build_context(
         ticker: str,
         allocation: AllocationResult,
@@ -241,17 +263,16 @@ class Rebalancer:
         # strategy truly drove the order — the allocator just rebalanced.
         if direction == Direction.BUY:
             aligned = {k: v for k, v in contribs.items() if v > 0}
-            source = max(aligned, key=lambda k: aligned[k]) if aligned else "Rebalancer"
+            source = max(aligned, key=lambda k: aligned[k]) if aligned else ""
         else:
             aligned = {k: v for k, v in contribs.items() if v < 0}
-            source = min(aligned, key=lambda k: aligned[k]) if aligned else "Rebalancer"
-        # Tag fallback "Rebalancer" source with the Phase 4 constraint that
-        # caused the trim (cap or normalize), so attribution reports can
-        # distinguish structural rebalances from mystery drift.
-        if source == "Rebalancer":
-            trim = allocation.trim_reasons.get(ticker)
-            if trim:
-                source = f"Rebalancer ({trim})"
+            source = min(aligned, key=lambda k: aligned[k]) if aligned else ""
+        # No aligned conviction contributor -> must be a Phase 4 constraint
+        # trim (cap or normalize). _has_justification guarantees one of these
+        # holds, so the empty-source branch should always find a trim reason.
+        if not source:
+            trim = allocation.trim_reasons.get(ticker, "unknown")
+            source = f"Rebalancer ({trim})"
         return OrderContext(
             contributions=contribs,
             blended_score=blended,

--- a/src/midas/rebalancer.py
+++ b/src/midas/rebalancer.py
@@ -245,6 +245,13 @@ class Rebalancer:
         else:
             aligned = {k: v for k, v in contribs.items() if v < 0}
             source = min(aligned, key=lambda k: aligned[k]) if aligned else "Rebalancer"
+        # Tag fallback "Rebalancer" source with the Phase 4 constraint that
+        # caused the trim (cap or normalize), so attribution reports can
+        # distinguish structural rebalances from mystery drift.
+        if source == "Rebalancer":
+            trim = allocation.trim_reasons.get(ticker)
+            if trim:
+                source = f"Rebalancer ({trim})"
         return OrderContext(
             contributions=contribs,
             blended_score=blended,

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -247,3 +247,43 @@ class TestAllocator:
         # Freed budget went to B, not to cash — sum stays at investable.
         assert abs(sum(result.targets.values()) - 0.95) < 1e-9
         assert result.targets["B"] > 0.40  # got the freed 0.45-ish
+
+    def test_cap_redistribution_multi_iteration(self):
+        """Capping one ticker can push another over the cap → second loop pass.
+
+        Regression test for the ``_apply_cap_with_redistribution`` iteration:
+        with very concentrated softmax (low T) and a tight cap, pinning the
+        top ticker frees enough budget to push the second-place ticker above
+        the cap as well, forcing the loop to run another iteration.
+        """
+        # threshold=0.20 yields non-saturated MeanReversion scores.
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.1,  # very concentrated
+            max_position_pct=0.35,
+        )
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=3,
+        )
+        # A: 20% drop → score saturates high
+        # B: 15% drop → score mid-high (would exceed cap on pass 2)
+        # C: ~5% drop → score low
+        prices_a = _prices([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 80.0])
+        prices_b = _prices([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 85.0])
+        prices_c = _prices([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 95.0])
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            {"A": prices_a, "B": prices_b, "C": prices_c},
+        )
+        # Both A and B pinned at the cap — the second pin only happens if the
+        # redistribution loop runs twice.
+        assert abs(result.targets["A"] - 0.35) < 1e-9
+        assert abs(result.targets["B"] - 0.35) < 1e-9
+        assert result.trim_reasons["A"] == "cap"
+        assert result.trim_reasons["B"] == "cap"
+        # Survivors absorb the rest; sum stays at investable.
+        assert abs(sum(result.targets.values()) - 0.95) < 1e-9

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -19,7 +19,7 @@ def _prices(values: list[float]) -> np.ndarray:
 
 class TestAllocator:
     def test_uniform_scores_produce_equal_weights(self):
-        """When all strategies score 0.0, targets equal base_weight (after cap)."""
+        """When all strategies score 0.0, softmax produces equal weights summing to investable."""
         mr = MeanReversion(window=5, threshold=0.01)
         constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.50)
         allocator = Allocator(
@@ -28,16 +28,12 @@ class TestAllocator:
             constraints=constraints,
             n_tickers=2,
         )
-        # Flat prices -> score 0.0
-        prices = {
-            "A": _prices([100.0] * 10),
-            "B": _prices([100.0] * 10),
-        }
+        prices = {"A": _prices([100.0] * 10), "B": _prices([100.0] * 10)}
         result = allocator.allocate(["A", "B"], prices)
         base = (1 - 0.05) / 2  # 0.475
-        # sigmoid(0) = 0.5, so target = base * 2 * 0.5 = base
-        assert abs(result.targets["A"] - base) < 1e-6
-        assert abs(result.targets["B"] - base) < 1e-6
+        # softmax of equal scores → equal split of investable budget
+        assert abs(result.targets["A"] - base) < 1e-9
+        assert abs(result.targets["B"] - base) < 1e-9
 
     def test_bullish_score_increases_weight(self):
         """A positive blended score should produce weight > base_weight."""
@@ -191,12 +187,9 @@ class TestAllocator:
         result = allocator.allocate(["A", "B"], {"A": prices_a, "B": prices_b})
         assert result.trim_reasons.get("A") == "cap"
 
-    def test_trim_reason_normalize_recorded(self):
-        """When normalization scales sum down, trim_reasons['normalize'] recorded."""
+    def test_softmax_sum_equals_investable(self):
+        """Softmax construct-to-budget: sum of active targets == investable, exactly."""
         mr = MeanReversion(window=5, threshold=0.01)
-        # High sigmoid steepness pushes targets near base_weight * 2 each, so
-        # their sum exceeds (1 - min_cash_pct) and triggers normalize. Large
-        # max_position_pct so cap doesn't fire first.
         constraints = AllocationConstraints(min_cash_pct=0.20, sigmoid_steepness=5.0, max_position_pct=0.90)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
@@ -210,7 +203,52 @@ class TestAllocator:
             "C": _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 50.0]),
         }
         result = allocator.allocate(["A", "B", "C"], prices)
-        assert all(result.trim_reasons.get(t) == "normalize" for t in ["A", "B", "C"])
+        investable = 1.0 - 0.20
+        assert abs(sum(result.targets.values()) - investable) < 1e-9
+        # No normalize trim — construct-to-budget means normalize cannot fire.
+        assert all(r != "normalize" for r in result.trim_reasons.values())
+
+    def test_softmax_concentrates_on_higher_conviction(self):
+        """Higher blended score → larger softmax share of the budget."""
+        # Use a large threshold so scores don't saturate at 1.0.
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(min_cash_pct=0.05, sigmoid_steepness=4.0, max_position_pct=0.90)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=3,
+        )
+        # A moderately bullish (bigger drop), B mildly bullish, C flat.
+        prices = {
+            "A": _prices([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 90.0]),  # ~10% drop
+            "B": _prices([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 96.0]),  # ~4% drop
+            "C": _prices([100.0] * 7),  # flat
+        }
+        result = allocator.allocate(["A", "B", "C"], prices)
+        assert result.targets["A"] > result.targets["B"] > result.targets["C"]
+        assert abs(sum(result.targets.values()) - 0.95) < 1e-9
+
+    def test_cap_with_redistribution(self):
+        """When a cap clamps a ticker, freed budget redistributes to survivors."""
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, sigmoid_steepness=8.0, max_position_pct=0.50)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=2,
+        )
+        # A overwhelmingly bullish → pre-cap softmax would give it > 0.50.
+        prices_a = _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 40.0])
+        prices_b = _prices([100.0] * 7)
+        result = allocator.allocate(["A", "B"], {"A": prices_a, "B": prices_b})
+        # A pinned at cap.
+        assert abs(result.targets["A"] - 0.50) < 1e-9
+        assert result.trim_reasons["A"] == "cap"
+        # Freed budget went to B, not to cash — sum stays at investable.
+        assert abs(sum(result.targets.values()) - 0.95) < 1e-9
+        assert result.targets["B"] > 0.40  # got the freed 0.45-ish
 
     def test_sigmoid_symmetry(self):
         """Verify sigmoid transform is symmetric around 0."""

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import numpy as np
 
 from midas.allocator import Allocator
@@ -38,7 +36,7 @@ class TestAllocator:
     def test_bullish_score_increases_weight(self):
         """A positive blended score should produce weight > base_weight."""
         mr = MeanReversion(window=5, threshold=0.01)
-        constraints = AllocationConstraints(min_cash_pct=0.05, sigmoid_steepness=2.0, max_position_pct=0.90)
+        constraints = AllocationConstraints(min_cash_pct=0.05, softmax_temperature=0.5, max_position_pct=0.90)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
             protective_strategies=[],
@@ -110,7 +108,7 @@ class TestAllocator:
     def test_normalization_respects_min_cash(self):
         """Sum of all target weights should not exceed 1 - min_cash_pct."""
         mr = MeanReversion(window=5, threshold=0.01)
-        constraints = AllocationConstraints(min_cash_pct=0.20, sigmoid_steepness=5.0)
+        constraints = AllocationConstraints(min_cash_pct=0.20, softmax_temperature=0.2)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
             protective_strategies=[],
@@ -190,7 +188,7 @@ class TestAllocator:
     def test_softmax_sum_equals_investable(self):
         """Softmax construct-to-budget: sum of active targets == investable, exactly."""
         mr = MeanReversion(window=5, threshold=0.01)
-        constraints = AllocationConstraints(min_cash_pct=0.20, sigmoid_steepness=5.0, max_position_pct=0.90)
+        constraints = AllocationConstraints(min_cash_pct=0.20, softmax_temperature=0.2, max_position_pct=0.90)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
             protective_strategies=[],
@@ -212,7 +210,7 @@ class TestAllocator:
         """Higher blended score → larger softmax share of the budget."""
         # Use a large threshold so scores don't saturate at 1.0.
         mr = MeanReversion(window=5, threshold=0.20)
-        constraints = AllocationConstraints(min_cash_pct=0.05, sigmoid_steepness=4.0, max_position_pct=0.90)
+        constraints = AllocationConstraints(min_cash_pct=0.05, softmax_temperature=0.25, max_position_pct=0.90)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
             protective_strategies=[],
@@ -232,7 +230,7 @@ class TestAllocator:
     def test_cap_with_redistribution(self):
         """When a cap clamps a ticker, freed budget redistributes to survivors."""
         mr = MeanReversion(window=5, threshold=0.01)
-        constraints = AllocationConstraints(min_cash_pct=0.05, sigmoid_steepness=8.0, max_position_pct=0.50)
+        constraints = AllocationConstraints(min_cash_pct=0.05, softmax_temperature=0.125, max_position_pct=0.50)
         allocator = Allocator(
             conviction_strategies=[(mr, 1.0)],
             protective_strategies=[],
@@ -249,12 +247,3 @@ class TestAllocator:
         # Freed budget went to B, not to cash — sum stays at investable.
         assert abs(sum(result.targets.values()) - 0.95) < 1e-9
         assert result.targets["B"] > 0.40  # got the freed 0.45-ish
-
-    def test_sigmoid_symmetry(self):
-        """Verify sigmoid transform is symmetric around 0."""
-        k = 2.0
-        for score in [0.5, 1.0, 0.3]:
-            pos = 1.0 / (1.0 + math.exp(-k * score))
-            neg = 1.0 / (1.0 + math.exp(-k * (-score)))
-            # pos + neg should equal 1.0 (sigmoid symmetry)
-            assert abs(pos + neg - 1.0) < 1e-10

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -137,6 +137,81 @@ class TestAllocator:
         result = allocator.allocate([], {})
         assert result.targets == {}
 
+    def test_neutral_holds_current_weight(self):
+        """When no conviction strategy scores, target = current weight (Option A)."""
+        # window too large to score
+        mr = MeanReversion(window=100, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=2,
+        )
+        prices = {
+            "A": _prices([100.0] * 10),
+            "B": _prices([100.0] * 10),
+        }
+        # A is overweight, B is underweight — neither should move.
+        result = allocator.allocate(
+            ["A", "B"],
+            prices,
+            current_weights={"A": 0.70, "B": 0.10},
+        )
+        assert abs(result.targets["A"] - 0.70) < 1e-9
+        assert abs(result.targets["B"] - 0.10) < 1e-9
+
+    def test_neutral_without_current_weights_falls_back_to_base(self):
+        """Back-compat: omitting current_weights keeps legacy drift-correct behavior."""
+        mr = MeanReversion(window=100, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=2,
+        )
+        prices = {"A": _prices([100.0] * 10), "B": _prices([100.0] * 10)}
+        result = allocator.allocate(["A", "B"], prices)
+        base = (1 - 0.05) / 2
+        assert abs(result.targets["A"] - base) < 1e-9
+
+    def test_trim_reason_cap_recorded(self):
+        """Target clamped by max_position_pct gets trim_reasons['cap']."""
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(max_position_pct=0.10, min_cash_pct=0.05)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=2,
+        )
+        prices_a = _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 50.0])
+        prices_b = _prices([100.0] * 7)
+        result = allocator.allocate(["A", "B"], {"A": prices_a, "B": prices_b})
+        assert result.trim_reasons.get("A") == "cap"
+
+    def test_trim_reason_normalize_recorded(self):
+        """When normalization scales sum down, trim_reasons['normalize'] recorded."""
+        mr = MeanReversion(window=5, threshold=0.01)
+        # High sigmoid steepness pushes targets near base_weight * 2 each, so
+        # their sum exceeds (1 - min_cash_pct) and triggers normalize. Large
+        # max_position_pct so cap doesn't fire first.
+        constraints = AllocationConstraints(min_cash_pct=0.20, sigmoid_steepness=5.0, max_position_pct=0.90)
+        allocator = Allocator(
+            conviction_strategies=[(mr, 1.0)],
+            protective_strategies=[],
+            constraints=constraints,
+            n_tickers=3,
+        )
+        prices = {
+            "A": _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 50.0]),
+            "B": _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 50.0]),
+            "C": _prices([100.0, 99.0, 98.0, 97.0, 96.0, 95.0, 50.0]),
+        }
+        result = allocator.allocate(["A", "B", "C"], prices)
+        assert all(result.trim_reasons.get(t) == "normalize" for t in ["A", "B", "C"])
+
     def test_sigmoid_symmetry(self):
         """Verify sigmoid transform is symmetric around 0."""
         k = 2.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ def portfolio_yaml(tmp_path: Path) -> Path:
 @pytest.fixture
 def strategy_yaml(tmp_path: Path) -> Path:
     data = {
-        "sigmoid_steepness": 3.0,
+        "softmax_temperature": 0.25,
         "rebalance_threshold": 0.03,
         "min_cash_pct": 0.10,
         "strategies": [
@@ -96,7 +96,7 @@ def test_load_strategies(strategy_yaml: Path) -> None:
     assert configs[2].veto_threshold == -0.5  # default
 
     # Allocation knobs
-    assert constraints.sigmoid_steepness == 3.0
+    assert constraints.softmax_temperature == 0.25
     assert constraints.rebalance_threshold == 0.03
     assert constraints.min_cash_pct == 0.10
     assert constraints.max_position_pct is None  # not specified -> None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,7 +36,7 @@ def test_full_pipeline(tmp_path: Path) -> None:
     strategy_data = {
         "min_cash_pct": 0.05,
         "rebalance_threshold": 0.01,
-        "sigmoid_steepness": 2.0,
+        "softmax_temperature": 0.5,
         "strategies": [
             {"name": "MeanReversion", "params": {"window": 20, "threshold": 0.05}},
             {"name": "ProfitTaking", "params": {"gain_threshold": 0.15}},

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,7 +84,7 @@ def test_allocation_constraints_defaults() -> None:
     assert c.max_position_pct is None
     assert c.min_cash_pct == 0.05
     assert c.rebalance_threshold == 0.02
-    assert c.sigmoid_steepness == 2.0
+    assert c.softmax_temperature == 0.5
 
 
 def test_mechanical_intent() -> None:

--- a/tests/test_rebalancer.py
+++ b/tests/test_rebalancer.py
@@ -141,22 +141,6 @@ class TestRebalancer:
         assert len(orders) == 1
         assert orders[0].context.source == "Rebalancer (cap)"
 
-    def test_fallback_source_tagged_with_normalize(self):
-        """Normalize trim produces Rebalancer (normalize) source."""
-        r = Rebalancer(RebalancerConfig(default_slippage=0.0))
-        allocation = _alloc_result(
-            {"A": 0.30},
-            contribs={"A": {}},
-            trim_reasons={"A": "normalize"},
-        )
-        positions = {"A": 50.0}
-        prices = {"A": 100.0}
-        cash = 5000.0
-        constraints = AllocationConstraints(rebalance_threshold=0.02)
-        orders = r.generate_orders(allocation, positions, prices, cash, constraints)
-        assert len(orders) == 1
-        assert orders[0].context.source == "Rebalancer (normalize)"
-
     def test_unjustified_trade_skipped(self):
         """No aligned contrib AND no trim reason → order is suppressed entirely.
 

--- a/tests/test_rebalancer.py
+++ b/tests/test_rebalancer.py
@@ -39,7 +39,7 @@ class TestRebalancer:
     def test_sell_generated_when_overweight(self):
         """Should generate SELL when current > target by more than threshold."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
-        allocation = _alloc_result({"A": 0.30})
+        allocation = _alloc_result({"A": 0.30}, contribs={"A": {"ProfitTaking": -0.5}})
         # A is 50% of portfolio, target is 30% -> need to sell
         positions = {"A": 50.0}
         prices = {"A": 100.0}
@@ -55,7 +55,7 @@ class TestRebalancer:
     def test_buy_generated_when_underweight(self):
         """Should generate BUY when current < target by more than threshold."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
-        allocation = _alloc_result({"A": 0.50})
+        allocation = _alloc_result({"A": 0.50}, contribs={"A": {"Momentum": 0.5}})
         # A is 30% of portfolio, target is 50% -> need to buy
         positions = {"A": 30.0}
         prices = {"A": 100.0}
@@ -71,7 +71,10 @@ class TestRebalancer:
     def test_sells_before_buys(self):
         """Sells should appear before buys in the order list."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
-        allocation = _alloc_result({"A": 0.20, "B": 0.60})
+        allocation = _alloc_result(
+            {"A": 0.20, "B": 0.60},
+            contribs={"A": {"ProfitTaking": -0.5}, "B": {"Momentum": 0.5}},
+        )
         # A overweight (50%), B underweight (20%)
         positions = {"A": 50.0, "B": 20.0}
         prices = {"A": 100.0, "B": 100.0}
@@ -86,7 +89,7 @@ class TestRebalancer:
     def test_cash_constraint_limits_buys(self):
         """Buy orders are reduced when cash is insufficient."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
-        allocation = _alloc_result({"A": 0.90})
+        allocation = _alloc_result({"A": 0.90}, contribs={"A": {"Momentum": 0.9}})
         positions = {"A": 0.0}
         prices = {"A": 100.0}
         cash = 500.0  # total = 500, want to buy 90% = $450 = 4 shares
@@ -98,7 +101,7 @@ class TestRebalancer:
     def test_circuit_breaker_limits_deployment(self):
         """Circuit breaker caps total buy deployment per day."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.0, circuit_breaker_pct=0.10))
-        allocation = _alloc_result({"A": 0.90})
+        allocation = _alloc_result({"A": 0.90}, contribs={"A": {"Momentum": 0.9}})
         positions = {"A": 0.0}
         prices = {"A": 10.0}
         cash = 10000.0  # total = 10000
@@ -111,7 +114,7 @@ class TestRebalancer:
     def test_slippage_applied(self):
         """Slippage adjusts execution prices."""
         r = Rebalancer(RebalancerConfig(default_slippage=0.01))
-        allocation = _alloc_result({"A": 0.80})
+        allocation = _alloc_result({"A": 0.80}, contribs={"A": {"Momentum": 0.8}})
         positions = {"A": 0.0}
         prices = {"A": 100.0}
         cash = 10000.0
@@ -154,8 +157,13 @@ class TestRebalancer:
         assert len(orders) == 1
         assert orders[0].context.source == "Rebalancer (normalize)"
 
-    def test_fallback_source_untagged_when_no_trim(self):
-        """No trim reason → plain Rebalancer source."""
+    def test_unjustified_trade_skipped(self):
+        """No aligned contrib AND no trim reason → order is suppressed entirely.
+
+        Pure drift-to-base trades are artifacts of the sigmoid centering on
+        base_weight. They serve no purpose and should not appear in the order
+        book.
+        """
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
         allocation = _alloc_result({"A": 0.30}, contribs={"A": {}})
         positions = {"A": 50.0}
@@ -163,8 +171,7 @@ class TestRebalancer:
         cash = 5000.0
         constraints = AllocationConstraints(rebalance_threshold=0.02)
         orders = r.generate_orders(allocation, positions, prices, cash, constraints)
-        assert len(orders) == 1
-        assert orders[0].context.source == "Rebalancer"
+        assert orders == []
 
     def test_order_context_populated(self):
         """Orders carry proper OrderContext."""

--- a/tests/test_rebalancer.py
+++ b/tests/test_rebalancer.py
@@ -160,9 +160,9 @@ class TestRebalancer:
     def test_unjustified_trade_skipped(self):
         """No aligned contrib AND no trim reason → order is suppressed entirely.
 
-        Pure drift-to-base trades are artifacts of the sigmoid centering on
-        base_weight. They serve no purpose and should not appear in the order
-        book.
+        Unjustified drift-correction trades serve no purpose and should not
+        appear in the order book. Softmax + Option A eliminate most of these
+        at the source; this check is a belt-and-braces guard.
         """
         r = Rebalancer(RebalancerConfig(default_slippage=0.0))
         allocation = _alloc_result({"A": 0.30}, contribs={"A": {}})

--- a/tests/test_rebalancer.py
+++ b/tests/test_rebalancer.py
@@ -15,10 +15,12 @@ def _alloc_result(
     targets: dict[str, float],
     blended: dict[str, float] | None = None,
     contribs: dict[str, dict[str, float]] | None = None,
+    trim_reasons: dict[str, str] | None = None,
 ) -> AllocationResult:
     blended = blended or {t: 0.0 for t in targets}
     contribs = contribs or {t: {} for t in targets}
-    return AllocationResult(targets, contribs, blended)
+    trim_reasons = trim_reasons or {}
+    return AllocationResult(targets, contribs, blended, trim_reasons)
 
 
 class TestRebalancer:
@@ -118,6 +120,51 @@ class TestRebalancer:
         assert len(orders) >= 1
         buy = orders[0]
         assert buy.price > 100.0  # slippage raises buy price
+
+    def test_fallback_source_tagged_with_cap(self):
+        """When no strategy drove the trade and trim_reason=cap, source = Rebalancer (cap)."""
+        r = Rebalancer(RebalancerConfig(default_slippage=0.0))
+        # No contribs → fallback path. Cap trim recorded.
+        allocation = _alloc_result(
+            {"A": 0.10},
+            contribs={"A": {}},
+            trim_reasons={"A": "cap"},
+        )
+        positions = {"A": 50.0}  # currently 50%
+        prices = {"A": 100.0}
+        cash = 5000.0  # total = 10000
+        constraints = AllocationConstraints(rebalance_threshold=0.02)
+        orders = r.generate_orders(allocation, positions, prices, cash, constraints)
+        assert len(orders) == 1
+        assert orders[0].context.source == "Rebalancer (cap)"
+
+    def test_fallback_source_tagged_with_normalize(self):
+        """Normalize trim produces Rebalancer (normalize) source."""
+        r = Rebalancer(RebalancerConfig(default_slippage=0.0))
+        allocation = _alloc_result(
+            {"A": 0.30},
+            contribs={"A": {}},
+            trim_reasons={"A": "normalize"},
+        )
+        positions = {"A": 50.0}
+        prices = {"A": 100.0}
+        cash = 5000.0
+        constraints = AllocationConstraints(rebalance_threshold=0.02)
+        orders = r.generate_orders(allocation, positions, prices, cash, constraints)
+        assert len(orders) == 1
+        assert orders[0].context.source == "Rebalancer (normalize)"
+
+    def test_fallback_source_untagged_when_no_trim(self):
+        """No trim reason → plain Rebalancer source."""
+        r = Rebalancer(RebalancerConfig(default_slippage=0.0))
+        allocation = _alloc_result({"A": 0.30}, contribs={"A": {}})
+        positions = {"A": 50.0}
+        prices = {"A": 100.0}
+        cash = 5000.0
+        constraints = AllocationConstraints(rebalance_threshold=0.02)
+        orders = r.generate_orders(allocation, positions, prices, cash, constraints)
+        assert len(orders) == 1
+        assert orders[0].context.source == "Rebalancer"
 
     def test_order_context_populated(self):
         """Orders carry proper OrderContext."""


### PR DESCRIPTION
## Summary

Fixes #25 by redesigning the allocator around construct-to-budget semantics. The old allocator mapped per-asset scores to per-asset targets independently and then tried to reconcile them with a normalize step, producing large volumes of phantom rebalance trades that no strategy actually drove.

### 1. Replace sigmoid+normalize with softmax (construct-to-budget)

The core fix. The old "score → sigmoid → multiply by base_weight → clip → normalize" pattern mapped each ticker to a target independently and then scaled back when the sum exceeded the investable budget. The normalize step was the source of the `Rebalancer (normalize)` bucket and an enormous amount of crowd-out reallocation noise.

Softmax fixes this at the root:

```
target_i = investable * exp(blended_i / T) / sum_j(exp(blended_j / T))
```

By construction `sum(targets) == investable` exactly, always. There is no normalize phase because oversubscription is mathematically impossible. This is the approach used by QuantConnect LEAN's `InsightWeightingPortfolioConstructionModel`, Markowitz-style mean-variance optimizers, PyPortfolioOpt, Riskfolio-Lib, cvxportfolio, Black-Litterman implementations, risk-parity libraries, and essentially every production portfolio construction system in the literature.

- **Phase 2** becomes `softmax(blended_scores / T) * investable`. `sigmoid_steepness` is renamed to `softmax_temperature` with standard ML softmax semantics (`T → 0` argmax, `T = 1` standard softmax, `T → ∞` uniform). Default `T = 0.5` (mild concentration). Example YAMLs and optimizer search ranges updated to match.
- **Phase 3** protective vetoes exclude vetoed tickers from the softmax denominator; their budget share flows to peers.
- **Phase 4** retains `max_position_pct`. When a cap clamps a ticker, the freed budget is redistributed by re-running softmax over the uncapped survivors (Option X, matches LEAN + QP formulations). The `normalize` trim reason is gone; only `cap` remains.

### 2. Option A (neutral = hold) + trim reason tagging

When no conviction strategy scores a ticker, the allocator holds the current weight instead of reverting to equal-weight. Tickers where all strategies abstain are excluded from the softmax; the remaining budget `investable - sum(held)` is distributed via softmax across tickers that actually scored. Tickers where Phase 4 constraints trimmed a target are tagged `cap` so the rebalancer can label fallback attribution as `Rebalancer (cap)` rather than bare `Rebalancer`.

`BacktestEngine._run_day` and `LiveEngine._tick` now compute current portfolio weights and pass them to `Allocator.allocate()`. Backwards-compatible: omitting `current_weights` falls back to the old equal-weight behavior.

### 3. Suppress unjustified drift-to-base trades

The rebalancer now verifies every trade is either (a) directionally aligned with a conviction contributor or (b) forced by a Phase 4 cap trim. Trades that fail both are pure drift-to-base artifacts and are suppressed entirely. Eliminates the plain `Rebalancer` attribution bucket. With softmax + Option A in place this check rarely fires at runtime — it acts as a belt-and-braces guard.

### 4. Review fixes

Follow-up commits addressing review feedback:

- **Live denominator guard.** `LiveEngine._tick` now skips the tick if any held position (`shares > 0`) is missing from fetched price data. Without this, Option A would anchor `current_weights` on a partial `total_value` denominator and produce inflated weights for the tickers we *can* price. Hardening this beyond full-skip is tracked in #31.
- **Multi-iteration cap test.** Added `test_cap_redistribution_multi_iteration` — concentrated softmax (`T=0.1`) + tight cap (`0.35`) forces the cap-redistribution loop to pin two tickers across two iterations. Regression coverage for the iterative `_apply_cap_with_redistribution` path.
- **Dead code cleanup.** Removed the `normalize` trim reason entirely — softmax construct-to-budget makes normalization impossible. Deleted the stale `test_fallback_source_tagged_with_normalize` test and updated the `AllocationResult.trim_reasons` and `Rebalancer._build_context` comments.
- **Protective veto attribution note.** Added a KNOWN LIMITATION comment in `Allocator.allocate` Phase 2 covering the edge case where a protective strategy vetoes with a score `>= 0` — the rebalancer's sign-based attribution picker would suppress or mislabel the forced SELL. Not exploitable with current strategies (StopLoss, TrailingStop both return strictly negative scores on veto) and the entire protective tier is slated for removal in #26, so this is comment-only.
- **Constant convention.** Promoted `_MIN_TEMPERATURE` from a class attribute to module-level `MIN_TEMPERATURE` to match the existing `MAX_POSITION_MULTIPLIER` / `LOW_POSITION_MULTIPLIER` / `HIGH_POSITION_MULTIPLIER` style in `allocator.py`. No behavior change.
- Follow-up issue #30 tracks live `available_cash` staleness (separate concern, out of scope).

## Results on the sample portfolio

10-year backtest, 3 tickers, optimized strategy config:

| Metric                   | Before | After |
|--------------------------|-------:|------:|
| Total trades             | 675    | 131   |
| Momentum (buys)          | 268    | 44    |
| ProfitTaking (sells)     | 108    | 46    |
| RSIOversold (buys)       | 86     | 35    |
| TrailingStop (sells)     | 8      | 6     |
| `Rebalancer`             | 13     | 0     |
| `Rebalancer (cap)`       | n/a    | 0     |
| `Rebalancer (normalize)` | 183    | 0     |

The entire `Rebalancer` attribution family is gone. Every trade now attributes to a real conviction strategy. Headline numbers on the sample backtest: Final value $227,820.70, Total return 637.95%, CAGR 21.61%, Sharpe 0.91, Max drawdown 48.55%.

The optimizer should be re-run against this new trade surface — the old sigmoid-tuned parameters aren't the right knobs for softmax.

## Test plan

- [x] `uv run pytest` — 162 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src` — clean
- [x] Allocator tests: `test_neutral_holds_current_weight`, `test_neutral_without_current_weights_falls_back_to_base`, `test_trim_reason_cap_recorded`, `test_softmax_sum_equals_investable`, `test_softmax_concentrates_on_higher_conviction`, `test_cap_with_redistribution`, `test_cap_redistribution_multi_iteration`
- [x] Rebalancer tests: `test_fallback_source_tagged_with_cap`, `test_unjustified_trade_skipped`
- [x] End-to-end backtest run on `sample-portfolio.yaml + optimized-strategy.yaml`
- [ ] Re-run walk-forward optimization on existing YAMLs

Docs updated in `docs/architecture.md` (Phase 2 rewritten around softmax, Phase 4 rewritten around cap-with-redistribution, Rebalancer section gains a justification-check subsection). `README.md` and `example-strategies/*.yaml` updated for the `softmax_temperature` rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)