### PR TITLE
Add DonchianBreakout, KeltnerChannel, ParabolicSARExit strategies

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -15,7 +15,9 @@ To add a new strategy: implement `EntrySignal` or `ExitRule` in a new file under
 | Strategy | Type | What it does |
 |----------|------|--------------|
 | BollingerBand | Entry | Bullish at the lower volatility band of the moving average |
+| DonchianBreakout | Entry | Bullish when price breaks above the rolling N-bar high (Turtle-style) |
 | GapDownRecovery | Entry | Bullish after a gap-down event starts recovering |
+| KeltnerChannel | Entry | Bullish on a breakout above the SMA + k x ATR upper band |
 | MACDCrossover | Entry | Bullish when the MACD line is above its signal line |
 | MeanReversion | Entry | Bullish when price drops below its moving average |
 | Momentum | Entry | Bullish when price is above its moving average |
@@ -25,6 +27,7 @@ To add a new strategy: implement `EntrySignal` or `ExitRule` in a new file under
 | ChandelierStop | Exit | Clamps target to 0 when price falls k x ATR below the rolling N-bar high |
 | MACDExit | Exit | Clamps target to 0 on a bearish MACD crossover |
 | MovingAverageCrossoverExit | Exit | Clamps target to 0 on the death cross |
+| ParabolicSARExit | Exit | Clamps target to 0 when Wilder's Parabolic SAR flips above price |
 | ProfitTaking | Exit | Clamps target to 0 when unrealized gain exceeds the threshold |
 | StopLoss | Exit | Clamps target to 0 when unrealized loss exceeds the threshold |
 | TrailingStop | Exit | Clamps target to 0 after a drawdown from the high-water mark |
@@ -125,6 +128,25 @@ Unlike plain `MeanReversion`, `BollingerBand` adapts to the stock's recent volat
 
 ---
 
+### KeltnerChannel
+
+**Type**: Entry signal
+
+A volatility-adjusted breakout entry. Computes an SMA centerline and an ATR-based band half-width, then fires when the current close breaks above the upper band (centerline + `multiplier` x ATR). The score is measured in ATR units of excess above the band: 1 ATR above the band reaches full conviction. ATR is approximated from close-to-close absolute differences since the engine's price history is close-only.
+
+Unlike `BollingerBand` — which is a *mean-reversion* entry that fires at the *lower* band — `KeltnerChannel` is trend-following and fires at the *upper* band. Their signals are symmetric but opposite: `BollingerBand` buys the dip to the bottom band, `KeltnerChannel` buys the breakout above the top band. Keltner also uses ATR rather than standard deviation, which makes the bands smoother and less sensitive to single outliers.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 20 | SMA and ATR lookback (trading days) |
+| `multiplier` | 2.0 | ATR multiple defining the upper band distance above the centerline |
+
+**Suited for**: All asset classes, especially trending markets
+
+**Interactions**: Aligns with `Momentum`, `MovingAverageCrossover`, `MACDCrossover`, and `DonchianBreakout` (all trend-following). Conflicts with `BollingerBand` and other mean-reversion entries — they'd fight each other. Pairs naturally with `ChandelierStop`, which uses the same ATR-based volatility framing for its exit distance.
+
+---
+
 ### MACDCrossover
 
 **Type**: Entry signal
@@ -177,6 +199,25 @@ The classic golden cross strategy. Tracks two moving averages of different lengt
 **Suited for**: All asset classes
 
 **Interactions**: Confirms `MACDCrossover`. Aligns with `Momentum`. Pairs naturally with `MovingAverageCrossoverExit` so entries and exits use the same indicator on the same timescale.
+
+---
+
+### DonchianBreakout
+
+**Type**: Entry signal
+
+The classic Turtle Trading entry. Bullish when the current close exceeds the highest close over the prior `window` bars — a strict breakout. Once the breakout fires, the score ramps linearly with the excess over the prior high, reaching full conviction at `breakout_scale` (default 2%). Before the breakout the score is 0; no partial credit for approaching the level.
+
+Unlike MA-based trend entries (`Momentum`, `MovingAverageCrossover`) which score continuously along a gradient, Donchian is binary-then-linear: either you're making a new high or you're not. This makes it late to enter trends but immune to whipsaws inside the lookback range.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `window` | 20 | Lookback for the prior high (trading days). The classical Turtle values are 20 (short system) and 55 (long system) |
+| `breakout_scale` | 0.02 | Excess over the prior high at which the score reaches 1.0 |
+
+**Suited for**: All asset classes, especially trending equities and commodities-like assets
+
+**Interactions**: Aligns with `Momentum` and `MovingAverageCrossover` (all trend-following) but measures a different thing — price vs. prior high rather than price vs. moving average — so it adds independent confirmation rather than redundancy. Conflicts with mean-reversion entries. Pairs naturally with `ChandelierStop`, which also uses a rolling-window high as its reference point.
 
 ---
 
