### PR TITLE
Replace pseudo-CSV backtest output with machine-readable directory

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import json
 import math
 from collections import defaultdict
 from collections.abc import Callable
@@ -67,6 +68,7 @@ class BacktestResult:
     efficiency_ratio: float  # test_return / train_return (0 if no split)
     strategy_stats: list[StrategyStats]
     unrealized_pnl: float  # mark-to-market gain on positions still held at end
+    basis_per_sell: list[float]  # cost basis for each SELL trade (parallel list)
 
 
 @dataclass
@@ -994,95 +996,143 @@ class BacktestEngine:
             efficiency_ratio=round(efficiency, 4),
             strategy_stats=strategy_stats,
             unrealized_pnl=round(unrealized_pnl, 2),
+            basis_per_sell=state.basis_per_sell,
         )
 
 
-def write_backtest_csv(result: BacktestResult, path: Path) -> None:
-    """Write backtest results to a CSV file."""
+def write_backtest_results(result: BacktestResult, output_dir: Path) -> None:
+    """Write backtest results to a directory of machine-readable files."""
+    if output_dir.is_file():
+        msg = f"Output path '{output_dir}' is an existing file, not a directory"
+        raise FileExistsError(msg)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_trades_csv(result, output_dir / "trades.csv")
+    _write_equity_curve_csv(result, output_dir / "equity_curve.csv")
+    _write_summary_json(result, output_dir / "summary.json")
+    _write_strategy_breakdown_csv(result, output_dir / "strategy_breakdown.csv")
+
+
+def _write_trades_csv(result: BacktestResult, path: Path) -> None:
+    sell_idx = 0
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
-
-        writer.writerow(["=== TRADE LOG ==="])
         writer.writerow(
             [
-                "Date",
-                "Ticker",
-                "Direction",
-                "Shares",
-                "Price",
-                "Strategy",
-                "Holding Period",
+                "date",
+                "ticker",
+                "direction",
+                "shares",
+                "price",
+                "strategy",
+                "holding_period",
+                "cost_basis",
+                "realized_pnl",
+                "return_pct",
             ]
         )
         for t in result.trades:
-            writer.writerow(
-                [
-                    t.date.isoformat(),
-                    t.ticker,
-                    t.direction.value,
-                    t.shares,
-                    f"{t.price:.2f}",
-                    t.strategy_name,
-                    t.holding_period.value if t.holding_period else "",
-                ]
-            )
-
-        writer.writerow([])
-        writer.writerow(["=== SUMMARY ==="])
-        writer.writerow(["Metric", "Value"])
-        sv = result.starting_value
-        total_return = (result.final_value - sv) / sv if sv > 0 else 0
-        bh_return = (result.buy_and_hold_value - sv) / sv if sv > 0 else 0
-        writer.writerow(["Starting Value", f"${sv:.2f}"])
-        writer.writerow(["Final Value", f"${result.final_value:.2f}"])
-        writer.writerow(["Total Return", f"{total_return:.2%}"])
-        writer.writerow(["CAGR", f"{result.cagr:.2%}"])
-        writer.writerow(["Time-Weighted Return", f"{result.twr:.2%}"])
-        writer.writerow(["Buy & Hold Value", f"${result.buy_and_hold_value:.2f}"])
-        writer.writerow(["Buy & Hold Return", f"{bh_return:.2%}"])
-        writer.writerow(["Total Trades", len(result.trades)])
-
-        writer.writerow([])
-        writer.writerow(["=== RISK METRICS ==="])
-        writer.writerow(["Max Drawdown", f"{result.max_drawdown:.2%}"])
-        writer.writerow(["Sharpe Ratio", f"{result.sharpe_ratio:.4f}"])
-        writer.writerow(["Sortino Ratio", f"{result.sortino_ratio:.4f}"])
-
-        sells = [t for t in result.trades if t.direction == Direction.SELL]
-        if sells:
-            writer.writerow([])
-            writer.writerow(["=== TRADE QUALITY ==="])
-            writer.writerow(["Win Rate", f"{result.win_rate:.2%}"])
-            pf = f"{result.profit_factor:.4f}" if not math.isinf(result.profit_factor) else "inf"
-            writer.writerow(["Profit Factor", pf])
-            writer.writerow(["Avg Win", f"${result.avg_win:.2f}"])
-            writer.writerow(["Avg Loss", f"${result.avg_loss:.2f}"])
-
-        if result.split_date:
-            writer.writerow([])
-            writer.writerow(["=== OUT-OF-SAMPLE SPLIT ==="])
-            writer.writerow(["Split Date", result.split_date.isoformat()])
-            writer.writerow(["Train Return", f"{result.train_return:.2%}"])
-            writer.writerow(["Train B&H Return", f"{result.train_bh_return:.2%}"])
-            writer.writerow(["Train Trades", len(result.train_trades)])
-            writer.writerow(["Test Return", f"{result.test_return:.2%}"])
-            writer.writerow(["Test B&H Return", f"{result.test_bh_return:.2%}"])
-            writer.writerow(["Test Trades", len(result.test_trades)])
-            writer.writerow(["Efficiency Ratio", f"{result.efficiency_ratio:.2%}"])
-
-        if result.strategy_stats:
-            writer.writerow([])
-            writer.writerow(["=== STRATEGY BREAKDOWN ==="])
-            writer.writerow(["Strategy", "Trades", "Buys", "Sells", "Win Rate", "P&L"])
-            for s in result.strategy_stats:
+            if t.direction == Direction.SELL:
+                basis = result.basis_per_sell[sell_idx] if sell_idx < len(result.basis_per_sell) else t.price
+                pnl = round((t.price - basis) * t.shares, 4)
+                ret = round((t.price - basis) / basis, 6) if basis != 0 else 0.0
+                sell_idx += 1
                 writer.writerow(
                     [
-                        s.name,
-                        s.trades,
-                        s.buys,
-                        s.sells,
-                        f"{s.win_rate:.2%}" if s.sells > 0 else "",
-                        f"${s.pnl:.2f}" if s.sells > 0 else "",
+                        t.date.isoformat(),
+                        t.ticker,
+                        t.direction.value,
+                        t.shares,
+                        t.price,
+                        t.strategy_name,
+                        t.holding_period.value if t.holding_period else "",
+                        round(basis, 4),
+                        pnl,
+                        ret,
                     ]
                 )
