### PR TITLE
Add ChandelierStop exit rule

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -22,6 +22,7 @@ To add a new strategy: implement `EntrySignal` or `ExitRule` in a new file under
 | MovingAverageCrossover | Entry | Bullish on the golden cross (short MA above long MA) |
 | RSIOversold | Entry | Bullish when RSI dips below 50 (oversold conditions) |
 | VWAPReversion | Entry | Bullish when price is below the average price (VWAP proxy) |
+| ChandelierStop | Exit | Clamps target to 0 when price falls k x ATR below the rolling N-bar high |
 | MACDExit | Exit | Clamps target to 0 on a bearish MACD crossover |
 | MovingAverageCrossoverExit | Exit | Clamps target to 0 on the death cross |
 | ProfitTaking | Exit | Clamps target to 0 when unrealized gain exceeds the threshold |
@@ -46,7 +47,7 @@ A strategy file needs at least one entry signal and at least one exit rule. With
 
 - **[Trend-Following](../example-strategies/trend-following.yaml)** — Two entry signals (`MovingAverageCrossover` + `MACDCrossover`) confirmed across timescales, paired with their symmetric exits (`MovingAverageCrossoverExit` + `MACDExit`) and a `ProfitTaking` target.
 - **[Dip-Buying](../example-strategies/dip-buying.yaml)** — `BollingerBand` and `RSIOversold` for independent confirmation that an asset is oversold, protected by a `StopLoss` floor.
-- **[Balanced Growth](../example-strategies/balanced-growth.yaml)** — `Momentum` and `MeanReversion` give entries in both trending and recovering markets; `ProfitTaking` and `TrailingStop` provide layered exits.
+- **[Balanced Growth](../example-strategies/balanced-growth.yaml)** — `Momentum` and `MeanReversion` give entries in both trending and recovering markets; `ProfitTaking` harvests gains at a fixed target and `ChandelierStop` provides a volatility-adjusted trailing stop that works whether the position is in profit or underwater.
 
 ## Entry Signals
 
@@ -234,6 +235,25 @@ Clamps the target weight to 0 when the position's drawdown from its aggregate hi
 **Suited for**: All asset classes
 
 **Interactions**: Complements `StopLoss` and `ProfitTaking`. `ProfitTaking` exits at a fixed gain threshold; `TrailingStop` dynamically protects whatever gains have accumulated, even beyond that threshold. Together they create layered exits: `ProfitTaking` harvests at the target, `TrailingStop` catches sharp reversals after gains have run further.
+
+---
+
+### ChandelierStop
+
+**Type**: Exit rule
+
+A volatility-adjusted trailing stop based on Chuck LeBeau's Chandelier Exit. Clamps the target weight to 0 when the current price falls more than `multiplier` × ATR below the highest close over the most recent `window` bars. ATR is approximated from close-to-close absolute differences since the engine's price history is close-only.
+
+Unlike `TrailingStop`, `ChandelierStop` uses a rolling window high rather than an all-time high-water-mark since entry, so its reference point breathes with the recent price range rather than being pinned to a months-old peak. It also has no `in_profit` gate — it fires on both profitable and losing positions, which makes it a drop-in replacement for `StopLoss + TrailingStop` rather than a layered partner. The stop distance scales with realized volatility, so the same `multiplier` produces a tighter stop in calm markets and a wider stop in choppy ones.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 22 | Rolling lookback for both the highest close and the ATR (trading days) |
+| `multiplier` | 3.0 | ATR multiple that sets the stop distance below the rolling high |
+
+**Suited for**: All asset classes
+
+**Interactions**: Generally substitutes for the `StopLoss` + `TrailingStop` pair — stacking all three produces overlapping protection with unclear attribution. Still pairs cleanly with `ProfitTaking` as the gain-harvest mechanism. Useful when fixed-percent stops feel regime-ignorant, since a single `multiplier` adapts across tickers with different volatility profiles.
 
 ---
 

--- a/example-strategies/README.md
+++ b/example-strategies/README.md
@@ -40,6 +40,6 @@ Moderately aggressive entries with disciplined exits. Two entries push you in, t
 
 - **Profit Taking** (20% threshold, exit) — trims lots whose unrealized gain exceeds 20%. A fixed target that ensures profits get harvested from winners.
 
-- **Trailing Stop** (10% trail, exit) — tracks the highest price each lot reaches after purchase (the "high-water mark") and sells if the price drops 10% from that peak — but only while above cost basis. Dynamically adjusts upward as the price rises, protecting gains without capping upside. Unlike a regular stop loss, it never forces a sell at a loss.
+- **Chandelier Stop** (22-day window, 3.0× ATR, exit) — a volatility-adjusted trailing stop. Tracks the highest close over the last 22 days and sells if the current price falls more than 3× the recent average true range below that high. Unlike a fixed-percent trailing stop, the stop distance breathes with realized volatility — tighter in calm markets, wider in choppy ones — and the rolling-window reference high keeps the stop responsive to recent price action instead of anchoring to a months-old peak. Fires on both profitable and underwater positions, so it subsumes the role of a separate stop loss.
 
 Best for: a general-purpose portfolio that balances growth capture with downside protection.