@@ -254,6 +295,26 @@ Unlike `TrailingStop`, `ChandelierStop` uses a rolling window high rather than a
 **Suited for**: All asset classes
 
 **Interactions**: Generally substitutes for the `StopLoss` + `TrailingStop` pair — stacking all three produces overlapping protection with unclear attribution. Still pairs cleanly with `ProfitTaking` as the gain-harvest mechanism. Useful when fixed-percent stops feel regime-ignorant, since a single `multiplier` adapts across tickers with different volatility profiles.
+
+---
+
+### ParabolicSARExit
+
+**Type**: Exit rule
+
+J. Welles Wilder's Parabolic SAR (Stop And Reverse) as a trailing-stop exit. Computes a self-accelerating trailing stop that starts slow and ratchets tighter as the trend extends: each time the price makes a new extreme in the direction of the trend, the acceleration factor (AF) is bumped up by `af_step` (capped at `af_max`), which pulls the SAR closer to price. When the SAR finally flips above price, the uptrend is considered broken and the rule clamps the target to 0.
+
+The defining property of SAR is that it converts elapsed trend time into stop tightness. A fresh breakout gets a generous stop (small AF, SAR trails far below); a long-running uptrend gets a tight one (AF near cap, SAR hugging price). This makes it well-suited for riding long trends without giving back too much at the end — the stop tightens on its own as the move matures.
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `af_start` | 0.02 | Initial acceleration factor — the fraction of the SAR-to-extreme gap closed per bar at trend start |
+| `af_step` | 0.02 | Increment added to AF on each new trend extreme |
+| `af_max` | 0.20 | Upper cap on AF — Wilder's original value |
+
+**Suited for**: All asset classes, especially trending markets
+
+**Interactions**: Overlaps functionally with `TrailingStop` and `ChandelierStop` — all three are trailing-stop exits — but uses a fundamentally different tightening rule. `TrailingStop` is a fixed percentage from the HWM; `ChandelierStop` scales with ATR; `ParabolicSARExit` scales with trend duration. Don't stack all three or they'll fight over attribution. Pairs naturally with strong trend-following entries like `DonchianBreakout`, `KeltnerChannel`, or `Momentum`, where the late-stage tightening matches the "ride the move, cut when it breaks" thesis.
 
 ---
 

--- a/example-strategies/README.md
+++ b/example-strategies/README.md
@@ -43,3 +43,45 @@ Moderately aggressive entries with disciplined exits. Two entries push you in, t
 - **Chandelier Stop** (22-day window, 3.0× ATR, exit) — a volatility-adjusted trailing stop. Tracks the highest close over the last 22 days and sells if the current price falls more than 3× the recent average true range below that high. Unlike a fixed-percent trailing stop, the stop distance breathes with realized volatility — tighter in calm markets, wider in choppy ones — and the rolling-window reference high keeps the stop responsive to recent price action instead of anchoring to a months-old peak. Fires on both profitable and underwater positions, so it subsumes the role of a separate stop loss.
 
 Best for: a general-purpose portfolio that balances growth capture with downside protection.