-            writer.writerow(["Open Positions", "", "", "", "", f"${result.unrealized_pnl:.2f}"])
+            else:
+                writer.writerow(
+                    [
+                        t.date.isoformat(),
+                        t.ticker,
+                        t.direction.value,
+                        t.shares,
+                        t.price,
+                        t.strategy_name,
+                        "",
+                        "",
+                        "",
+                        "",
+                    ]
+                )
+
+
+def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "nav", "drawdown"])
+        peak = 0.0
+        for d, nav in result.equity_curve:
+            peak = max(peak, nav)
+            dd = round((peak - nav) / peak, 6) if peak > 0 else 0.0
+            writer.writerow([d.isoformat(), round(nav, 2), dd])
+
+
+def _write_summary_json(result: BacktestResult, path: Path) -> None:
+    sv = result.starting_value
+    total_return = (result.final_value - sv) / sv if sv > 0 else 0.0
+    bh_return = (result.buy_and_hold_value - sv) / sv if sv > 0 else 0.0
+
+    summary: dict[str, object] = {
+        "starting_value": sv,
+        "final_value": result.final_value,
+        "total_return": round(total_return, 6),
+        "cagr": result.cagr,
+        "twr": result.twr,
+        "buy_and_hold_value": result.buy_and_hold_value,
+        "buy_and_hold_return": round(bh_return, 6),
+        "total_trades": len(result.trades),
+        "max_drawdown": result.max_drawdown,
+        "sharpe_ratio": result.sharpe_ratio,
+        "sortino_ratio": result.sortino_ratio,
+        "win_rate": result.win_rate,
+        "profit_factor": result.profit_factor if not math.isinf(result.profit_factor) else "inf",
+        "avg_win": result.avg_win,
+        "avg_loss": result.avg_loss,
+        "unrealized_pnl": result.unrealized_pnl,
+        "efficiency_ratio": result.efficiency_ratio,
+    }
+
+    if result.split_date:
+        summary["split"] = {
+            "date": result.split_date.isoformat(),
+            "train_return": result.train_return,
+            "test_return": result.test_return,
+            "train_bh_return": result.train_bh_return,
+            "test_bh_return": result.test_bh_return,
+            "train_trades": len(result.train_trades),
+            "test_trades": len(result.test_trades),
+        }
+
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+        f.write("\n")
+
+
+def _write_strategy_breakdown_csv(result: BacktestResult, path: Path) -> None:
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["strategy", "trades", "buys", "sells", "win_rate", "pnl"])
+        for s in result.strategy_stats:
+            writer.writerow(
+                [
+                    s.name,
+                    s.trades,
+                    s.buys,
+                    s.sells,
+                    round(s.win_rate, 4) if s.sells > 0 else "",
+                    round(s.pnl, 2) if s.sells > 0 else "",
+                ]
+            )
+        writer.writerow(["Open Positions", "", "", "", "", round(result.unrealized_pnl, 2)])

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -31,14 +31,51 @@ from midas.strategies.base import ExitRule, max_warmup
 
 @dataclass
 class StrategyStats:
-    """Per-strategy performance breakdown."""
+    """Per-strategy, per-ticker performance breakdown."""
 
     name: str
