### PR TITLE
Clarify Open Positions row as unrealized P&L

### DIFF
--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -1169,5 +1169,5 @@ def _write_strategy_breakdown_csv(result: BacktestResult, path: Path) -> None:
 
         # Per-ticker open positions
         for ticker, pnl in sorted(result.unrealized_pnl_by_ticker.items()):
-            writer.writerow(["Open Positions", ticker, "", "", "", "", round(pnl, 2)])
-        writer.writerow(["Open Positions", "*", "", "", "", "", round(result.unrealized_pnl, 2)])
+            writer.writerow(["Open Positions (Unrealized)", ticker, "", "", "", "", round(pnl, 2)])
+        writer.writerow(["Open Positions (Unrealized)", "*", "", "", "", "", round(result.unrealized_pnl, 2)])

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -202,7 +202,7 @@ def print_backtest_summary(result: BacktestResult) -> None:
         unr = result.unrealized_pnl
         unr_style = "green" if unr >= 0 else "red"
         agg_table.add_row(
-            "[dim]Open Positions[/dim]",
+            "[dim]Open Positions (Unrealized)[/dim]",
             "—",
             "—",
             "—",
@@ -238,7 +238,7 @@ def print_backtest_summary(result: BacktestResult) -> None:
         for ticker, pnl in sorted(result.unrealized_pnl_by_ticker.items()):
             pnl_style = "green" if pnl >= 0 else "red"
             detail_table.add_row(
-                "[dim]Open Positions[/dim]",
+                "[dim]Open Positions (Unrealized)[/dim]",
                 ticker,
                 "—",
                 "—",


### PR DESCRIPTION
## Summary
- Rename the "Open Positions" row in the strategy breakdown table and `strategy_breakdown.csv` to "Open Positions (Unrealized)" so readers don't mistake the negative P&L column for a negative position value.

## Context
A backtest showed `Open Positions | AAPL | -$11,544.51` and read as if the ticker held a negative position. It's actually the unrealized mark-to-market delta on 593 still-held shares (cost basis $271.11, final close $251.64) — a legitimate underwater lot, not negative shares. The column is labeled `P&L` with a footer note, but the row label was ambiguous enough to be misread. Explicit `(Unrealized)` kills the ambiguity.

## Test plan
- [x] Rerun backtest; verify row reads `Open Positions (Unrealized)` in the Rich table
- [x] Verify `strategy_breakdown.csv` reflects the new label
- [x] Pre-commit hooks (ruff, mypy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)