+
+## [Turtle Breakout](turtle-breakout.yaml)
+
+The classic "buy new highs" system from Richard Dennis's Turtle Trading experiment, updated with a modern trailing-stop exit.
+
+- **Donchian Breakout** (20-day, entry) — buys when the current close exceeds the highest close of the prior 20 days. This is the short Turtle system — it fires on fresh breakouts and is silent the rest of the time. The score ramps linearly once the breakout happens, so a small poke above the prior high gets partial conviction while a 2%+ push gets full conviction.
+
+- **Keltner Channel** (20-day, 2.0× ATR, entry) — confirms the breakout from a different angle. Rather than comparing the current price to a prior high, Keltner compares it to the moving average plus two times recent average true range. Donchian fires on raw price level; Keltner fires on volatility-adjusted distance from the average. When both agree, the breakout is both "new" and "large relative to normal noise" — independent confirmation that isn't just two copies of the same signal.
+
+- **Parabolic SAR Exit** (AF 0.02 → 0.20, exit) — Wilder's self-accelerating trailing stop. Starts loose right after the breakout (small acceleration factor, SAR trails far below price) and ratchets tighter every time the price makes a new high, until the stop is hugging price late in the trend. The result is a stop that gives breakouts room to develop but locks down the exit once the move has had time to play out — a natural pairing with breakout entries.
+
+- **Profit Taking** (30% threshold, exit) — an absolute ceiling on how long to hold a single breakout. Even with a trailing stop still loose, any lot up 30% gets trimmed so winners don't round-trip back to the basis.
+
+Best for: trending, high-momentum assets (growth stocks, momentum ETFs, commodities-like assets). Poor fit for range-bound assets where repeated false breakouts chop the strategy.
+
+## [Volatility Momentum](volatility-momentum.yaml)
+
+A trend-following system built entirely on volatility-adjusted signals. Every component scales with realized ATR, so the strategy adapts its sensitivity as market conditions change.
+
+- **Keltner Channel** (20-day, 2.0× ATR, entry) — bullish when the price breaks above the SMA + 2 × ATR upper band. In calm markets the band is tight and small moves trigger conviction; in volatile markets the band is wide and it takes a bigger move to fire. This auto-calibration keeps the entry from getting trigger-happy during chop and from missing real breakouts during high-volatility regimes.
+
+- **Momentum** (20-day, entry) — buys when the price is above its 20-day moving average. Provides continuation support: once Keltner fires on a breakout, Momentum keeps scoring bullish as long as the price stays elevated, so the allocator won't prematurely drain the position just because the initial breakout excess has compressed back into the band.
+
+- **Chandelier Stop** (22-day, 3.0× ATR, exit) — a volatility-matched trailing stop. Since the entries are calibrated in ATR units, it only makes sense for the exit to use the same yardstick: a 3× ATR trailing stop sits at roughly the same "distance in normal-noise terms" regardless of the ticker. The whole strategy speaks one consistent volatility language end-to-end.
+
+- **Profit Taking** (25% threshold, exit) — a fixed-gain harvest to complement the volatility-relative trailing stop. Even if Chandelier is trailing at a wide ATR multiple, Profit Taking still ensures any lot up 25% is trimmed on schedule.
+
+Best for: assets with stable, measurable volatility (index ETFs, large-cap tech). Less suited to micro-caps or post-earnings-spike situations where ATR is noisy or non-stationary.
+
+## [Long Trend](long-trend.yaml)
+
+A patient system built for capturing multi-month trends without getting shaken out by short-term pullbacks.
+
+- **Donchian Breakout** (55-day, 3% breakout scale, entry) — the long Turtle system. A 55-day window demands a genuine regime change before firing, so the strategy sits out noise and false starts and only engages when a meaningful trend has formed. The wider 3% breakout scale means the score takes a larger push to reach full conviction, reflecting that long-window breakouts are higher-stakes commitments than short-window ones.
+
+- **MACD Crossover** (12/26/9, entry) — trend confirmation on a completely different timescale and indicator family. Donchian is a binary event (new N-bar high, yes or no); MACD is a continuous measure of momentum strength. Together they fire when both the level (new multi-month high) and the acceleration (bullish MACD) agree the trend is real.
+
+- **Parabolic SAR Exit** (AF 0.01 → 0.15, exit) — a deliberately slow version of Wilder's SAR. The smaller starting and step AFs mean the stop acceptance far more slack in the early weeks of a trend — exactly when Donchian has just fired and the trend needs room to breathe — and only tightens well after the position is deep in profit. The capped 0.15 max AF keeps the stop from ever getting so tight that normal pullbacks close the position.
+
+- **Profit Taking** (35% threshold, exit) — a generous ceiling that reflects the long-trend thesis: these are meant to be multi-month holds, so trimming at 20% would cut winners off just as they're getting started.
+
+Best for: secular bull markets and long-duration uptrends where the thesis is measured in months rather than weeks. A poor fit for fast-moving, mean-reverting assets where a 55-day lookback means you're always buying the top.

--- a/example-strategies/long-trend.yaml
+++ b/example-strategies/long-trend.yaml
@@ -1,0 +1,29 @@
+softmax_temperature: 0.5
+min_buy_delta: 0.02
+min_cash_pct: 0.05
+
+strategies:
+  # -- Entry signals --
+  - name: DonchianBreakout
+    weight: 1.0
+    params:
+      window: 55
+      breakout_scale: 0.03
+
+  - name: MACDCrossover
+    weight: 1.0
+    params:
+      fast_period: 12
+      slow_period: 26
+      signal_period: 9
+
+  # -- Exit rules --
+  - name: ParabolicSARExit
+    params:
+      af_start: 0.01
+      af_step: 0.01
+      af_max: 0.15
+
+  - name: ProfitTaking
+    params:
+      gain_threshold: 0.35

--- a/example-strategies/turtle-breakout.yaml
+++ b/example-strategies/turtle-breakout.yaml
@@ -1,0 +1,28 @@
+softmax_temperature: 0.5
+min_buy_delta: 0.02
+min_cash_pct: 0.05
+
+strategies:
+  # -- Entry signals --
+  - name: DonchianBreakout
+    weight: 1.0
+    params:
+      window: 20
+      breakout_scale: 0.02
+
+  - name: KeltnerChannel
+    weight: 1.0
+    params:
+      window: 20
+      multiplier: 2.0
+
+  # -- Exit rules --
+  - name: ParabolicSARExit
+    params:
+      af_start: 0.02
+      af_step: 0.02
+      af_max: 0.20
+
+  - name: ProfitTaking
+    params:
+      gain_threshold: 0.30