+    ticker: str
     trades: int
     buys: int
     sells: int
     win_rate: float  # fraction of profitable sells
     pnl: float  # total realized P&L from sells
+
+
+@dataclass
+class AggregateStrategyStats:
+    """Per-strategy totals aggregated across all tickers."""
+
+    name: str
+    trades: int
+    buys: int
+    sells: int
+    win_rate: float
+    pnl: float
+
+
+def aggregate_strategy_stats(stats: list[StrategyStats]) -> list[AggregateStrategyStats]:
+    """Aggregate per-(strategy, ticker) stats into per-strategy totals."""
+    by_strategy: dict[str, list[StrategyStats]] = defaultdict(list)
+    for s in stats:
+        by_strategy[s.name].append(s)
+    result: list[AggregateStrategyStats] = []
+    for name, group in sorted(by_strategy.items()):
+        total_sells = sum(s.sells for s in group)
+        total_pnl = sum(s.pnl for s in group)
+        winning = sum(round(s.win_rate * s.sells) for s in group)
+        agg_wr = winning / total_sells if total_sells > 0 else 0.0
+        result.append(
+            AggregateStrategyStats(
+                name=name,
+                trades=sum(s.trades for s in group),
+                buys=sum(s.buys for s in group),
+                sells=total_sells,
+                win_rate=round(agg_wr, 4),
+                pnl=round(total_pnl, 2),
+            )
+        )
+    return result
 
 
 @dataclass
@@ -68,6 +105,7 @@ class BacktestResult:
     efficiency_ratio: float  # test_return / train_return (0 if no split)
     strategy_stats: list[StrategyStats]
     unrealized_pnl: float  # mark-to-market gain on positions still held at end
+    unrealized_pnl_by_ticker: dict[str, float]  # per-ticker unrealized P&L
     basis_per_sell: list[float]  # cost basis for each SELL trade (parallel list)
 
 
@@ -237,15 +275,15 @@ def compute_strategy_stats(
     trades: list[TradeRecord],
     basis_per_sell: list[float],
 ) -> list[StrategyStats]:
-    """Compute per-strategy trade breakdown."""
+    """Compute per-(strategy, ticker) trade breakdown."""
     sell_basis: dict[int, float] = {id(t): b for t, b in _pair_sells_with_basis(trades, basis_per_sell)}
 
-    by_strategy: dict[str, list[TradeRecord]] = defaultdict(list)
+    by_key: dict[tuple[str, str], list[TradeRecord]] = defaultdict(list)
     for t in trades:
-        by_strategy[t.strategy_name].append(t)
+        by_key[(t.strategy_name, t.ticker)].append(t)
 
     stats: list[StrategyStats] = []
-    for name, strades in sorted(by_strategy.items()):
+    for (name, ticker), strades in sorted(by_key.items()):
         buys = [t for t in strades if t.direction == Direction.BUY]
         sells = [t for t in strades if t.direction == Direction.SELL]
         winning_sells = 0
