### PR TITLE
Fix 6 bugs: live cache, monthly drift, logger leak, RSI warmup, DCA t…

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -225,7 +225,9 @@ def compute_strategy_stats(
     basis_per_sell: list[float],
 ) -> list[StrategyStats]:
     """Compute per-strategy trade breakdown."""
-    sell_basis: dict[int, float] = {id(t): b for t, b in _pair_sells_with_basis(trades, basis_per_sell)}
+    # Key by the TradeRecord object itself (not id()) so the lookup is safe
+    # even if objects are ever reconstructed or the list is reordered.
+    sell_basis: dict[TradeRecord, float] = {t: b for t, b in _pair_sells_with_basis(trades, basis_per_sell)}
 
     by_strategy: dict[str, list[TradeRecord]] = defaultdict(list)
     for t in trades:
@@ -238,7 +240,7 @@ def compute_strategy_stats(
         winning_sells = 0
         total_pnl = 0.0
         for t in sells:
-            basis = sell_basis.get(id(t), t.price)
+            basis = sell_basis.get(t, t.price)
             pnl = (t.price - basis) * t.shares
             total_pnl += pnl
             if pnl >= 0:

--- a/src/midas/data/yfinance_provider.py
+++ b/src/midas/data/yfinance_provider.py
@@ -21,8 +21,12 @@ class CachedYFinanceProvider(DataProvider):
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
     def get_history(self, ticker: str, start: date, end: date) -> pd.Series:
+        # Never serve cached data when the requested end date is today — the
+        # live engine polls repeatedly with end=today and would otherwise
+        # receive stale prices for the entire session.
+        is_live = end >= date.today()
         cache_key = self._cache_path(ticker, start, end)
-        if cache_key.exists():
+        if not is_live and cache_key.exists():
             with open(cache_key, "rb") as f:
                 return pickle.load(f)  # type: ignore[no-any-return]
 
@@ -42,8 +46,9 @@ class CachedYFinanceProvider(DataProvider):
         series.index = pd.to_datetime(series.index).date
         series.name = ticker
 
-        with open(cache_key, "wb") as f:
-            pickle.dump(series, f)
+        if not is_live:
+            with open(cache_key, "wb") as f:
+                pickle.dump(series, f)
 
         return series
 

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import calendar
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from enum import Enum
@@ -48,7 +49,6 @@ class Holding:
 FREQUENCY_DAYS: dict[str, int] = {
     "weekly": 7,
     "biweekly": 14,
-    "monthly": 30,
 }
 
 
@@ -61,6 +61,15 @@ class CashInfusion:
     def advance(self) -> None:
         """Advance next_date by frequency. No-op if frequency is None."""
         if self.frequency is None:
+            return
+        if self.frequency == "monthly":
+            # Advance by exactly one calendar month, preserving day-of-month
+            # (clamped to the last valid day, e.g. Jan 31 → Feb 28/29).
+            # A fixed 30-day offset would drift ~5 days per year.
+            month = self.next_date.month % 12 + 1
+            year = self.next_date.year + (1 if self.next_date.month == 12 else 0)
+            day = min(self.next_date.day, calendar.monthrange(year, month)[1])
+            self.next_date = self.next_date.replace(year=year, month=month, day=day)
             return
         days = FREQUENCY_DAYS.get(self.frequency)
         if days is None:

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -215,59 +215,65 @@ def _run_trial(
     """
     # Suppress allocator warnings during optimization — the optimizer explores
     # boundary values that trigger heuristic warnings but are fine to evaluate.
-    logging.getLogger("midas.allocator").setLevel(logging.ERROR)
+    # Restore the level afterward so callers in the main process (e.g. the
+    # best-trial re-run) aren't permanently silenced.
+    _allocator_logger = logging.getLogger("midas.allocator")
+    _saved_level = _allocator_logger.level
+    _allocator_logger.setLevel(logging.ERROR)
+    try:
+        # Extract global allocation knobs
+        global_params = strategy_params.get(ALLOCATION_KEY, {})
+        conviction: list[tuple[Strategy, float]] = []
+        protective: list[tuple[Strategy, float]] = []
+        mechanical: list[Strategy] = []
 
-    # Extract global allocation knobs
-    global_params = strategy_params.get(ALLOCATION_KEY, {})
-    conviction: list[tuple[Strategy, float]] = []
-    protective: list[tuple[Strategy, float]] = []
-    mechanical: list[Strategy] = []
+        for name, params in strategy_params.items():
+            if name == ALLOCATION_KEY:
+                continue
+            cls = STRATEGY_REGISTRY[name]
+            # Separate meta-params from constructor params
+            weight = params.get("_weight", 1.0)
+            veto_threshold = params.get("_veto_threshold", -0.5)
+            clean_params = {k: int(v) if k in INT_PARAMS else v for k, v in params.items() if k not in META_PARAMS}
+            strategy = cls(**clean_params)
 
-    for name, params in strategy_params.items():
-        if name == ALLOCATION_KEY:
-            continue
-        cls = STRATEGY_REGISTRY[name]
-        # Separate meta-params from constructor params
-        weight = params.get("_weight", 1.0)
-        veto_threshold = params.get("_veto_threshold", -0.5)
-        clean_params = {k: int(v) if k in INT_PARAMS else v for k, v in params.items() if k not in META_PARAMS}
-        strategy = cls(**clean_params)
+            if strategy.tier == StrategyTier.PROTECTIVE:
+                protective.append((strategy, veto_threshold))
+            elif strategy.tier == StrategyTier.MECHANICAL:
+                mechanical.append(strategy)
+            else:
+                conviction.append((strategy, weight))
 
-        if strategy.tier == StrategyTier.PROTECTIVE:
-            protective.append((strategy, veto_threshold))
-        elif strategy.tier == StrategyTier.MECHANICAL:
-            mechanical.append(strategy)
-        else:
-            conviction.append((strategy, weight))
+        # Count tickers in portfolio
+        n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
+        constraints = AllocationConstraints(
+            max_position_pct=global_params.get("max_position_pct"),
+            min_cash_pct=min_cash_pct,
+            softmax_temperature=global_params.get("softmax_temperature", 0.5),
+            rebalance_threshold=global_params.get("rebalance_threshold", 0.02),
+        )
 
-    # Count tickers in portfolio
-    n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
-    constraints = AllocationConstraints(
-        max_position_pct=global_params.get("max_position_pct"),
-        min_cash_pct=min_cash_pct,
-        softmax_temperature=global_params.get("softmax_temperature", 0.5),
-        rebalance_threshold=global_params.get("rebalance_threshold", 0.02),
-    )
+        allocator = Allocator(conviction, protective, constraints, n_tickers)
+        rebalancer = Rebalancer()
 
-    allocator = Allocator(conviction, protective, constraints, n_tickers)
-    rebalancer = Rebalancer()
+        engine = BacktestEngine(
+            allocator=allocator,
+            rebalancer=rebalancer,
+            mechanical_strategies=mechanical,
+            constraints=constraints,
+            train_pct=train_pct,
+            enable_split=enable_split,
+        )
+        result = engine.run(portfolio, price_data, start, end)
 
-    engine = BacktestEngine(
-        allocator=allocator,
-        rebalancer=rebalancer,
-        mechanical_strategies=mechanical,
-        constraints=constraints,
-        train_pct=train_pct,
-        enable_split=enable_split,
-    )
-    result = engine.run(portfolio, price_data, start, end)
+        if result.starting_value <= 0:
+            return 0.0, 0.0, 0.0, 0.0, 0.0, result
 
-    if result.starting_value <= 0:
-        return 0.0, 0.0, 0.0, 0.0, 0.0, result
-
-    total_return = (result.final_value - result.starting_value) / result.starting_value
-    bh_return = (result.buy_and_hold_value - result.starting_value) / result.starting_value
-    return total_return, bh_return, result.train_return, result.test_return, result.twr, result
+        total_return = (result.final_value - result.starting_value) / result.starting_value
+        bh_return = (result.buy_and_hold_value - result.starting_value) / result.starting_value
+        return total_return, bh_return, result.train_return, result.test_return, result.twr, result
+    finally:
+        _allocator_logger.setLevel(_saved_level)
 
 
 _worker_state: dict[str, Any] = {}

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -217,63 +217,63 @@ def _run_trial(
     # boundary values that trigger heuristic warnings but are fine to evaluate.
     # Restore the level afterward so callers in the main process (e.g. the
     # best-trial re-run) aren't permanently silenced.
-    _allocator_logger = logging.getLogger("midas.allocator")
-    _saved_level = _allocator_logger.level
-    _allocator_logger.setLevel(logging.ERROR)
-    try:
-        # Extract global allocation knobs
-        global_params = strategy_params.get(ALLOCATION_KEY, {})
-        conviction: list[tuple[Strategy, float]] = []
-        protective: list[tuple[Strategy, float]] = []
-        mechanical: list[Strategy] = []
+    allocator_logger = logging.getLogger("midas.allocator")
+    saved_level = allocator_logger.level
+    allocator_logger.setLevel(logging.ERROR)
 
-        for name, params in strategy_params.items():
-            if name == ALLOCATION_KEY:
-                continue
-            cls = STRATEGY_REGISTRY[name]
-            # Separate meta-params from constructor params
-            weight = params.get("_weight", 1.0)
-            veto_threshold = params.get("_veto_threshold", -0.5)
-            clean_params = {k: int(v) if k in INT_PARAMS else v for k, v in params.items() if k not in META_PARAMS}
-            strategy = cls(**clean_params)
+    # Extract global allocation knobs
+    global_params = strategy_params.get(ALLOCATION_KEY, {})
+    conviction: list[tuple[Strategy, float]] = []
+    protective: list[tuple[Strategy, float]] = []
+    mechanical: list[Strategy] = []
 
-            if strategy.tier == StrategyTier.PROTECTIVE:
-                protective.append((strategy, veto_threshold))
-            elif strategy.tier == StrategyTier.MECHANICAL:
-                mechanical.append(strategy)
-            else:
-                conviction.append((strategy, weight))
+    for name, params in strategy_params.items():
+        if name == ALLOCATION_KEY:
+            continue
+        cls = STRATEGY_REGISTRY[name]
+        # Separate meta-params from constructor params
+        weight = params.get("_weight", 1.0)
+        veto_threshold = params.get("_veto_threshold", -0.5)
+        clean_params = {k: int(v) if k in INT_PARAMS else v for k, v in params.items() if k not in META_PARAMS}
+        strategy = cls(**clean_params)
 
-        # Count tickers in portfolio
-        n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
-        constraints = AllocationConstraints(
-            max_position_pct=global_params.get("max_position_pct"),
-            min_cash_pct=min_cash_pct,
-            softmax_temperature=global_params.get("softmax_temperature", 0.5),
-            rebalance_threshold=global_params.get("rebalance_threshold", 0.02),
-        )
+        if strategy.tier == StrategyTier.PROTECTIVE:
+            protective.append((strategy, veto_threshold))
+        elif strategy.tier == StrategyTier.MECHANICAL:
+            mechanical.append(strategy)
+        else:
+            conviction.append((strategy, weight))
 
-        allocator = Allocator(conviction, protective, constraints, n_tickers)
-        rebalancer = Rebalancer()
+    # Count tickers in portfolio
+    n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
+    constraints = AllocationConstraints(
+        max_position_pct=global_params.get("max_position_pct"),
+        min_cash_pct=min_cash_pct,
+        softmax_temperature=global_params.get("softmax_temperature", 0.5),
+        rebalance_threshold=global_params.get("rebalance_threshold", 0.02),
+    )
 
-        engine = BacktestEngine(
-            allocator=allocator,
-            rebalancer=rebalancer,
-            mechanical_strategies=mechanical,
-            constraints=constraints,
-            train_pct=train_pct,
-            enable_split=enable_split,
-        )
-        result = engine.run(portfolio, price_data, start, end)
+    allocator = Allocator(conviction, protective, constraints, n_tickers)
+    rebalancer = Rebalancer()
 
-        if result.starting_value <= 0:
-            return 0.0, 0.0, 0.0, 0.0, 0.0, result
+    engine = BacktestEngine(
+        allocator=allocator,
+        rebalancer=rebalancer,
+        mechanical_strategies=mechanical,
+        constraints=constraints,
+        train_pct=train_pct,
+        enable_split=enable_split,
+    )
+    result = engine.run(portfolio, price_data, start, end)
 
-        total_return = (result.final_value - result.starting_value) / result.starting_value
-        bh_return = (result.buy_and_hold_value - result.starting_value) / result.starting_value
-        return total_return, bh_return, result.train_return, result.test_return, result.twr, result
-    finally:
-        _allocator_logger.setLevel(_saved_level)
+    allocator_logger.setLevel(saved_level)
+
+    if result.starting_value <= 0:
+        return 0.0, 0.0, 0.0, 0.0, 0.0, result
+
+    total_return = (result.final_value - result.starting_value) / result.starting_value
+    bh_return = (result.buy_and_hold_value - result.starting_value) / result.starting_value
+    return total_return, bh_return, result.train_return, result.test_return, result.twr, result
 
 
 _worker_state: dict[str, Any] = {}

--- a/src/midas/strategies/dca.py
+++ b/src/midas/strategies/dca.py
@@ -17,7 +17,7 @@ class DollarCostAveraging(Strategy):
     def __init__(self, frequency_days: int = 14, amount: float = 500.0) -> None:
         self._frequency_days = frequency_days
         self._amount = amount
-        self._last_trigger_len: int = 0
+        self._last_trigger_len: dict[str, int] = {}
 
     @property
     def tier(self) -> StrategyTier:
@@ -41,13 +41,15 @@ class DollarCostAveraging(Strategy):
         if n < self._frequency_days:
             return []
 
-        if self._last_trigger_len == 0:
+        last = self._last_trigger_len.get(ticker, 0)
+        if last == 0:
             # Align the first trigger to the end of the first full window so
             # behaviour is deterministic regardless of warmup buffer size.
-            self._last_trigger_len = n - (n % self._frequency_days or self._frequency_days)
+            last = n - (n % self._frequency_days or self._frequency_days)
+            self._last_trigger_len[ticker] = last
 
-        if n - self._last_trigger_len >= self._frequency_days:
-            self._last_trigger_len = n
+        if n - last >= self._frequency_days:
+            self._last_trigger_len[ticker] = n
             current = float(price_history[-1])
             return [
                 MechanicalIntent(

--- a/src/midas/strategies/dca.py
+++ b/src/midas/strategies/dca.py
@@ -17,6 +17,7 @@ class DollarCostAveraging(Strategy):
     def __init__(self, frequency_days: int = 14, amount: float = 500.0) -> None:
         self._frequency_days = frequency_days
         self._amount = amount
+        self._last_trigger_len: int = 0
 
     @property
     def tier(self) -> StrategyTier:
@@ -36,10 +37,17 @@ class DollarCostAveraging(Strategy):
         price_history: np.ndarray,
         **kwargs: object,
     ) -> list[MechanicalIntent]:
-        if len(price_history) < self._frequency_days:
+        n = len(price_history)
+        if n < self._frequency_days:
             return []
 
-        if len(price_history) % self._frequency_days == 0:
+        if self._last_trigger_len == 0:
+            # Align the first trigger to the end of the first full window so
+            # behaviour is deterministic regardless of warmup buffer size.
+            self._last_trigger_len = n - (n % self._frequency_days or self._frequency_days)
+
+        if n - self._last_trigger_len >= self._frequency_days:
+            self._last_trigger_len = n
             current = float(price_history[-1])
             return [
                 MechanicalIntent(

--- a/src/midas/strategies/rsi_overbought.py
+++ b/src/midas/strategies/rsi_overbought.py
@@ -15,8 +15,9 @@ class RSIOverbought(Strategy):
 
     @property
     def warmup_period(self) -> int:
-        # RSI is recursive — see RSIOversold for rationale.
-        return self._window * RECURSIVE_WARMUP_MULTIPLIER
+        # Both score() and precompute() use SMA (not Wilder EMA), so the true
+        # minimum is window + 1 bars (window deltas). No stability multiplier needed.
+        return self._window + 1
 
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)

--- a/src/midas/strategies/rsi_overbought.py
+++ b/src/midas/strategies/rsi_overbought.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 
 from midas.models import AssetSuitability
-from midas.strategies.base import RECURSIVE_WARMUP_MULTIPLIER, Strategy
+from midas.strategies.base import Strategy
 
 
 class RSIOverbought(Strategy):

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -15,9 +15,9 @@ class RSIOversold(Strategy):
 
     @property
     def warmup_period(self) -> int:
-        # RSI is recursive (Wilder-style smoothing) — strict min of `window`
-        # bars gives a mathematically valid but numerically unstable value.
-        return self._window * RECURSIVE_WARMUP_MULTIPLIER
+        # Both score() and precompute() use SMA (not Wilder EMA), so the true
+        # minimum is window + 1 bars (window deltas). No stability multiplier needed.
+        return self._window + 1
 
     def precompute(self, prices: np.ndarray) -> np.ndarray | None:
         n = len(prices)

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 
 from midas.models import AssetSuitability
-from midas.strategies.base import RECURSIVE_WARMUP_MULTIPLIER, Strategy
+from midas.strategies.base import Strategy
 
 
 class RSIOversold(Strategy):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -118,7 +118,15 @@ class TestCashInfusion:
     def test_advance_monthly(self) -> None:
         infusion = CashInfusion(amount=2000.0, next_date=date(2025, 1, 3), frequency="monthly")
         infusion.advance()
-        assert infusion.next_date == date(2025, 2, 2)
+        # Should advance by exactly one calendar month (Jan 3 → Feb 3),
+        # not a fixed 30 days (which would give Feb 2 and drift ~5 days/year).
+        assert infusion.next_date == date(2025, 2, 3)
+
+    def test_advance_monthly_end_of_month_clamped(self) -> None:
+        # Jan 31 + 1 month → Feb 28 (no Feb 31)
+        infusion = CashInfusion(amount=500.0, next_date=date(2025, 1, 31), frequency="monthly")
+        infusion.advance()
+        assert infusion.next_date == date(2025, 2, 28)
 
     def test_advance_no_frequency_is_noop(self) -> None:
         infusion = CashInfusion(amount=1500.0, next_date=date(2025, 1, 3))

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -322,11 +322,11 @@ class TestWarmupPeriod:
     def test_ma_crossover_uses_long_window(self) -> None:
         assert MovingAverageCrossover(short_window=10, long_window=60).warmup_period == 60
 
-    def test_rsi_applies_recursive_multiplier(self) -> None:
-        # Recursive indicators need 4x their nominal period to converge
-        # (TA-Lib unstable-period convention).
-        assert RSIOversold(window=14).warmup_period == 56
-        assert RSIOverbought(window=14).warmup_period == 56
+    def test_rsi_warmup_is_window_plus_one(self) -> None:
+        # RSI uses SMA (not Wilder EMA), so only window+1 bars are needed —
+        # window bars produce window deltas, which is exactly one SMA period.
+        assert RSIOversold(window=14).warmup_period == 15
+        assert RSIOverbought(window=14).warmup_period == 15
 
     def test_macd_uses_slow_period_times_multiplier_plus_signal(self) -> None:
         assert MACDCrossover(slow_period=26, signal_period=9).warmup_period == 26 * 4 + 9

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -187,6 +187,15 @@ class TestDollarCostAveraging:
         intents = strategy.generate_intents("FLAT", flat_prices[:11])
         assert intents == []
 
+    def test_multi_ticker_all_trigger(self, flat_prices: np.ndarray) -> None:
+        # One strategy instance shared across tickers (as the backtest engine does).
+        # All tickers must trigger on the same day, not just the first in iteration order.
+        strategy = DollarCostAveraging(frequency_days=10)
+        prices = flat_prices[:10]
+        for ticker in ("AAPL", "VOO", "MSFT"):
+            intents = strategy.generate_intents(ticker, prices)
+            assert len(intents) == 1, f"{ticker} did not trigger"
+
     def test_name_and_description(self) -> None:
         s = DollarCostAveraging(frequency_days=7)
         assert s.name == "DollarCostAveraging"


### PR DESCRIPTION
…rigger, id() P&L lookup

- yfinance_provider: skip cache when end >= today so live engine sees fresh prices each poll
- models: advance monthly infusions by one calendar month (not 30 days) to prevent ~5-day/year drift
- optimizer: restore allocator log level after _run_trial to avoid permanently silencing warnings in main process
- rsi_oversold/overbought: warmup_period is window+1 (SMA needs window deltas, not 4x multiplier)
- dca: trigger on elapsed trading days since last buy, not total array length mod frequency
- backtest: key sell_basis dict by TradeRecord object instead of id() for safer P&L lookup