--- a/example-strategies/volatility-momentum.yaml
+++ b/example-strategies/volatility-momentum.yaml
@@ -1,0 +1,27 @@
+softmax_temperature: 0.5
+min_buy_delta: 0.02
+min_cash_pct: 0.05
+
+strategies:
+  # -- Entry signals --
+  - name: KeltnerChannel
+    weight: 1.0
+    params:
+      window: 20
+      multiplier: 2.0
+
+  - name: Momentum
+    weight: 1.0
+    params:
+      window: 20
+      momentum_scale: 0.05
+
+  # -- Exit rules --
+  - name: ChandelierStop
+    params:
+      window: 22
+      multiplier: 3.0
+
+  - name: ProfitTaking
+    params:
+      gain_threshold: 0.25

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -69,6 +69,11 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float]]] = {
         "num_std": (1.5, 3.0, 0.25),
         "_weight": (0.5, 3.0, 0.25),
     },
+    "DonchianBreakout": {
+        "window": (10, 60, 5),
+        "breakout_scale": (0.01, 0.06, 0.005),
+        "_weight": (0.5, 3.0, 0.25),
+    },
     "MACDCrossover": {
         "fast_period": (8, 16, 2),
         "slow_period": (20, 40, 2),
@@ -77,6 +82,11 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float]]] = {
     },
     "GapDownRecovery": {
         "gap_threshold": (0.02, 0.08, 0.005),
+        "_weight": (0.5, 3.0, 0.25),
+    },
+    "KeltnerChannel": {
+        "window": (10, 50, 5),
+        "multiplier": (1.0, 4.0, 0.25),
         "_weight": (0.5, 3.0, 0.25),
     },
     "VWAPReversion": {
@@ -112,6 +122,11 @@ PARAM_RANGES: dict[str, dict[str, tuple[float, float, float]]] = {
     "MovingAverageCrossoverExit": {
         "short_window": (10, 30, 2),
         "long_window": (40, 100, 5),
+    },
+    "ParabolicSARExit": {
+        "af_start": (0.01, 0.04, 0.005),
+        "af_step": (0.01, 0.04, 0.005),
+        "af_max": (0.10, 0.30, 0.02),
     },
     ALLOCATION_KEY: {
         # softmax_temperature: low = concentrated, high = uniform split.

--- a/src/midas/strategies/__init__.py
+++ b/src/midas/strategies/__init__.py
@@ -3,13 +3,16 @@
 from midas.strategies.base import EntrySignal, ExitRule, Strategy
 from midas.strategies.bollinger_band import BollingerBand
 from midas.strategies.chandelier_stop import ChandelierStop
+from midas.strategies.donchian_breakout import DonchianBreakout
 from midas.strategies.gap_down_recovery import GapDownRecovery
+from midas.strategies.keltner_channel import KeltnerChannel
 from midas.strategies.ma_crossover import MovingAverageCrossover
 from midas.strategies.ma_crossover_exit import MovingAverageCrossoverExit
 from midas.strategies.macd_crossover import MACDCrossover
 from midas.strategies.macd_exit import MACDExit
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.momentum import Momentum
+from midas.strategies.parabolic_sar_exit import ParabolicSARExit
 from midas.strategies.profit_taking import ProfitTaking
 from midas.strategies.rsi_oversold import RSIOversold
 from midas.strategies.stop_loss import StopLoss
@@ -19,7 +22,9 @@ from midas.strategies.vwap_reversion import VWAPReversion
 STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
     # Entry signals
     "BollingerBand": BollingerBand,
+    "DonchianBreakout": DonchianBreakout,
     "GapDownRecovery": GapDownRecovery,
+    "KeltnerChannel": KeltnerChannel,
     "MACDCrossover": MACDCrossover,
     "MeanReversion": MeanReversion,
     "Momentum": Momentum,
@@ -30,6 +35,7 @@ STRATEGY_REGISTRY: dict[str, type[Strategy]] = {
     "ChandelierStop": ChandelierStop,
     "MACDExit": MACDExit,
     "MovingAverageCrossoverExit": MovingAverageCrossoverExit,
+    "ParabolicSARExit": ParabolicSARExit,
     "ProfitTaking": ProfitTaking,
     "StopLoss": StopLoss,
     "TrailingStop": TrailingStop,
@@ -39,15 +45,18 @@ __all__ = [
     "STRATEGY_REGISTRY",
     "BollingerBand",
     "ChandelierStop",
+    "DonchianBreakout",
     "EntrySignal",
     "ExitRule",
     "GapDownRecovery",
+    "KeltnerChannel",
     "MACDCrossover",
     "MACDExit",
     "MeanReversion",
     "Momentum",
     "MovingAverageCrossover",
     "MovingAverageCrossoverExit",
+    "ParabolicSARExit",
     "ProfitTaking",
     "RSIOversold",
     "StopLoss",

--- a/src/midas/strategies/donchian_breakout.py
+++ b/src/midas/strategies/donchian_breakout.py
@@ -17,6 +17,21 @@ class DonchianBreakout(EntrySignal):
     def warmup_period(self) -> int:
         return self._window + 1
 
+    def precompute(self, prices: np.ndarray) -> np.ndarray | None:
+        n = len(prices)
+        w = self._window
+        scores = np.full(n, np.nan)
+        if n < w + 1:
+            return scores
+        windows = np.lib.stride_tricks.sliding_window_view(prices[:-1], w)
+        prior_highs = windows.max(axis=1)
+        current = prices[w:]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            excess_pct = np.where(prior_highs > 0, (current - prior_highs) / prior_highs, 0.0)
+        raw = np.where(current > prior_highs, excess_pct / self._breakout_scale, 0.0)
+        scores[w:] = np.clip(raw, 0.0, 1.0)
+        return scores
+
     def score(
         self,
         price_history: np.ndarray,

--- a/src/midas/strategies/donchian_breakout.py
+++ b/src/midas/strategies/donchian_breakout.py
@@ -1,0 +1,46 @@
+"""Donchian breakout: buy when price breaks above the rolling N-bar high."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from midas.models import AssetSuitability
+from midas.strategies.base import EntrySignal
+
+
+class DonchianBreakout(EntrySignal):
+    def __init__(self, window: int = 20, breakout_scale: float = 0.02) -> None:
+        self._window = window
+        self._breakout_scale = breakout_scale
+
+    @property
+    def warmup_period(self) -> int:
+        return self._window + 1
+
+    def score(
+        self,
+        price_history: np.ndarray,
+        **kwargs: object,
+    ) -> float | None:
+        if len(price_history) < self._window + 1:
+            return None
+
+        prior_high = float(price_history[-self._window - 1 : -1].max())
+        current = float(price_history[-1])
+
+        if prior_high <= 0 or current <= prior_high:
+            return 0.0
+
+        excess_pct = (current - prior_high) / prior_high
+        return self.clamp(excess_pct / self._breakout_scale, 0.0, 1.0)
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Bullish when current price breaks above the highest close of "
+            f"the prior {self._window} bars (Turtle-style breakout)"
+        )

--- a/src/midas/strategies/keltner_channel.py
+++ b/src/midas/strategies/keltner_channel.py
@@ -17,6 +17,29 @@ class KeltnerChannel(EntrySignal):
     def warmup_period(self) -> int:
         return self._window
 
+    def precompute(self, prices: np.ndarray) -> np.ndarray | None:
+        n = len(prices)
+        w = self._window
+        scores = np.full(n, np.nan)
+        if n < w or w < 2:
+            return scores
+        cs = np.empty(n + 1)
+        cs[0] = 0.0
+        np.cumsum(prices, out=cs[1:])
+        centerlines = (cs[w:] - cs[:-w]) / w
+        abs_diffs = np.abs(np.diff(prices))
+        cs_diff = np.empty(n)
+        cs_diff[0] = 0.0
+        np.cumsum(abs_diffs, out=cs_diff[1:])
+        atr_series = (cs_diff[w - 1 :] - cs_diff[: n - w + 1]) / (w - 1)
+        upper = centerlines + self._multiplier * atr_series
+        current = prices[w - 1 :]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            excess_atr = np.where(atr_series > 0, (current - upper) / atr_series, 0.0)
+        raw = np.where(current > upper, excess_atr, 0.0)
+        scores[w - 1 :] = np.clip(raw, 0.0, 1.0)
+        return scores
+
     def score(
         self,
         price_history: np.ndarray,

--- a/src/midas/strategies/keltner_channel.py
+++ b/src/midas/strategies/keltner_channel.py
@@ -1,0 +1,53 @@
+"""Keltner Channel breakout: bullish when price breaks above SMA + k x ATR."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from midas.models import AssetSuitability
+from midas.strategies.base import EntrySignal
+
+
+class KeltnerChannel(EntrySignal):
+    def __init__(self, window: int = 20, multiplier: float = 2.0) -> None:
+        self._window = window
+        self._multiplier = multiplier
+
+    @property
+    def warmup_period(self) -> int:
+        return self._window
+
+    def score(
+        self,
+        price_history: np.ndarray,
+        **kwargs: object,
+    ) -> float | None:
+        if len(price_history) < self._window:
+            return None
+
+        recent = price_history[-self._window :]
+        centerline = float(recent.mean())
+        atr = float(np.abs(np.diff(recent)).mean())
+
+        if atr <= 0:
+            return 0.0
+
+        upper = centerline + self._multiplier * atr
+        current = float(price_history[-1])
+
+        if current <= upper:
+            return 0.0
+
+        excess_atr = (current - upper) / atr
+        return self.clamp(excess_atr, 0.0, 1.0)
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Bullish when price breaks above the {self._window}-bar SMA + "
+            f"{self._multiplier:.1f} x ATR upper Keltner band"
+        )

--- a/src/midas/strategies/parabolic_sar_exit.py
+++ b/src/midas/strategies/parabolic_sar_exit.py
@@ -1,0 +1,105 @@
+"""Parabolic SAR exit: Wilder's self-accelerating trailing stop."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from midas.models import AssetSuitability
+from midas.strategies.base import ExitRule
+
+
+class ParabolicSARExit(ExitRule):
+    def __init__(
+        self,
+        af_start: float = 0.02,
+        af_step: float = 0.02,
+        af_max: float = 0.20,
+    ) -> None:
+        self._af_start = af_start
+        self._af_step = af_step
+        self._af_max = af_max
+
+    @property
+    def warmup_period(self) -> int:
+        return 2
+
+    def _compute(self, prices: np.ndarray) -> tuple[float, bool] | None:
+        """Return (sar, uptrend) at the final bar, or None if too little data."""
+        n = len(prices)
+        if n < 2:
+            return None
+
+        p0 = float(prices[0])
+        p1 = float(prices[1])
+        uptrend = p1 >= p0
+        if uptrend:
+            sar = min(p0, p1)
+            ep = max(p0, p1)
+        else:
+            sar = max(p0, p1)
+            ep = min(p0, p1)
+        af = self._af_start
+
+        for i in range(2, n):
+            sar = sar + af * (ep - sar)
+            close = float(prices[i])
+            if uptrend:
+                if close > ep:
+                    ep = close
+                    af = min(af + self._af_step, self._af_max)
+                if sar > close:
+                    uptrend = False
+                    sar = ep
+                    ep = close
+                    af = self._af_start
+            else:
+                if close < ep:
+                    ep = close
+                    af = min(af + self._af_step, self._af_max)
+                if sar < close:
+                    uptrend = True
+                    sar = ep
+                    ep = close
+                    af = self._af_start
+
+        return sar, uptrend
+
+    def clamp_target(
+        self,
+        ticker: str,
+        proposed_target: float,
+        price_history: np.ndarray,
+        cost_basis: float,
+        high_water_mark: float,
+    ) -> float:
+        if proposed_target <= 0:
+            return proposed_target
+        result = self._compute(price_history)
+        if result is None:
+            return proposed_target
+        _sar, uptrend = result
+        if not uptrend:
+            return 0.0
+        return proposed_target
+
+    def clamp_reason(
+        self,
+        ticker: str,
+        price_history: np.ndarray,
+        cost_basis: float,
+        high_water_mark: float,
+    ) -> str:
+        result = self._compute(price_history)
+        current = float(price_history[-1]) if len(price_history) > 0 else 0.0
+        if result is None:
+            return f"ParabolicSARExit: flip on {ticker}"
+        sar, _ = result
+        return f"ParabolicSARExit: SAR ${sar:.2f} flipped above price ${current:.2f} (downtrend)"
+
+    @property
+    def suitability(self) -> list[AssetSuitability]:
+        return [AssetSuitability.ALL]
+
+    @property
+    def description(self) -> str:
+        return f"Sell when Wilder's Parabolic SAR (AF {self._af_start:.2f}->{self._af_max:.2f}) flips above price"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -123,7 +123,9 @@ def test_strategy_registry_complete() -> None:
     expected = {
         # entry signals
         "BollingerBand",
+        "DonchianBreakout",
         "GapDownRecovery",
+        "KeltnerChannel",
         "MACDCrossover",
         "MeanReversion",
         "Momentum",
@@ -134,6 +136,7 @@ def test_strategy_registry_complete() -> None:
         "ChandelierStop",
         "MACDExit",
         "MovingAverageCrossoverExit",
+        "ParabolicSARExit",
         "ProfitTaking",
         "StopLoss",
         "TrailingStop",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -5,13 +5,16 @@ import numpy as np
 from midas.strategies.base import MIN_WARMUP_CALENDAR_DAYS, warmup_bars_to_calendar_days
 from midas.strategies.bollinger_band import BollingerBand
 from midas.strategies.chandelier_stop import ChandelierStop
+from midas.strategies.donchian_breakout import DonchianBreakout
 from midas.strategies.gap_down_recovery import GapDownRecovery
+from midas.strategies.keltner_channel import KeltnerChannel
 from midas.strategies.ma_crossover import MovingAverageCrossover
 from midas.strategies.ma_crossover_exit import MovingAverageCrossoverExit
 from midas.strategies.macd_crossover import MACDCrossover
 from midas.strategies.macd_exit import MACDExit
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.momentum import Momentum
+from midas.strategies.parabolic_sar_exit import ParabolicSARExit
 from midas.strategies.profit_taking import ProfitTaking
 from midas.strategies.rsi_oversold import RSIOversold
 from midas.strategies.stop_loss import StopLoss
@@ -199,6 +202,96 @@ class TestTrailingStop:
         assert result == 0.10
 
 
+class TestDonchianBreakout:
+    """Turtle-style breakout: buy when current close exceeds the prior N-bar high."""
+
+    def test_zero_on_flat_prices(self, flat_prices: np.ndarray) -> None:
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        assert strategy.score(flat_prices) == 0.0
+
+    def test_insufficient_history(self) -> None:
+        # Needs window + 1 bars (N prior + 1 current).
+        short = np.full(20, 100.0)
+        strategy = DonchianBreakout(window=20)
+        assert strategy.score(short) is None
+
+    def test_full_conviction_on_scale_breakout(self) -> None:
+        # 20 flat bars at 100, then break to 102 (2% above the prior high).
+        prices = np.concatenate([np.full(20, 100.0), np.array([102.0])])
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        score = strategy.score(prices)
+        assert score == 1.0
+
+    def test_partial_score_on_partial_breakout(self) -> None:
+        # 20 flat bars at 100, then break to 101 — half of the 2% scale.
+        prices = np.concatenate([np.full(20, 100.0), np.array([101.0])])
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        score = strategy.score(prices)
+        assert score is not None
+        assert 0.4 < score < 0.6
+
+    def test_zero_when_below_prior_high(self) -> None:
+        # Current close below the prior high — no breakout, no score.
+        prices = np.concatenate([np.full(20, 100.0), np.array([99.0])])
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        assert strategy.score(prices) == 0.0
+
+    def test_tie_with_prior_high_does_not_fire(self) -> None:
+        # Equalling the prior high is not a "breakout".
+        prices = np.concatenate([np.full(20, 100.0), np.array([100.0])])
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        assert strategy.score(prices) == 0.0
+
+    def test_name_and_description(self) -> None:
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        assert strategy.name == "DonchianBreakout"
+        assert strategy.description
+
+
+class TestKeltnerChannel:
+    """Breakout entry: bullish when price breaks above EMA + k x ATR upper band."""
+
+    def test_zero_on_flat_prices(self, flat_prices: np.ndarray) -> None:
+        strategy = KeltnerChannel(window=20, multiplier=2.0)
+        assert strategy.score(flat_prices) == 0.0
+
+    def test_insufficient_history(self) -> None:
+        short = np.full(10, 100.0)
+        strategy = KeltnerChannel(window=20)
+        assert strategy.score(short) is None
+
+    def test_positive_score_on_breakout(self) -> None:
+        # Strong uptrend: centerline trails far behind current, ATR rises
+        # with the linear ramp — current ends well above the upper band.
+        prices = np.linspace(100.0, 140.0, 25)
+        strategy = KeltnerChannel(window=20, multiplier=1.0)
+        score = strategy.score(prices)
+        assert score is not None
+        assert score > 0.0
+
+    def test_zero_when_inside_bands(self) -> None:
+        # Noise around a flat level — current close barely above the mean,
+        # far below the upper band.
+        rng = np.random.default_rng(seed=7)
+        prices = 100.0 + rng.normal(0, 0.5, size=25)
+        prices[-1] = 100.1
+        strategy = KeltnerChannel(window=20, multiplier=2.0)
+        assert strategy.score(prices) == 0.0
+
+    def test_higher_multiplier_suppresses_breakout(self) -> None:
+        # Same path, wider band → no longer a breakout.
+        prices = np.linspace(100.0, 140.0, 25)
+        tight = KeltnerChannel(window=20, multiplier=1.0)
+        wide = KeltnerChannel(window=20, multiplier=50.0)
+        assert tight.score(prices) > 0.0  # type: ignore[operator]
+        assert wide.score(prices) == 0.0
+
+    def test_name_and_description(self) -> None:
+        strategy = KeltnerChannel(window=20, multiplier=2.0)
+        assert strategy.name == "KeltnerChannel"
+        assert strategy.description
+
+
 class TestChandelierStop:
     """Volatility-adjusted trailing stop: k x ATR below the rolling N-bar high."""
 
@@ -263,6 +356,67 @@ class TestChandelierStop:
     def test_name_and_description(self) -> None:
         rule = ChandelierStop(window=22, multiplier=3.0)
         assert rule.name == "ChandelierStop"
+        assert rule.description
+
+
+class TestParabolicSARExit:
+    """Wilder's self-accelerating SAR trailing stop: fire when SAR flips above price."""
+
+    def test_no_clamp_on_steady_rise(self, rising_prices: np.ndarray) -> None:
+        rule = ParabolicSARExit()
+        result = rule.clamp_target(
+            "X",
+            0.10,
+            rising_prices,
+            cost_basis=100.0,
+            high_water_mark=float(rising_prices.max()),
+        )
+        assert result == 0.10
+
+    def test_clamps_on_reversal(self, peak_then_drop_prices: np.ndarray) -> None:
+        rule = ParabolicSARExit()
+        peak = float(peak_then_drop_prices.max())
+        result = rule.clamp_target(
+            "X",
+            0.10,
+            peak_then_drop_prices,
+            cost_basis=100.0,
+            high_water_mark=peak,
+        )
+        assert result == 0.0
+
+    def test_returns_proposed_on_insufficient_history(self) -> None:
+        short = np.array([100.0])
+        rule = ParabolicSARExit()
+        result = rule.clamp_target(
+            "X",
+            0.10,
+            short,
+            cost_basis=100.0,
+            high_water_mark=100.0,
+        )
+        assert result == 0.10
+
+    def test_higher_af_max_flips_faster(self) -> None:
+        # A rise then sharp pullback — a faster-accelerating SAR will catch
+        # the reversal, while a slow one may not yet have crossed price.
+        prices = np.concatenate(
+            [
+                np.linspace(100.0, 120.0, 15),
+                np.array([119.0, 115.0]),
+            ]
+        )
+        slow = ParabolicSARExit(af_start=0.02, af_step=0.001, af_max=0.005)
+        fast = ParabolicSARExit(af_start=0.02, af_step=0.02, af_max=0.20)
+        slow_res = slow.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=120.0)
+        fast_res = fast.clamp_target("X", 0.10, prices, cost_basis=100.0, high_water_mark=120.0)
+        # Fast SAR must flip on the pullback; slow SAR trailing far below may not.
+        assert fast_res == 0.0
+        assert slow_res == 0.10
+
+    def test_name_and_description(self) -> None:
+        rule = ParabolicSARExit()
+        assert rule.name == "ParabolicSARExit"
         assert rule.description
 
 
@@ -359,9 +513,22 @@ class TestWarmupPeriod:
         assert ProfitTaking().warmup_period == 0
         assert TrailingStop().warmup_period == 0
 
+    def test_parabolic_sar_needs_two_bars(self) -> None:
+        assert ParabolicSARExit().warmup_period == 2
+
+    def test_keltner_channel_uses_window(self) -> None:
+        assert KeltnerChannel(window=20).warmup_period == 20
+        assert KeltnerChannel(window=50).warmup_period == 50
+
     def test_chandelier_stop_uses_window(self) -> None:
         assert ChandelierStop(window=22).warmup_period == 22
         assert ChandelierStop(window=30).warmup_period == 30
+
+    def test_donchian_breakout_needs_window_plus_one(self) -> None:
+        # Donchian compares current to the prior N bars, so it needs
+        # N + 1 bars total before it can score.
+        assert DonchianBreakout(window=20).warmup_period == 21
+        assert DonchianBreakout(window=55).warmup_period == 56
 
     def test_gap_down_recovery_needs_three_bars(self) -> None:
         assert GapDownRecovery().warmup_period == 3

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -247,6 +247,22 @@ class TestDonchianBreakout:
         assert strategy.name == "DonchianBreakout"
         assert strategy.description
 
+    def test_precompute_matches_score(self) -> None:
+        # Vectorized precompute must match the per-bar score() exactly for
+        # every prefix — the backtest engine relies on this equivalence.
+        rng = np.random.default_rng(seed=11)
+        prices = 100.0 + np.cumsum(rng.normal(0, 1.0, size=80))
+        strategy = DonchianBreakout(window=20, breakout_scale=0.02)
+        precomputed = strategy.precompute(prices)
+        assert precomputed is not None
+        for i in range(len(prices)):
+            expected = strategy.score(prices[: i + 1])
+            actual = precomputed[i]
+            if expected is None:
+                assert np.isnan(actual)
+            else:
+                assert np.isclose(actual, expected, rtol=1e-9), f"mismatch at i={i}: {actual} vs {expected}"
+
 
 class TestKeltnerChannel:
     """Breakout entry: bullish when price breaks above EMA + k x ATR upper band."""
@@ -290,6 +306,20 @@ class TestKeltnerChannel:
         strategy = KeltnerChannel(window=20, multiplier=2.0)
         assert strategy.name == "KeltnerChannel"
         assert strategy.description
+
+    def test_precompute_matches_score(self) -> None:
+        rng = np.random.default_rng(seed=13)
+        prices = 100.0 + np.cumsum(rng.normal(0, 1.2, size=80))
+        strategy = KeltnerChannel(window=20, multiplier=2.0)
+        precomputed = strategy.precompute(prices)
+        assert precomputed is not None
+        for i in range(len(prices)):
+            expected = strategy.score(prices[: i + 1])
+            actual = precomputed[i]
+            if expected is None:
+                assert np.isnan(actual)
+            else:
+                assert np.isclose(actual, expected, rtol=1e-9), f"mismatch at i={i}: {actual} vs {expected}"
 
 
 class TestChandelierStop:


### PR DESCRIPTION
## Summary
- **DonchianBreakout** (entry) — classical Turtle-style breakout; scores 0→1 as the close pushes above the prior N-bar high
- **KeltnerChannel** (entry) — trend-following breakout above SMA + k×ATR upper band, scored in ATR units of excess
- **ParabolicSARExit** (exit) — Wilder's self-accelerating SAR trailing stop, fires when SAR flips above price

All three are registered in `STRATEGY_REGISTRY`, wired into `PARAM_RANGES` for Bayesian optimization, covered by unit tests + the integration registry test, and documented in `docs/strategies.md` with per-strategy usage, interactions, and a row in the summary table.

## Test plan
- [x] `uv run pytest -q --no-cov` — 195/195 passing
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run mypy src` — clean
- [x] Sanity-check a backtest using each new strategy in a real YAML config

🤖 Generated with [Claude Code](https://claude.com/claude-code)