@@ -260,6 +298,7 @@ def compute_strategy_stats(
         stats.append(
             StrategyStats(
                 name=name,
+                ticker=ticker,
                 trades=len(strades),
                 buys=len(buys),
                 sells=len(sells),
@@ -969,11 +1008,12 @@ class BacktestEngine:
         strategy_stats = compute_strategy_stats(state.trades, state.basis_per_sell)
 
         # Unrealized P&L: mark-to-market gain on positions still held at end.
-        unrealized_pnl = sum(
-            lot.shares * (final_prices.get(ticker, 0.0) - lot.cost_basis)
-            for ticker, lots in state.lots.items()
-            for lot in lots
-        )
+        unrealized_pnl_by_ticker: dict[str, float] = {}
+        for ticker, lots in state.lots.items():
+            ticker_pnl = sum(lot.shares * (final_prices.get(ticker, 0.0) - lot.cost_basis) for lot in lots)
+            if lots:
+                unrealized_pnl_by_ticker[ticker] = round(ticker_pnl, 2)
+        unrealized_pnl = sum(unrealized_pnl_by_ticker.values())
 
         return BacktestResult(
             trades=state.trades,
@@ -1000,6 +1040,7 @@ class BacktestEngine:
             efficiency_ratio=round(efficiency, 4),
             strategy_stats=strategy_stats,
             unrealized_pnl=round(unrealized_pnl, 2),
+            unrealized_pnl_by_ticker=unrealized_pnl_by_ticker,
             basis_per_sell=state.basis_per_sell,
         )
 
@@ -1107,11 +1148,14 @@ def _write_summary_json(result: BacktestResult, path: Path) -> None:
 def _write_strategy_breakdown_csv(result: BacktestResult, path: Path) -> None:
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["strategy", "trades", "buys", "sells", "win_rate", "pnl"])
+        writer.writerow(["strategy", "ticker", "trades", "buys", "sells", "win_rate", "pnl"])
+
+        # Per-(strategy, ticker) rows
         for s in result.strategy_stats:
             writer.writerow(
                 [
                     s.name,
+                    s.ticker,
                     s.trades,
                     s.buys,
                     s.sells,
@@ -1119,4 +1163,22 @@ def _write_strategy_breakdown_csv(result: BacktestResult, path: Path) -> None:
                     round(s.pnl, 2) if s.sells > 0 else "",
                 ]
             )
-        writer.writerow(["Open Positions", "", "", "", "", round(result.unrealized_pnl, 2)])
+
+        # Aggregate per-strategy rows
+        for a in aggregate_strategy_stats(result.strategy_stats):
+            writer.writerow(
+                [
+                    a.name,
+                    "*",
+                    a.trades,
+                    a.buys,
+                    a.sells,
+                    a.win_rate if a.sells > 0 else "",
+                    a.pnl if a.sells > 0 else "",
+                ]
+            )
+
+        # Per-ticker open positions
+        for ticker, pnl in sorted(result.unrealized_pnl_by_ticker.items()):
+            writer.writerow(["Open Positions", ticker, "", "", "", "", round(pnl, 2)])
+        writer.writerow(["Open Positions", "*", "", "", "", "", round(result.unrealized_pnl, 2)])

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -125,19 +125,23 @@ def compute_cagr(starting: float, final: float, days: int) -> float:
     return float((final / starting) ** (1.0 / years) - 1.0)
 
 
-def compute_max_drawdown(equity_curve: list[tuple[date, float]]) -> float:
-    """Maximum peak-to-trough percentage decline."""
-    if len(equity_curve) < 2:
-        return 0.0
+def _drawdown_series(equity_curve: list[tuple[date, float]]) -> list[float]:
+    """Per-point drawdown (fraction from running peak) for each equity curve entry."""
+    if not equity_curve:
+        return []
     peak = equity_curve[0][1]
-    max_dd = 0.0
+    result: list[float] = []
     for _, value in equity_curve:
         if value > peak:
             peak = value
-        dd = (peak - value) / peak if peak > 0 else 0.0
-        if dd > max_dd:
-            max_dd = dd
-    return max_dd
+        result.append((peak - value) / peak if peak > 0 else 0.0)
+    return result
+
+
+def compute_max_drawdown(equity_curve: list[tuple[date, float]]) -> float:
+    """Maximum peak-to-trough percentage decline."""
+    dd = _drawdown_series(equity_curve)
+    return max(dd) if len(dd) >= 2 else 0.0
 
 
 def compute_sharpe(equity_curve: list[tuple[date, float]]) -> float:
@@ -1014,7 +1018,7 @@ def write_backtest_results(result: BacktestResult, output_dir: Path) -> None:
 
 
 def _write_trades_csv(result: BacktestResult, path: Path) -> None:
-    sell_idx = 0
+    sell_basis = {id(t): b for t, b in _pair_sells_with_basis(result.trades, result.basis_per_sell)}
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
@@ -1032,51 +1036,31 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
             ]
         )
         for t in result.trades:
+            common = [
+                t.date.isoformat(),
+                t.ticker,
+                t.direction.value,
+                t.shares,
+                t.price,
+                t.strategy_name,
+                t.holding_period.value if t.holding_period else "",
+            ]
             if t.direction == Direction.SELL:
-                basis = result.basis_per_sell[sell_idx] if sell_idx < len(result.basis_per_sell) else t.price
+                basis = sell_basis.get(id(t), t.price)
                 pnl = round((t.price - basis) * t.shares, 4)
                 ret = round((t.price - basis) / basis, 6) if basis != 0 else 0.0
-                sell_idx += 1
-                writer.writerow(
-                    [
-                        t.date.isoformat(),
-                        t.ticker,
-                        t.direction.value,
-                        t.shares,
-                        t.price,
-                        t.strategy_name,
-                        t.holding_period.value if t.holding_period else "",
-                        round(basis, 4),
-                        pnl,
-                        ret,
-                    ]
-                )
+                writer.writerow([*common, round(basis, 4), pnl, ret])
             else:
-                writer.writerow(
-                    [
-                        t.date.isoformat(),
-                        t.ticker,
-                        t.direction.value,
-                        t.shares,
-                        t.price,
-                        t.strategy_name,
-                        "",
-                        "",
-                        "",
-                        "",
-                    ]
-                )
+                writer.writerow([*common, "", "", ""])
 
 
 def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