--- a/example-strategies/balanced-growth.yaml
+++ b/example-strategies/balanced-growth.yaml
@@ -20,6 +20,7 @@ strategies:
     params:
       gain_threshold: 0.20
 
-  - name: TrailingStop
+  - name: ChandelierStop
     params:
-      trail_pct: 0.10
+      window: 22
+      multiplier: 3.0

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -100,6 +100,10 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float]]] = {
     "StopLoss": {
         "loss_threshold": (0.05, 0.25, 0.02),
     },
+    "ChandelierStop": {
+        "window": (10, 40, 2),
+        "multiplier": (1.5, 5.0, 0.25),
+    },
     "MACDExit": {
         "fast_period": (8, 16, 2),
         "slow_period": (20, 40, 2),

--- a/src/midas/strategies/__init__.py
+++ b/src/midas/strategies/__init__.py
@@ -2,6 +2,7 @@
 
 from midas.strategies.base import EntrySignal, ExitRule, Strategy
 from midas.strategies.bollinger_band import BollingerBand
+from midas.strategies.chandelier_stop import ChandelierStop
 from midas.strategies.gap_down_recovery import GapDownRecovery
 from midas.strategies.ma_crossover import MovingAverageCrossover
 from midas.strategies.ma_crossover_exit import MovingAverageCrossoverExit
@@ -26,6 +27,7 @@ STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
     "RSIOversold": RSIOversold,
     "VWAPReversion": VWAPReversion,
     # Exit rules
+    "ChandelierStop": ChandelierStop,
     "MACDExit": MACDExit,
     "MovingAverageCrossoverExit": MovingAverageCrossoverExit,
     "ProfitTaking": ProfitTaking,
@@ -36,6 +38,7 @@ STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
 __all__ = [
     "STRATEGY_REGISTRY",
     "BollingerBand",
+    "ChandelierStop",
     "EntrySignal",
     "ExitRule",
     "GapDownRecovery",

--- a/src/midas/strategies/chandelier_stop.py
+++ b/src/midas/strategies/chandelier_stop.py
@@ -1,0 +1,73 @@
+"""Chandelier exit: k x ATR trailing stop off the rolling N-bar highest close."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from midas.models import AssetSuitability
+from midas.strategies.base import ExitRule
+
+
+class ChandelierStop(ExitRule):
+    def __init__(self, window: int = 22, multiplier: float = 3.0) -> None:
+        self._window = window
+        self._multiplier = multiplier
+
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
+    def _stop_level(self, price_history: np.ndarray) -> float | None:
+        if len(price_history) < self._window:
+            return None
+        recent = price_history[-self._window :]
+        highest = float(recent.max())
+        atr = float(np.abs(np.diff(recent)).mean())
+        return highest - self._multiplier * atr
+
+    def clamp_target(
+        self,
+        ticker: str,
+        proposed_target: float,
+        price_history: np.ndarray,
+        cost_basis: float,
+        high_water_mark: float,
+    ) -> float:
+        if proposed_target <= 0:
+            return proposed_target
+        stop = self._stop_level(price_history)
+        if stop is None:
+            return proposed_target
+        current = float(price_history[-1])
+        if current < stop:
+            return 0.0
+        return proposed_target
+
+    def clamp_reason(
+        self,
+        ticker: str,
+        price_history: np.ndarray,
+        cost_basis: float,
+        high_water_mark: float,
+    ) -> str:
+        recent = price_history[-self._window :]
+        highest = float(recent.max())
+        atr = float(np.abs(np.diff(recent)).mean()) if len(recent) > 1 else 0.0
+        stop = highest - self._multiplier * atr
+        current = float(price_history[-1])
+        return (
+            f"ChandelierStop: price ${current:.2f} below "
+            f"${stop:.2f} (${highest:.2f} peak - "
+            f"{self._multiplier:.1f} x ${atr:.2f} ATR{self._window})"
+        )
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Sell when price falls {self._multiplier:.1f} x ATR below the "
+            f"rolling {self._window}-bar high (volatility-adjusted trailing stop)"
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -131,6 +131,7 @@ def test_strategy_registry_complete() -> None:
         "RSIOversold",
         "VWAPReversion",
         # exit rules
+        "ChandelierStop",
         "MACDExit",
         "MovingAverageCrossoverExit",
         "ProfitTaking",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from midas.strategies.base import MIN_WARMUP_CALENDAR_DAYS, warmup_bars_to_calendar_days
 from midas.strategies.bollinger_band import BollingerBand
+from midas.strategies.chandelier_stop import ChandelierStop
 from midas.strategies.gap_down_recovery import GapDownRecovery
 from midas.strategies.ma_crossover import MovingAverageCrossover
 from midas.strategies.ma_crossover_exit import MovingAverageCrossoverExit
@@ -198,6 +199,73 @@ class TestTrailingStop:
         assert result == 0.10
 
 
+class TestChandelierStop:
+    """Volatility-adjusted trailing stop: k x ATR below the rolling N-bar high."""
+
+    def test_fires_when_drawdown_exceeds_k_atr(self) -> None:
+        # 21 bars rising by $1 (101..121), then a 5-point jump to 125 (peak),
+        # then a 15-point crash to 110. Last 22 bars cover everything after bar 0.
+        # |diffs| over the window: 20 ones + 4 (one of the ones absorbed) + 15 = ...
+        # Concretely: close-to-close ATR ≈ 1.86, highest = 125, stop ≈ 119.4.
+        # Current = 110 < 119.4 → fire.
+        prices = np.concatenate(
+            [
+                np.arange(100.0, 121.0, 1.0),  # 21 bars: 100..120
+                np.array([125.0, 110.0]),  # peak then crash
+            ]
+        )
+        rule = ChandelierStop(window=22, multiplier=3.0)
+        result = rule.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=125.0)
+        assert result == 0.0
+
+    def test_no_fire_on_steady_rise(self) -> None:
+        # All-increasing prices: current == highest, no drawdown at all.
+        prices = np.linspace(100.0, 125.0, 25)
+        rule = ChandelierStop(window=22, multiplier=3.0)
+        result = rule.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=125.0)
+        assert result == 0.10
+
+    def test_fires_even_when_underwater(self) -> None:
+        # Chandelier does not gate on cost basis the way TrailingStop does —
+        # replacing StopLoss is part of the point. Peak barely clears basis,
+        # then price crashes through basis: Chandelier should still fire.
+        prices = np.concatenate(
+            [
+                np.arange(100.0, 121.0, 1.0),  # 21 bars: 100..120
+                np.array([122.0, 95.0]),
+            ]
+        )
+        rule = ChandelierStop(window=22, multiplier=3.0)
+        # Basis 120 is above current 95, so position is underwater.
+        result = rule.clamp_target("X", 0.10, prices, cost_basis=120.0, high_water_mark=122.0)
+        assert result == 0.0
+
+    def test_higher_multiplier_widens_stop(self) -> None:
+        # Same price path; raising k should push the stop past the current
+        # price and suppress the fire.
+        prices = np.concatenate(
+            [
+                np.arange(100.0, 121.0, 1.0),
+                np.array([125.0, 110.0]),
+            ]
+        )
+        tight = ChandelierStop(window=22, multiplier=3.0)
+        wide = ChandelierStop(window=22, multiplier=15.0)
+        assert tight.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=125.0) == 0.0
+        assert wide.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=125.0) == 0.10
+
+    def test_returns_proposed_on_insufficient_history(self) -> None:
+        short = np.array([100.0, 101.0, 102.0])
+        rule = ChandelierStop(window=22, multiplier=3.0)
+        result = rule.clamp_target("X", 0.10, short, cost_basis=100.0, high_water_mark=102.0)
+        assert result == 0.10
+
+    def test_name_and_description(self) -> None:
+        rule = ChandelierStop(window=22, multiplier=3.0)
+        assert rule.name == "ChandelierStop"
+        assert rule.description
+
+
 class TestStopLoss:
     def test_clamps_on_loss(self, dropping_prices: np.ndarray) -> None:
         rule = StopLoss(loss_threshold=0.10)
@@ -290,6 +358,10 @@ class TestWarmupPeriod:
         assert StopLoss().warmup_period == 0
         assert ProfitTaking().warmup_period == 0
         assert TrailingStop().warmup_period == 0
+
+    def test_chandelier_stop_uses_window(self) -> None:
+        assert ChandelierStop(window=22).warmup_period == 22
+        assert ChandelierStop(window=30).warmup_period == 30
 
     def test_gap_down_recovery_needs_three_bars(self) -> None:
         assert GapDownRecovery().warmup_period == 3


### PR DESCRIPTION
## Summary
- New `ChandelierStop` exit rule: volatility-adjusted trailing stop that clamps target to 0 when price falls `multiplier * ATR` below the rolling `window`-bar high (ATR approximated from close-to-close absolute differences).
- Registered in `STRATEGY_REGISTRY` and `PARAM_RANGES` (`window` 10–40, `multiplier` 1.5–5.0) for optimization.
- `balanced-growth.yaml` switched from `TrailingStop` to `ChandelierStop` to demonstrate the pairing with `ProfitTaking`; `docs/strategies.md` documents the rule and contrasts it with `TrailingStop`.

## Test Plan
- [x] `uv run pytest` — 174 passed
- [x] pre-commit hooks (ruff, ruff format, mypy) pass
- [ ] Spot-check that `ChandelierStop` appears in `midas optimize` output when included in a strategy file