+    drawdowns = _drawdown_series(result.equity_curve)
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["date", "nav", "drawdown"])
-        peak = 0.0
-        for d, nav in result.equity_curve:
-            peak = max(peak, nav)
-            dd = round((peak - nav) / peak, 6) if peak > 0 else 0.0
-            writer.writerow([d.isoformat(), round(nav, 2), dd])
+        for (d, nav), dd in zip(result.equity_curve, drawdowns, strict=True):
+            writer.writerow([d.isoformat(), round(nav, 2), round(dd, 6)])
 
 
 def _write_summary_json(result: BacktestResult, path: Path) -> None:

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -31,10 +31,10 @@ from midas.strategies.base import ExitRule, max_warmup
 
 @dataclass
 class StrategyStats:
-    """Per-strategy, per-ticker performance breakdown."""
+    """Per-strategy performance breakdown, optionally scoped to a ticker."""
 
     name: str
-    ticker: str
+    ticker: str | None
     trades: int
     buys: int
     sells: int
@@ -42,32 +42,21 @@ class StrategyStats:
     pnl: float  # total realized P&L from sells
 
 
-@dataclass
-class AggregateStrategyStats:
-    """Per-strategy totals aggregated across all tickers."""
-
-    name: str
-    trades: int
-    buys: int
-    sells: int
-    win_rate: float
-    pnl: float
-
-
-def aggregate_strategy_stats(stats: list[StrategyStats]) -> list[AggregateStrategyStats]:
+def aggregate_strategy_stats(stats: list[StrategyStats]) -> list[StrategyStats]:
     """Aggregate per-(strategy, ticker) stats into per-strategy totals."""
     by_strategy: dict[str, list[StrategyStats]] = defaultdict(list)
     for s in stats:
         by_strategy[s.name].append(s)
-    result: list[AggregateStrategyStats] = []
+    result: list[StrategyStats] = []
     for name, group in sorted(by_strategy.items()):
         total_sells = sum(s.sells for s in group)
         total_pnl = sum(s.pnl for s in group)
         winning = sum(round(s.win_rate * s.sells) for s in group)
         agg_wr = winning / total_sells if total_sells > 0 else 0.0
         result.append(
-            AggregateStrategyStats(
+            StrategyStats(
                 name=name,
+                ticker=None,
                 trades=sum(s.trades for s in group),
                 buys=sum(s.buys for s in group),
                 sells=total_sells,

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -9,7 +9,7 @@ import click
 import pandas as pd
 
 from midas.allocator import Allocator
-from midas.backtest import DEFAULT_TRAIN_PCT, BacktestEngine, write_backtest_csv
+from midas.backtest import DEFAULT_TRAIN_PCT, BacktestEngine, write_backtest_results
 from midas.config import load_portfolio, load_strategies
 from midas.data import CachedYFinanceProvider
 from midas.models import (
@@ -116,8 +116,8 @@ def cli() -> None:
 @click.option(
     "--output",
     "-o",
-    default="backtest_results.csv",
-    help="Output CSV path.",
+    default="backtest_results",
+    help="Output directory path.",
 )
 @click.option(
     "--train-pct",
@@ -164,8 +164,8 @@ def backtest(
     result = engine.run(port, price_data, start_d, end_d)
 
     out_path = Path(output)
-    write_backtest_csv(result, out_path)
-    print_status(f"Results written to {out_path}")
+    write_backtest_results(result, out_path)
+    print_status(f"Results written to {out_path}/")
     print_backtest_summary(result)
 
 

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from midas.backtest import aggregate_strategy_stats
 from midas.models import Direction, Order
 from midas.strategies.base import Strategy
 
@@ -177,31 +178,30 @@ def print_backtest_summary(result: BacktestResult) -> None:
         trade_table.add_row("Avg Loss", f"[red]${result.avg_loss:,.2f}[/red]")
         print_centered(trade_table)
 
-    # --- Per-Strategy Breakdown ---
+    # --- Per-Strategy Breakdown (aggregate) ---
     if result.strategy_stats:
-        strat_table = make_wide_table("Strategy Breakdown")
-        strat_table.add_column("Strategy", style="bold")
-        strat_table.add_column("Trades", justify="right")
-        strat_table.add_column("Buys", justify="right")
-        strat_table.add_column("Sells", justify="right")
-        strat_table.add_column("Win Rate", justify="right")
-        strat_table.add_column("P&L", justify="right")
+        agg_table = make_wide_table("Strategy Breakdown")
+        agg_table.add_column("Strategy", style="bold")
+        agg_table.add_column("Trades", justify="right")
+        agg_table.add_column("Buys", justify="right")
+        agg_table.add_column("Sells", justify="right")
+        agg_table.add_column("Win Rate", justify="right")
+        agg_table.add_column("P&L", justify="right")
 
-        for s in result.strategy_stats:
-            pnl_style = "green" if s.pnl >= 0 else "red"
-            strat_table.add_row(
-                s.name,
-                str(s.trades),
-                str(s.buys),
-                str(s.sells),
-                f"{s.win_rate:.0%}" if s.sells > 0 else "—",
-                f"[{pnl_style}]${s.pnl:,.2f}[/{pnl_style}]" if s.sells > 0 else "—",
+        for a in aggregate_strategy_stats(result.strategy_stats):
+            pnl_style = "green" if a.pnl >= 0 else "red"
+            agg_table.add_row(
+                a.name,
+                str(a.trades),
+                str(a.buys),
+                str(a.sells),
+                f"{a.win_rate:.0%}" if a.sells > 0 else "—",
+                f"[{pnl_style}]${a.pnl:,.2f}[/{pnl_style}]" if a.sells > 0 else "—",
             )
 
-        # Unrealized P&L from positions still held at end of backtest.
         unr = result.unrealized_pnl
         unr_style = "green" if unr >= 0 else "red"
-        strat_table.add_row(
+        agg_table.add_row(
             "[dim]Open Positions[/dim]",
             "—",
             "—",
@@ -210,7 +210,44 @@ def print_backtest_summary(result: BacktestResult) -> None:
             f"[{unr_style}]${unr:,.2f}[/{unr_style}]",
         )
 
-        print_centered(strat_table)
+        print_centered(agg_table)
+
+        # --- Strategy x Ticker Breakdown ---
+        detail_table = make_wide_table("Strategy x Ticker Breakdown")
+        detail_table.add_column("Strategy", style="bold")
+        detail_table.add_column("Ticker", style="bold")
+        detail_table.add_column("Trades", justify="right")
+        detail_table.add_column("Buys", justify="right")
+        detail_table.add_column("Sells", justify="right")
+        detail_table.add_column("Win Rate", justify="right")
+        detail_table.add_column("P&L", justify="right")
+
+        for s in result.strategy_stats:
+            pnl_style = "green" if s.pnl >= 0 else "red"
+            detail_table.add_row(
+                s.name,
+                s.ticker,
+                str(s.trades),
+                str(s.buys),
+                str(s.sells),
+                f"{s.win_rate:.0%}" if s.sells > 0 else "—",
+                f"[{pnl_style}]${s.pnl:,.2f}[/{pnl_style}]" if s.sells > 0 else "—",
+            )
+
+        detail_table.add_section()
+        for ticker, pnl in sorted(result.unrealized_pnl_by_ticker.items()):
+            pnl_style = "green" if pnl >= 0 else "red"
+            detail_table.add_row(
+                "[dim]Open Positions[/dim]",
+                ticker,
+                "—",
+                "—",
+                "—",
+                "—",
+                f"[{pnl_style}]${pnl:,.2f}[/{pnl_style}]",
+            )
+
+        print_centered(detail_table)
         console.print(
             "[dim italic]Note: P&L is credited to the exit strategy. "
             "Open Positions shows unrealized gain/loss on shares still "

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,5 +1,7 @@
 """Tests for the backtest engine."""
 
+import csv as csv_mod
+import json
 import math
 from datetime import date
 from pathlib import Path
@@ -13,6 +15,7 @@ from midas.allocator import Allocator
 from midas.backtest import (
     TRADING_DAYS_PER_YEAR,
     BacktestEngine,
+    BacktestResult,
     _SimState,
     compute_cagr,
     compute_max_drawdown,
@@ -136,15 +139,9 @@ def test_backtest_results_output(tmp_path: Path) -> None:
     out_dir = tmp_path / "results"
     write_backtest_results(result, out_dir)
 
-    # Directory created with all 4 files
     assert out_dir.is_dir()
-    assert (out_dir / "trades.csv").exists()
-    assert (out_dir / "equity_curve.csv").exists()
-    assert (out_dir / "summary.json").exists()
-    assert (out_dir / "strategy_breakdown.csv").exists()
-
-    # trades.csv: parseable, raw numbers, has expected columns
-    import csv as csv_mod
+    for name in ("trades.csv", "equity_curve.csv", "summary.json", "strategy_breakdown.csv"):
+        assert (out_dir / name).exists()
 
     with open(out_dir / "trades.csv") as f:
         reader = csv_mod.DictReader(f)
@@ -167,32 +164,22 @@ def test_backtest_results_output(tmp_path: Path) -> None:
         assert "%" not in row.get("return_pct", "")
         assert row["ticker"] == "AAPL"
 
-    # equity_curve.csv: parseable, has drawdown column
     with open(out_dir / "equity_curve.csv") as f:
         reader = csv_mod.DictReader(f)
         curve_rows = list(reader)
     assert len(curve_rows) > 0
-    assert "nav" in reader.fieldnames  # type: ignore[operator]
-    assert "drawdown" in reader.fieldnames  # type: ignore[operator]
     for row in curve_rows:
         assert float(row["nav"]) > 0
         assert float(row["drawdown"]) >= 0
 
-    # summary.json: parseable, has key fields
-    import json
-
     with open(out_dir / "summary.json") as f:
         summary = json.load(f)
-    assert "starting_value" in summary
-    assert "final_value" in summary
-    assert "sharpe_ratio" in summary
-    assert "split" in summary  # split was enabled
     assert isinstance(summary["starting_value"], (int, float))
+    assert "sharpe_ratio" in summary
+    assert "split" in summary
 
-    # strategy_breakdown.csv: parseable
     with open(out_dir / "strategy_breakdown.csv") as f:
-        reader = csv_mod.DictReader(f)
-        strat_rows = list(reader)
+        strat_rows = list(csv_mod.DictReader(f))
     assert len(strat_rows) > 0
 
 
@@ -200,11 +187,33 @@ def test_write_backtest_results_rejects_existing_file(tmp_path: Path) -> None:
     existing_file = tmp_path / "results"
     existing_file.write_text("oops")
 
-    portfolio, price_data = _make_backtest_data()
-    engine = _build_engine(entries=[(MeanReversion(window=20, threshold=0.05), 1.0)])
-    start = min(price_data["AAPL"].index)
-    end = max(price_data["AAPL"].index)
-    result = engine.run(portfolio, price_data, start, end)
+    result = BacktestResult(
+        trades=[],
+        final_value=0,
+        starting_value=0,
+        buy_and_hold_value=0,
+        train_trades=[],
+        test_trades=[],
+        train_return=0,
+        test_return=0,
+        train_bh_return=0,
+        test_bh_return=0,
+        split_date=None,
+        twr=0,
+        equity_curve=[],
+        cagr=0,
+        max_drawdown=0,
+        sharpe_ratio=0,
+        sortino_ratio=0,
+        win_rate=0,
+        profit_factor=0,
+        avg_win=0,
+        avg_loss=0,
+        efficiency_ratio=0,
+        strategy_stats=[],
+        unrealized_pnl=0,
+        basis_per_sell=[],
+    )
 
     with pytest.raises(FileExistsError, match="existing file"):
         write_backtest_results(result, existing_file)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -212,6 +212,7 @@ def test_write_backtest_results_rejects_existing_file(tmp_path: Path) -> None:
         efficiency_ratio=0,
         strategy_stats=[],
         unrealized_pnl=0,
+        unrealized_pnl_by_ticker={},
         basis_per_sell=[],
     )
 

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 from conftest import make_price_series
 
 from midas.allocator import Allocator
@@ -19,7 +20,7 @@ from midas.backtest import (
     compute_sortino,
     compute_strategy_stats,
     compute_trade_stats,
-    write_backtest_csv,
+    write_backtest_results,
 )
 from midas.models import (
     AllocationConstraints,
@@ -120,7 +121,7 @@ def test_backtest_with_split() -> None:
     assert start < result.split_date < end
 
 
-def test_backtest_csv_output(tmp_path: Path) -> None:
+def test_backtest_results_output(tmp_path: Path) -> None:
     portfolio, price_data = _make_backtest_data()
     mr = MeanReversion(window=20, threshold=0.05)
     engine = _build_engine(
@@ -132,13 +133,81 @@ def test_backtest_csv_output(tmp_path: Path) -> None:
     end = max(price_data["AAPL"].index)
     result = engine.run(portfolio, price_data, start, end)
 
-    csv_path = tmp_path / "results.csv"
-    write_backtest_csv(result, csv_path)
+    out_dir = tmp_path / "results"
+    write_backtest_results(result, out_dir)
 
-    content = csv_path.read_text()
-    assert "TRADE LOG" in content
-    assert "SUMMARY" in content
-    assert "AAPL" in content
+    # Directory created with all 4 files
+    assert out_dir.is_dir()
+    assert (out_dir / "trades.csv").exists()
+    assert (out_dir / "equity_curve.csv").exists()
+    assert (out_dir / "summary.json").exists()
+    assert (out_dir / "strategy_breakdown.csv").exists()
+
+    # trades.csv: parseable, raw numbers, has expected columns
+    import csv as csv_mod
+
+    with open(out_dir / "trades.csv") as f:
+        reader = csv_mod.DictReader(f)
+        rows = list(reader)
+    assert len(rows) > 0
+    assert set(reader.fieldnames) == {  # type: ignore[arg-type]
+        "date",
+        "ticker",
+        "direction",
+        "shares",
+        "price",
+        "strategy",
+        "holding_period",
+        "cost_basis",
+        "realized_pnl",
+        "return_pct",
+    }
+    for row in rows:
+        assert "$" not in row["price"]
+        assert "%" not in row.get("return_pct", "")
+        assert row["ticker"] == "AAPL"
+
+    # equity_curve.csv: parseable, has drawdown column
+    with open(out_dir / "equity_curve.csv") as f:
+        reader = csv_mod.DictReader(f)
+        curve_rows = list(reader)
+    assert len(curve_rows) > 0
+    assert "nav" in reader.fieldnames  # type: ignore[operator]
+    assert "drawdown" in reader.fieldnames  # type: ignore[operator]
+    for row in curve_rows:
+        assert float(row["nav"]) > 0
+        assert float(row["drawdown"]) >= 0
+
+    # summary.json: parseable, has key fields
+    import json
+
+    with open(out_dir / "summary.json") as f:
+        summary = json.load(f)
+    assert "starting_value" in summary
+    assert "final_value" in summary
+    assert "sharpe_ratio" in summary
+    assert "split" in summary  # split was enabled
+    assert isinstance(summary["starting_value"], (int, float))
+
+    # strategy_breakdown.csv: parseable
+    with open(out_dir / "strategy_breakdown.csv") as f:
+        reader = csv_mod.DictReader(f)
+        strat_rows = list(reader)
+    assert len(strat_rows) > 0
+
+
+def test_write_backtest_results_rejects_existing_file(tmp_path: Path) -> None:
+    existing_file = tmp_path / "results"
+    existing_file.write_text("oops")
+
+    portfolio, price_data = _make_backtest_data()
+    engine = _build_engine(entries=[(MeanReversion(window=20, threshold=0.05), 1.0)])
+    start = min(price_data["AAPL"].index)
+    end = max(price_data["AAPL"].index)
+    result = engine.run(portfolio, price_data, start, end)
+
+    with pytest.raises(FileExistsError, match="existing file"):
+        write_backtest_results(result, existing_file)
 
 
 def test_backtest_cost_basis_uses_start_price() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,7 @@ import yaml
 from conftest import make_price_series
 
 from midas.allocator import Allocator
-from midas.backtest import BacktestEngine, write_backtest_csv
+from midas.backtest import BacktestEngine, write_backtest_results
 from midas.config import load_portfolio, load_strategies
 from midas.models import Direction
 from midas.order_sizer import OrderSizer
@@ -102,14 +102,21 @@ def test_full_pipeline(tmp_path: Path) -> None:
     directions = {t.direction for t in result.trades}
     assert Direction.BUY in directions
 
-    # 8. Write CSV and verify
-    csv_path = tmp_path / "integration_results.csv"
-    write_backtest_csv(result, csv_path)
+    # 8. Write results directory and verify
+    out_dir = tmp_path / "integration_results"
+    write_backtest_results(result, out_dir)
 
-    content = csv_path.read_text()
-    assert "TRADE LOG" in content
-    assert "SUMMARY" in content
-    assert "OUT-OF-SAMPLE SPLIT" in content
+    assert out_dir.is_dir()
+    assert (out_dir / "trades.csv").exists()
+    assert (out_dir / "equity_curve.csv").exists()
+    assert (out_dir / "summary.json").exists()
+    assert (out_dir / "strategy_breakdown.csv").exists()
+
+    import json
+
+    with open(out_dir / "summary.json") as f:
+        summary = json.load(f)
+    assert "split" in summary  # split was enabled
 
 
 def test_strategy_registry_complete() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 """Integration test — full pipeline from config to backtest output."""
 
+import json
 from datetime import date
 from pathlib import Path
 
@@ -111,8 +112,6 @@ def test_full_pipeline(tmp_path: Path) -> None:
     assert (out_dir / "equity_curve.csv").exists()
     assert (out_dir / "summary.json").exists()
     assert (out_dir / "strategy_breakdown.csv").exists()
-
-    import json
 
     with open(out_dir / "summary.json") as f:
         summary = json.load(f)


### PR DESCRIPTION
## Summary

Closes #37.

- Replaces `write_backtest_csv` (unparseable concatenated sections with `$`/`%` formatting) with `write_backtest_results`, which writes a directory of 4 files: `trades.csv`, `equity_curve.csv`, `summary.json`, `strategy_breakdown.csv`
- All numeric values are raw — no formatting. Every file parseable by `pandas.read_csv` / `json.load` out of the box
- Adds `basis_per_sell` to `BacktestResult` so per-trade cost basis, realized P&L, and return % are exported in `trades.csv` for sells
- Guards against writing to an existing file path (`FileExistsError`)
- CLI `--output` default changes from `backtest_results.csv` to `backtest_results/`

## Test plan

- [x] `uv run pytest` — 167 tests pass
- [x] `uv run mypy src/midas/backtest.py src/midas/cli.py` — clean
- [x] New test verifies all 4 output files exist and are parseable with correct columns
- [x] New test verifies `FileExistsError` on existing file path
- [ ] Integration test updated for directory output

🤖 Generated with [Claude Code](https://claude.com/claude-code)