### PR TITLE
Enforce Google Python Style Guide naming across codebase

### DIFF
--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -62,7 +62,7 @@ class Allocator:
         constraints: AllocationConstraints,
         n_tickers: int,
     ) -> None:
-        self._entries: list[_ScoredEntry] = [_ScoredEntry(s, w) for s, w in entries]
+        self._entries: list[_ScoredEntry] = [_ScoredEntry(strat, wt) for strat, wt in entries]
         self._constraints = constraints
         self._n_tickers = n_tickers
         self._signal_cache: dict[int, dict[str, np.ndarray]] = {}
@@ -92,7 +92,7 @@ class Allocator:
 
     @property
     def strategies(self) -> list[EntrySignal]:
-        return [e.strategy for e in self._entries]
+        return [entry.strategy for entry in self._entries]
 
     def precompute_signals(self, price_data: dict[str, PriceHistory]) -> None:
         """Precompute entry-signal scores for all tickers over the full price arrays."""
@@ -137,13 +137,13 @@ class Allocator:
             and blended scores.
         """
         ctx = context or {}
-        cur_w = current_weights or {}
-        n = len(tickers)
-        if n == 0:
+        cur_weights = current_weights or {}
+        num_tickers = len(tickers)
+        if num_tickers == 0:
             return AllocationResult({}, {}, {})
 
         investable = 1.0 - self._constraints.min_cash_pct
-        base_weight = investable / n  # fallback when current_weights unknown
+        base_weight = investable / num_tickers  # fallback when current_weights unknown
         temperature = self._constraints.softmax_temperature
 
         contributions: dict[str, dict[str, float]] = {}
@@ -172,12 +172,12 @@ class Allocator:
             weight_total = 0.0
 
             for entry in self._entries:
-                hit, s = self._lookup_score(entry.strategy, ticker, len(history))
+                hit, score = self._lookup_score(entry.strategy, ticker, len(history))
                 if not hit:
-                    s = entry.strategy.score(history, **ticker_ctx)
-                if s is not None:
-                    ticker_contributions[entry.strategy.name] = s
-                    weighted_sum += entry.weight * s
+                    score = entry.strategy.score(history, **ticker_ctx)
+                if score is not None:
+                    ticker_contributions[entry.strategy.name] = score
+                    weighted_sum += entry.weight * score
                     weight_total += entry.weight
 
             contributions[ticker] = ticker_contributions
@@ -194,13 +194,13 @@ class Allocator:
         def _held_target(ticker: str) -> float:
             if current_weights is None:
                 return base_weight
-            return cur_w.get(ticker, 0.0)
+            return cur_weights.get(ticker, 0.0)
 
         held_total = 0.0
-        for t in held:
-            w = _held_target(t)
-            targets[t] = w
-            held_total += w
+        for ticker in held:
+            weight = _held_target(ticker)
+            targets[ticker] = weight
+            held_total += weight
 
         budget_for_active = max(investable - held_total, 0.0)
 
@@ -231,16 +231,16 @@ class Allocator:
             T → ∞   uniform split regardless of conviction
         """
         if not tickers or budget <= 0:
-            for t in tickers:
-                targets[t] = 0.0
+            for ticker in tickers:
+                targets[ticker] = 0.0
             return
-        t_safe = max(temperature, MIN_TEMPERATURE)
+        temp_safe = max(temperature, MIN_TEMPERATURE)
         # Subtract max for numerical stability — softmax is translation-invariant.
-        max_score = max(blended_scores[t] for t in tickers)
-        exps = {t: math.exp((blended_scores[t] - max_score) / t_safe) for t in tickers}
-        z = sum(exps.values())
-        for t in tickers:
-            targets[t] = budget * exps[t] / z
+        max_score = max(blended_scores[ticker] for ticker in tickers)
+        exps = {ticker: math.exp((blended_scores[ticker] - max_score) / temp_safe) for ticker in tickers}
+        total_exp = sum(exps.values())
+        for ticker in tickers:
+            targets[ticker] = budget * exps[ticker] / total_exp
 
     def _apply_cap_with_redistribution(
         self,
@@ -261,18 +261,18 @@ class Allocator:
         budget = initial_budget
         # At most one iteration per ticker (each pass pins at least one).
         for _ in range(len(active) + 1):
-            over = [t for t in survivors if targets[t] > cap + 1e-12]
+            over = [ticker for ticker in survivors if targets[ticker] > cap + 1e-12]
             if not over:
                 return
-            for t in over:
-                targets[t] = cap
+            for ticker in over:
+                targets[ticker] = cap
                 budget -= cap
-                survivors.remove(t)
+                survivors.remove(ticker)
             if not survivors or budget <= 0:
                 # Caps consumed the entire investable budget. Survivors get
                 # zero new allocation; they'll naturally drift until an
                 # ExitRule fires.
-                for t in survivors:
-                    targets[t] = 0.0
+                for ticker in survivors:
+                    targets[ticker] = 0.0
                 return
             self._softmax_allocate(survivors, blended_scores, budget, temperature, targets)

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -47,22 +47,22 @@ class StrategyStats:
 def aggregate_strategy_stats(stats: list[StrategyStats]) -> list[StrategyStats]:
     """Aggregate per-(strategy, ticker) stats into per-strategy totals."""
     by_strategy: dict[str, list[StrategyStats]] = defaultdict(list)
-    for s in stats:
-        by_strategy[s.name].append(s)
+    for stat in stats:
+        by_strategy[stat.name].append(stat)
     result: list[StrategyStats] = []
     for name, group in sorted(by_strategy.items()):
-        total_sells = sum(s.sells for s in group)
-        total_pnl = sum(s.pnl for s in group)
-        winning = sum(round(s.win_rate * s.sells) for s in group)
-        agg_wr = winning / total_sells if total_sells > 0 else 0.0
+        total_sells = sum(stat.sells for stat in group)
+        total_pnl = sum(stat.pnl for stat in group)
+        winning = sum(round(stat.win_rate * stat.sells) for stat in group)
+        agg_win_rate = winning / total_sells if total_sells > 0 else 0.0
         result.append(
             StrategyStats(
                 name=name,
                 ticker=None,
-                trades=sum(s.trades for s in group),
-                buys=sum(s.buys for s in group),
+                trades=sum(stat.trades for stat in group),
+                buys=sum(stat.buys for stat in group),
                 sells=total_sells,
-                win_rate=round(agg_wr, 4),
+                win_rate=round(agg_win_rate, 4),
                 pnl=round(total_pnl, 2),
             )
         )
@@ -144,17 +144,19 @@ class _Decision:
 
     def filtered(self, available: set[str]) -> _Decision | None:
         """Return a copy keeping only tickers in *available*, or None if empty."""
-        active = [t for t in self.active_tickers if t in available]
+        active = [ticker for ticker in self.active_tickers if ticker in available]
         if not active:
             return None
         keep = set(active)
         return _Decision(
             allocation=AllocationResult(
-                targets={t: w for t, w in self.allocation.targets.items() if t in keep},
-                contributions={t: v for t, v in self.allocation.contributions.items() if t in keep},
-                blended_scores={t: v for t, v in self.allocation.blended_scores.items() if t in keep},
+                targets={ticker: weight for ticker, weight in self.allocation.targets.items() if ticker in keep},
+                contributions={ticker: val for ticker, val in self.allocation.contributions.items() if ticker in keep},
+                blended_scores={
+                    ticker: val for ticker, val in self.allocation.blended_scores.items() if ticker in keep
+                },
             ),
-            clamp_attribution={k: v for k, v in self.clamp_attribution.items() if k in keep},
+            clamp_attribution={key: val for key, val in self.clamp_attribution.items() if key in keep},
             active_tickers=active,
             decision_day=self.decision_day,
         )
@@ -200,7 +202,9 @@ class _SimState:
     def portfolio_value(self, close_prices: dict[str, float]) -> float:
         """Cash + mark-to-market of held positions at *close_prices*."""
         return self.cash + sum(
-            shares * close_prices[t] for t, shares in self.positions.items() if shares > 0 and t in close_prices
+            shares * close_prices[ticker]
+            for ticker, shares in self.positions.items()
+            if shares > 0 and ticker in close_prices
         )
 
     def close_twr_period(self, current_value: float) -> None:
@@ -212,7 +216,7 @@ class _SimState:
 
 def _close_prices(current_data: dict[str, PriceHistory]) -> dict[str, float]:
     """Latest close price for every ticker in *current_data*."""
-    return {t: float(current_data[t].close[-1]) for t in current_data}
+    return {ticker: float(current_data[ticker].close[-1]) for ticker in current_data}
 
 
 TRADING_DAYS_PER_YEAR = 252
@@ -249,16 +253,16 @@ def compute_sharpe(equity_curve: list[tuple[date, float]]) -> float:
     """Annualized Sharpe ratio (risk-free = 0) from daily returns."""
     if len(equity_curve) < 3:
         return 0.0
-    values = [v for _, v in equity_curve]
+    values = [val for _, val in equity_curve]
     daily_returns = [(values[i] - values[i - 1]) / values[i - 1] for i in range(1, len(values)) if values[i - 1] > 0]
     if len(daily_returns) < 2:
         return 0.0
-    mean_r = sum(daily_returns) / len(daily_returns)
-    variance = sum((r - mean_r) ** 2 for r in daily_returns) / (len(daily_returns) - 1)
-    std_r = math.sqrt(variance) if variance > 0 else 0.0
-    if std_r == 0:
+    mean_ret = sum(daily_returns) / len(daily_returns)
+    variance = sum((ret - mean_ret) ** 2 for ret in daily_returns) / (len(daily_returns) - 1)
+    std_ret = math.sqrt(variance) if variance > 0 else 0.0
+    if std_ret == 0:
         return 0.0
-    return (mean_r / std_r) * math.sqrt(TRADING_DAYS_PER_YEAR)
+    return (mean_ret / std_ret) * math.sqrt(TRADING_DAYS_PER_YEAR)
 
 
 def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
@@ -271,19 +275,19 @@ def compute_sortino(equity_curve: list[tuple[date, float]]) -> float:
     """
     if len(equity_curve) < 3:
         return 0.0
-    values = [v for _, v in equity_curve]
+    values = [val for _, val in equity_curve]
     daily_returns = [(values[i] - values[i - 1]) / values[i - 1] for i in range(1, len(values)) if values[i - 1] > 0]
     if len(daily_returns) < 2:
         return 0.0
-    mean_r = sum(daily_returns) / len(daily_returns)
-    downside = [r for r in daily_returns if r < 0]
+    mean_ret = sum(daily_returns) / len(daily_returns)
+    downside = [ret for ret in daily_returns if ret < 0]
     if not downside:
         return 0.0
-    downside_var = sum(r**2 for r in downside) / len(daily_returns)
+    downside_var = sum(ret**2 for ret in downside) / len(daily_returns)
     downside_dev = math.sqrt(downside_var) if downside_var > 0 else 0.0
     if downside_dev == 0:
         return 0.0
-    return (mean_r / downside_dev) * math.sqrt(TRADING_DAYS_PER_YEAR)
+    return (mean_ret / downside_dev) * math.sqrt(TRADING_DAYS_PER_YEAR)
 
 
 def _pair_sells_with_basis(
@@ -295,11 +299,11 @@ def _pair_sells_with_basis(
     Falls back to the trade price (zero P&L) for any sell beyond the recorded
     basis list — defensive only; the lists should always be the same length.
     """
-    sells = [t for t in trades if t.direction == Direction.SELL]
+    sells = [trade for trade in trades if trade.direction == Direction.SELL]
     paired: list[tuple[TradeRecord, float]] = []
-    for i, t in enumerate(sells):
-        basis = basis_per_sell[i] if i < len(basis_per_sell) else t.price
-        paired.append((t, basis))
+    for idx, trade in enumerate(sells):
+        basis = basis_per_sell[idx] if idx < len(basis_per_sell) else trade.price
+        paired.append((trade, basis))
     return paired
 
 
@@ -317,8 +321,8 @@ def compute_trade_stats(
 
     wins: list[float] = []
     losses: list[float] = []
-    for t, basis in paired:
-        pnl = (t.price - basis) * t.shares
+    for trade, basis in paired:
+        pnl = (trade.price - basis) * trade.shares
         if pnl >= 0:
             wins.append(pnl)
         else:
@@ -328,7 +332,12 @@ def compute_trade_stats(
     win_rate = len(wins) / total if total > 0 else 0.0
     gross_wins = sum(wins) if wins else 0.0
     gross_losses = abs(sum(losses)) if losses else 0.0
-    profit_factor = gross_wins / gross_losses if gross_losses > 0 else float("inf") if gross_wins > 0 else 0.0
+    if gross_losses > 0:
+        profit_factor = gross_wins / gross_losses
+    elif gross_wins > 0:
+        profit_factor = float("inf")
+    else:
+        profit_factor = 0.0
     avg_win = gross_wins / len(wins) if wins else 0.0
     avg_loss = sum(losses) / len(losses) if losses else 0.0  # negative number
     return win_rate, profit_factor, avg_win, avg_loss
@@ -339,21 +348,21 @@ def compute_strategy_stats(
     basis_per_sell: list[float],
 ) -> list[StrategyStats]:
     """Compute per-(strategy, ticker) trade breakdown."""
-    sell_basis: dict[int, float] = {id(t): b for t, b in _pair_sells_with_basis(trades, basis_per_sell)}
+    sell_basis: dict[int, float] = {id(trade): basis for trade, basis in _pair_sells_with_basis(trades, basis_per_sell)}
 
     by_key: dict[tuple[str, str], list[TradeRecord]] = defaultdict(list)
-    for t in trades:
-        by_key[(t.strategy_name, t.ticker)].append(t)
+    for trade in trades:
+        by_key[(trade.strategy_name, trade.ticker)].append(trade)
 
     stats: list[StrategyStats] = []
-    for (name, ticker), strades in sorted(by_key.items()):
-        buys = [t for t in strades if t.direction == Direction.BUY]
-        sells = [t for t in strades if t.direction == Direction.SELL]
+    for (name, ticker), strategy_trades in sorted(by_key.items()):
+        buys = [trade for trade in strategy_trades if trade.direction == Direction.BUY]
+        sells = [trade for trade in strategy_trades if trade.direction == Direction.SELL]
         winning_sells = 0
         total_pnl = 0.0
-        for t in sells:
-            basis = sell_basis.get(id(t), t.price)
-            pnl = (t.price - basis) * t.shares
+        for trade in sells:
+            basis = sell_basis.get(id(trade), trade.price)
+            pnl = (trade.price - basis) * trade.shares
             total_pnl += pnl
             if pnl >= 0:
                 winning_sells += 1
@@ -362,7 +371,7 @@ def compute_strategy_stats(
             StrategyStats(
                 name=name,
                 ticker=ticker,
-                trades=len(strades),
+                trades=len(strategy_trades),
                 buys=len(buys),
                 sells=len(sells),
                 win_rate=round(win_rate, 4),
@@ -376,6 +385,12 @@ DEFAULT_TRAIN_PCT = 0.70
 
 
 class BacktestEngine:
+    """Replays historical price data through strategies to evaluate performance.
+
+    Orchestrates allocation, exit rules, order sizing, and trade execution
+    across a date range, producing a BacktestResult with performance metrics.
+    """
+
     def __init__(
         self,
         allocator: Allocator,
@@ -403,6 +418,19 @@ class BacktestEngine:
         start: date,
         end: date,
     ) -> BacktestResult:
+        """Execute a full backtest over the given date range.
+
+        Args:
+            portfolio: Holdings, cash, and configuration.
+            price_data: Per-ticker OHLCV DataFrames keyed by
+                ticker symbol.
+            start: First calendar date of the simulation window.
+            end: Last calendar date of the simulation window.
+
+        Returns:
+            A BacktestResult containing trades, metrics, and the
+            equity curve.
+        """
         trading_days = self._collect_trading_days(price_data, start, end)
         _, split_date = self._compute_split(trading_days)
         ticker_idx = self._build_ticker_index(price_data, start, end)
@@ -441,7 +469,7 @@ class BacktestEngine:
     ) -> list[date]:
         all_dates: set[date] = set()
         for df in price_data.values():
-            all_dates.update(d for d in df.index if start <= d <= end)
+            all_dates.update(dt for dt in df.index if start <= dt <= end)
         days = sorted(all_dates)
         if not days:
             msg = "No trading days found in date range"
@@ -530,33 +558,32 @@ class BacktestEngine:
             )
         first_dates = self._first_data_dates(price_data, start)
 
-        for h in portfolio.holdings:
-            if h.shares <= 0:
+        for holding in portfolio.holdings:
+            if holding.shares <= 0:
                 continue
 
-            if h.ticker not in first_dates:
-                self._log(f"{h.ticker}: no price data in backtest range ({start} to {end}) — excluded")
+            if holding.ticker not in first_dates:
+                self._log(f"{holding.ticker}: no price data in backtest range ({start} to {end}) — excluded")
                 continue
 
-            ticker_start = first_dates[h.ticker]
+            ticker_start = first_dates[holding.ticker]
             if ticker_start <= trading_days[0]:
-                # Backtest seeds the cost basis from the start-day market
-                # price, not the YAML ``cost_basis``. The YAML value is the
-                # user's real purchase basis (used by the live engine and for
-                # display) — using it here would let exit rules fire on
+                # Backtest seeds the cost basis from the start-day market price, not the YAML
+                # ``cost_basis``. The YAML value is the user's real purchase basis (used by the
+                # live engine and for display) — using it here would let exit rules fire on
                 # pre-backtest gains, distorting strategy performance.
-                entry_df = price_data[h.ticker][price_data[h.ticker].index >= start]
+                entry_df = price_data[holding.ticker][price_data[holding.ticker].index >= start]
                 entry_price = float(entry_df["close"].iloc[0])
-                state.positions[h.ticker] = h.shares
-                state.bh_positions[h.ticker] = h.shares
-                state.lots[h.ticker] = [
+                state.positions[holding.ticker] = holding.shares
+                state.bh_positions[holding.ticker] = holding.shares
+                state.lots[holding.ticker] = [
                     PositionLot(
-                        shares=h.shares,
+                        shares=holding.shares,
                         purchase_date=trading_days[0],
                         cost_basis=entry_price,
                     )
                 ]
-                state.high_water_marks[h.ticker] = entry_price
+                state.high_water_marks[holding.ticker] = entry_price
 
         state.starting_value = state.cash + sum(
             lot.shares * lot.cost_basis for lots in state.lots.values() for lot in lots
@@ -575,16 +602,15 @@ class BacktestEngine:
         first_dates = self._first_data_dates(price_data, start)
         deferred: dict[str, float] = {}
 
-        for h in portfolio.holdings:
-            if h.shares <= 0 or h.ticker not in first_dates:
+        for holding in portfolio.holdings:
+            if holding.shares <= 0 or holding.ticker not in first_dates:
                 continue
-            ticker_start = first_dates[h.ticker]
+            ticker_start = first_dates[holding.ticker]
             if ticker_start > trading_days[0]:
-                deferred[h.ticker] = h.shares
+                deferred[holding.ticker] = holding.shares
                 self._log(
-                    f"{h.ticker}: data starts {ticker_start} "
-                    f"(after backtest start {start}) — "
-                    f"position deferred until first available date"
+                    f"{holding.ticker}: data starts {ticker_start} (after backtest start {start})"
+                    f" — position deferred until first available date"
                 )
         return deferred
 
@@ -628,7 +654,7 @@ class BacktestEngine:
                 closes = _close_prices(current_data)
                 state.split_value = state.portfolio_value(closes)
                 state.split_bh_value = portfolio.available_cash + sum(
-                    state.bh_positions.get(t, 0) * closes.get(t, 0) for t in state.bh_positions
+                    state.bh_positions.get(ticker, 0) * closes.get(ticker, 0) for ticker in state.bh_positions
                 )
                 state.close_twr_period(state.split_value)
                 state.twr_split_idx = len(state.twr_periods)
@@ -652,11 +678,10 @@ class BacktestEngine:
                 entry_price = float(current_data[ticker].close[-1])
                 added_value = shares * entry_price
 
-                # Treat deferred activation like a capital infusion for TWR:
-                # close the current sub-period on existing positions (excluding
-                # the newly activated ticker), then reset the base to include
-                # the new position. Otherwise the new capital would be counted
-                # as pure return by the closing final_value / twr_base ratio.
+                # Treat deferred activation like a capital infusion for TWR: close the current
+                # sub-period on existing positions (excluding the newly activated ticker), then
+                # reset the base to include the new position. Otherwise the new capital would be
+                # counted as pure return by the closing final_value / twr_base ratio.
                 pre_activation_value = state.portfolio_value(_close_prices(current_data))
                 state.close_twr_period(pre_activation_value)
                 state.twr_base_value = pre_activation_value + added_value
@@ -696,7 +721,9 @@ class BacktestEngine:
             pending = state.pending.filtered(set(current_data))
             if pending is not None:
                 price_field = "open" if self._execution_mode == "next_open" else "close"
-                exec_prices = {t: float(getattr(current_data[t], price_field)[-1]) for t in pending.active_tickers}
+                exec_prices = {
+                    ticker: float(getattr(current_data[ticker], price_field)[-1]) for ticker in pending.active_tickers
+                }
                 self._size_and_execute(state, pending, exec_prices, day)
             state.pending = None
 
@@ -746,8 +773,8 @@ class BacktestEngine:
         """
         for ticker, pos in state.positions.items():
             if pos > 0 and ticker in current_data:
-                px = float(current_data[ticker].close[-1])
-                state.high_water_marks[ticker] = max(px, state.high_water_marks.get(ticker, 0.0))
+                price = float(current_data[ticker].close[-1])
+                state.high_water_marks[ticker] = max(price, state.high_water_marks.get(ticker, 0.0))
 
     def _decide(
         self,
@@ -763,8 +790,10 @@ class BacktestEngine:
         ``clamp_attribution`` identifies which exit rule drove each
         clamp for sell-side attribution.
         """
-        active_tickers = [t for t in state.positions if state.positions.get(t, 0) > 0 or t in current_data]
-        active_tickers = [t for t in active_tickers if t in current_data]
+        active_tickers = [
+            ticker for ticker in state.positions if state.positions.get(ticker, 0) > 0 or ticker in current_data
+        ]
+        active_tickers = [ticker for ticker in active_tickers if ticker in current_data]
 
         if not active_tickers:
             return None
@@ -776,9 +805,14 @@ class BacktestEngine:
         # Pass ``None`` (not ``{}``) when the denominator is zero so the
         # allocator falls back to its equal-weight baseline rather than
         # anchoring held tickers at 0.
-        total_value = state.cash + sum(state.positions.get(t, 0.0) * current_prices[t] for t in active_tickers)
+        total_value = state.cash + sum(
+            state.positions.get(ticker, 0.0) * current_prices[ticker] for ticker in active_tickers
+        )
         current_weights: dict[str, float] | None = (
-            {t: (state.positions.get(t, 0.0) * current_prices[t]) / total_value for t in active_tickers}
+            {
+                ticker: (state.positions.get(ticker, 0.0) * current_prices[ticker]) / total_value
+                for ticker in active_tickers
+            }
             if total_value > 0
             else None
         )
@@ -804,11 +838,22 @@ class BacktestEngine:
                     continue
                 cost_basis = self._aggregate_cost_basis(state.lots.get(ticker, []))
                 hwm = state.high_water_marks.get(ticker, 0.0)
-                clamped = rule.clamp_target(ticker, proposed, current_data[ticker], cost_basis, hwm)
+                clamped = rule.clamp_target(
+                    ticker,
+                    proposed,
+                    current_data[ticker],
+                    cost_basis,
+                    hwm,
+                )
                 if clamped < proposed:
                     clamped_targets[ticker] = clamped
                     if ticker not in clamp_attribution:
-                        reason = rule.clamp_reason(ticker, current_data[ticker], cost_basis, hwm)
+                        reason = rule.clamp_reason(
+                            ticker,
+                            current_data[ticker],
+                            cost_basis,
+                            hwm,
+                        )
                         clamp_attribution[ticker] = (rule.name, reason)
 
         clamped_allocation = AllocationResult(
@@ -839,8 +884,8 @@ class BacktestEngine:
         so the delta math is self-consistent with what will actually fill.
         """
         active_tickers = decision.active_tickers
-        positions = {t: state.positions.get(t, 0.0) for t in active_tickers}
-        total_value = state.cash + sum(positions[t] * exec_prices[t] for t in active_tickers)
+        positions = {ticker: state.positions.get(ticker, 0.0) for ticker in active_tickers}
+        total_value = state.cash + sum(positions[ticker] * exec_prices[ticker] for ticker in active_tickers)
 
         # Preserve "hold" semantics across price drift between decision and
         # fill.  A pure-hold ticker (no positive entry-signal contributions,
@@ -853,7 +898,7 @@ class BacktestEngine:
             if ticker in decision.clamp_attribution:
                 continue
             contribs = contribs_map.get(ticker, {})
-            if any(v > 0 for v in contribs.values()):
+            if any(val > 0 for val in contribs.values()):
                 continue
             if total_value <= 0:
                 rebalanced_targets[ticker] = 0.0
@@ -872,7 +917,11 @@ class BacktestEngine:
         def unrestricted(orders: list[Order]) -> list[Order]:
             if not state.restriction_tracker:
                 return orders
-            return [o for o in orders if not state.restriction_tracker.is_blocked(o.ticker, o.direction, day)]
+            return [
+                order
+                for order in orders
+                if not state.restriction_tracker.is_blocked(order.ticker, order.direction, day)
+            ]
 
         exit_orders = unrestricted(
             self._order_sizer.size_sells(
@@ -883,7 +932,7 @@ class BacktestEngine:
                 decision.clamp_attribution,
             )
         )
-        post_sell_cash = state.cash + sum(o.estimated_value for o in exit_orders)
+        post_sell_cash = state.cash + sum(order.estimated_value for order in exit_orders)
 
         buy_orders = unrestricted(
             self._order_sizer.size_buys(
@@ -1094,19 +1143,19 @@ class BacktestEngine:
                 final_prices[ticker] = float(in_range["close"].iloc[-1])
         final_value = state.portfolio_value(final_prices)
         bh_value = portfolio.available_cash + sum(
-            state.bh_positions.get(t, 0) * final_prices.get(t, 0) for t in state.bh_positions
+            state.bh_positions.get(ticker, 0) * final_prices.get(ticker, 0) for ticker in state.bh_positions
         )
 
         # Close the final TWR sub-period and compound all periods.
         state.close_twr_period(final_value)
         twr = math.prod(state.twr_periods) - 1.0
 
-        sv = state.starting_value
-        spbh = state.split_bh_value
+        starting_val = state.starting_value
+        split_bh_val = state.split_bh_value
 
         if split_date:
-            train_trades = [t for t in state.trades if t.date < split_date]
-            test_trades = [t for t in state.trades if t.date >= split_date]
+            train_trades = [trade for trade in state.trades if trade.date < split_date]
+            test_trades = [trade for trade in state.trades if trade.date >= split_date]
         else:
             train_trades = list(state.trades)
             test_trades = []
@@ -1115,12 +1164,12 @@ class BacktestEngine:
         split_idx = state.twr_split_idx
         if split_idx is not None:
             train_twr = 1.0
-            for p in state.twr_periods[:split_idx]:
-                train_twr *= p
+            for period in state.twr_periods[:split_idx]:
+                train_twr *= period
             train_twr -= 1.0
             test_twr = 1.0
-            for p in state.twr_periods[split_idx:]:
-                test_twr *= p
+            for period in state.twr_periods[split_idx:]:
+                test_twr *= period
             test_twr -= 1.0
         else:
             train_twr = twr
@@ -1128,15 +1177,23 @@ class BacktestEngine:
 
         train_return = train_twr
         test_return = test_twr
-        train_bh_return = (spbh - sv) / sv if spbh is not None and sv > 0 else (bh_value - sv) / sv if sv > 0 else 0.0
-        test_bh_return = (
-            (bh_value - spbh) / spbh if spbh is not None and spbh > 0 else (bh_value - sv) / sv if sv > 0 else 0.0
-        )
+        if split_bh_val is not None and starting_val > 0:
+            train_bh_return = (split_bh_val - starting_val) / starting_val
+        elif starting_val > 0:
+            train_bh_return = (bh_value - starting_val) / starting_val
+        else:
+            train_bh_return = 0.0
+        if split_bh_val is not None and split_bh_val > 0:
+            test_bh_return = (bh_value - split_bh_val) / split_bh_val
+        elif starting_val > 0:
+            test_bh_return = (bh_value - starting_val) / starting_val
+        else:
+            test_bh_return = 0.0
 
         # New metrics
         equity_curve = state.equity_curve
         total_days = (trading_days[-1] - trading_days[0]).days if len(trading_days) > 1 else 0
-        cagr = compute_cagr(sv, final_value, total_days)
+        cagr = compute_cagr(starting_val, final_value, total_days)
         max_drawdown = compute_max_drawdown(equity_curve)
         sharpe = compute_sharpe(equity_curve)
         sortino = compute_sortino(equity_curve)
@@ -1155,7 +1212,7 @@ class BacktestEngine:
         return BacktestResult(
             trades=state.trades,
             final_value=round(final_value, 2),
-            starting_value=round(sv, 2),
+            starting_value=round(starting_val, 2),
             buy_and_hold_value=round(bh_value, 2),
             train_trades=train_trades,
             test_trades=test_trades,
@@ -1171,7 +1228,7 @@ class BacktestEngine:
             sharpe_ratio=round(sharpe, 4),
             sortino_ratio=round(sortino, 4),
             win_rate=round(win_rate, 4),
-            profit_factor=round(profit_factor, 4) if not math.isinf(profit_factor) else float("inf"),
+            profit_factor=(round(profit_factor, 4) if not math.isinf(profit_factor) else float("inf")),
             avg_win=round(avg_win, 2),
             avg_loss=round(avg_loss, 2),
             efficiency_ratio=round(efficiency, 4),
@@ -1196,7 +1253,7 @@ def write_backtest_results(result: BacktestResult, output_dir: Path) -> None:
 
 
 def _write_trades_csv(result: BacktestResult, path: Path) -> None:
-    sell_basis = {id(t): b for t, b in _pair_sells_with_basis(result.trades, result.basis_per_sell)}
+    sell_basis = {id(trade): basis for trade, basis in _pair_sells_with_basis(result.trades, result.basis_per_sell)}
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
@@ -1213,20 +1270,20 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
                 "return_pct",
             ]
         )
-        for t in result.trades:
+        for trade in result.trades:
             common = [
-                t.date.isoformat(),
-                t.ticker,
-                t.direction.value,
-                t.shares,
-                t.price,
-                t.strategy_name,
-                t.holding_period.value if t.holding_period else "",
+                trade.date.isoformat(),
+                trade.ticker,
+                trade.direction.value,
+                trade.shares,
+                trade.price,
+                trade.strategy_name,
+                trade.holding_period.value if trade.holding_period else "",
             ]
-            if t.direction == Direction.SELL:
-                basis = sell_basis.get(id(t), t.price)
-                pnl = round((t.price - basis) * t.shares, 4)
-                ret = round((t.price - basis) / basis, 6) if basis != 0 else 0.0
+            if trade.direction == Direction.SELL:
+                basis = sell_basis.get(id(trade), trade.price)
+                pnl = round((trade.price - basis) * trade.shares, 4)
+                ret = round((trade.price - basis) / basis, 6) if basis != 0 else 0.0
                 writer.writerow([*common, round(basis, 4), pnl, ret])
             else:
                 writer.writerow([*common, "", "", ""])
@@ -1237,17 +1294,17 @@ def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["date", "nav", "drawdown"])
-        for (d, nav), dd in zip(result.equity_curve, drawdowns, strict=True):
-            writer.writerow([d.isoformat(), round(nav, 2), round(dd, 6)])
+        for (dt, nav), drawdown in zip(result.equity_curve, drawdowns, strict=True):
+            writer.writerow([dt.isoformat(), round(nav, 2), round(drawdown, 6)])
 
 
 def _write_summary_json(result: BacktestResult, path: Path) -> None:
-    sv = result.starting_value
-    total_return = (result.final_value - sv) / sv if sv > 0 else 0.0
-    bh_return = (result.buy_and_hold_value - sv) / sv if sv > 0 else 0.0
+    starting_val = result.starting_value
+    total_return = (result.final_value - starting_val) / starting_val if starting_val > 0 else 0.0
+    bh_return = (result.buy_and_hold_value - starting_val) / starting_val if starting_val > 0 else 0.0
 
     summary: dict[str, object] = {
-        "starting_value": sv,
+        "starting_value": starting_val,
         "final_value": result.final_value,
         "total_return": round(total_return, 6),
         "cagr": result.cagr,
@@ -1288,30 +1345,30 @@ def _write_strategy_breakdown_csv(result: BacktestResult, path: Path) -> None:
         writer.writerow(["strategy", "ticker", "trades", "buys", "sells", "win_rate", "pnl"])
 
         # Per-(strategy, ticker) rows
-        for s in result.strategy_stats:
+        for stat in result.strategy_stats:
             writer.writerow(
                 [
-                    s.name,
-                    s.ticker,
-                    s.trades,
-                    s.buys,
-                    s.sells,
-                    round(s.win_rate, 4) if s.sells > 0 else "",
-                    round(s.pnl, 2) if s.sells > 0 else "",
+                    stat.name,
+                    stat.ticker,
+                    stat.trades,
+                    stat.buys,
+                    stat.sells,
+                    round(stat.win_rate, 4) if stat.sells > 0 else "",
+                    round(stat.pnl, 2) if stat.sells > 0 else "",
                 ]
             )
 
         # Aggregate per-strategy rows
-        for a in aggregate_strategy_stats(result.strategy_stats):
+        for agg in aggregate_strategy_stats(result.strategy_stats):
             writer.writerow(
                 [
-                    a.name,
+                    agg.name,
                     "*",
-                    a.trades,
-                    a.buys,
-                    a.sells,
-                    a.win_rate if a.sells > 0 else "",
-                    a.pnl if a.sells > 0 else "",
+                    agg.trades,
+                    agg.buys,
+                    agg.sells,
+                    agg.win_rate if agg.sells > 0 else "",
+                    agg.pnl if agg.sells > 0 else "",
                 ]
             )
 

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -79,15 +79,15 @@ def _fetch_prices(
     """
     provider = CachedYFinanceProvider()
     price_data: dict[str, pd.DataFrame] = {}
-    tickers = [h.ticker for h in portfolio.holdings]
+    tickers = [holding.ticker for holding in portfolio.holdings]
     buffer_days = warmup_bars_to_calendar_days(warmup_bars)
     fetch_start = start - timedelta(days=buffer_days)
     print_status(f"Fetching data for {', '.join(tickers)} (with {buffer_days}-day warmup buffer from {fetch_start})...")
     for ticker in tickers:
         try:
             price_data[ticker] = provider.get_history(ticker, fetch_start, end)
-        except Exception as e:
-            print_status(f"Skipping {ticker}: {e}")
+        except Exception as exc:
+            print_status(f"Skipping {ticker}: {exc}")
     return price_data
 
 
@@ -153,7 +153,7 @@ def backtest(
 
     start_d, end_d = _to_date(start), _to_date(end)
 
-    n_tickers = sum(1 for h in port.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in port.holdings if holding.shares > 0)
     allocator, order_sizer, exit_rules = _build_components(
         strat_configs,
         constraints,
@@ -213,7 +213,7 @@ def live(
     strat_configs, constraints = load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints())
     provider = CachedYFinanceProvider()
 
-    n_tickers = sum(1 for h in port.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in port.holdings if holding.shares > 0)
     allocator, order_sizer, exit_rules = _build_components(
         strat_configs,
         constraints,
@@ -330,11 +330,11 @@ def optimize(
     min_cash_pct = AllocationConstraints().min_cash_pct
     if strategies:
         strat_configs, strat_constraints = load_strategies(Path(strategies))
-        strategy_names = [c.name for c in strat_configs]
+        strategy_names = [cfg.name for cfg in strat_configs]
         min_cash_pct = strat_constraints.min_cash_pct
 
     start_d, end_d = _to_date(start), _to_date(end)
-    n_tickers = sum(1 for h in port.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in port.holdings if holding.shares > 0)
     warmup_bars = max_warmup_for_search(strategy_names, min_cash_pct, n_tickers)
     price_data = _fetch_prices(port, start_d, end_d, warmup_bars=warmup_bars)
 
@@ -378,17 +378,17 @@ def optimize(
         fold_table.add_column("Sharpe", justify="right")
         fold_table.add_column("Sortino", justify="right")
         fold_table.add_column("Win Rate", justify="right")
-        for f in wf_result.folds:
+        for fold in wf_result.folds:
             fold_table.add_row(
-                str(f.fold),
-                f"{f.train_start} → {f.train_end}",
-                f"{f.test_start} → {f.test_end}",
-                f"{f.train_return:.2%}",
-                color_signed(f.test_return),
-                f"[red]{f.max_drawdown:.2%}[/red]",
-                color_signed(f.sharpe_ratio, fmt=".2f"),
-                color_signed(f.sortino_ratio, fmt=".2f"),
-                f"{f.win_rate:.0%}" if f.win_rate > 0 else "—",
+                str(fold.fold),
+                f"{fold.train_start} → {fold.train_end}",
+                f"{fold.test_start} → {fold.test_end}",
+                f"{fold.train_return:.2%}",
+                color_signed(fold.test_return),
+                f"[red]{fold.max_drawdown:.2%}[/red]",
+                color_signed(fold.sharpe_ratio, fmt=".2f"),
+                color_signed(fold.sortino_ratio, fmt=".2f"),
+                f"{fold.win_rate:.0%}" if fold.win_rate > 0 else "—",
             )
         print_centered(fold_table)
 

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -27,11 +27,11 @@ def load_portfolio(path: Path) -> PortfolioConfig:
 
     holdings = [
         Holding(
-            ticker=h["ticker"],
-            shares=float(h["shares"]),
-            cost_basis=float(h["cost_basis"]) if "cost_basis" in h else None,
+            ticker=entry["ticker"],
+            shares=float(entry["shares"]),
+            cost_basis=float(entry["cost_basis"]) if "cost_basis" in entry else None,
         )
-        for h in raw["portfolio"]
+        for entry in raw["portfolio"]
     ]
 
     infusion = None
@@ -77,13 +77,13 @@ def load_strategies(
     raw = _load_yaml(path)
 
     configs = []
-    for s in raw["strategies"]:
+    for strat in raw["strategies"]:
         configs.append(
             StrategyConfig(
-                name=s["name"],
-                params=s.get("params", {}),
-                tickers=s.get("tickers"),
-                weight=float(s.get("weight", 1.0)),
+                name=strat["name"],
+                params=strat.get("params", {}),
+                tickers=strat.get("tickers"),
+                weight=float(strat.get("weight", 1.0)),
             )
         )
 

--- a/src/midas/data/price_history.py
+++ b/src/midas/data/price_history.py
@@ -70,7 +70,7 @@ class PriceHistory:
         objects (provider contract). Values are copied into numpy arrays.
         """
         required = ("open", "high", "low", "close")
-        missing = [c for c in required if c not in df.columns]
+        missing = [col for col in required if col not in df.columns]
         if missing:
             msg = f"PriceHistory requires columns {required}; missing: {missing}"
             raise ValueError(msg)

--- a/src/midas/data/yfinance_provider.py
+++ b/src/midas/data/yfinance_provider.py
@@ -83,8 +83,8 @@ class CachedYFinanceProvider(DataProvider):
         return frame
 
     def get_current_price(self, ticker: str) -> float:
-        t = yf.Ticker(ticker)
-        hist = t.history(period="1d")
+        yf_ticker = yf.Ticker(ticker)
+        hist = yf_ticker.history(period="1d")
         if hist.empty:
             msg = f"No current price available for {ticker}"
             raise ValueError(msg)

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -70,7 +70,7 @@ class LiveEngine:
         # in-profit gate fails when underwater. The rule never fires.
         # Warn loudly so optimized strategies that rely on TrailingStop
         # aren't silently neutered at deployment.
-        if any(isinstance(r, TrailingStop) for r in self._exit_rules):
+        if any(isinstance(rule, TrailingStop) for rule in self._exit_rules):
             logger.warning(
                 "TrailingStop is configured but live mode does not track a "
                 "real high-water mark — it will NOT fire. Optimized backtest "
@@ -79,7 +79,7 @@ class LiveEngine:
             )
 
     def run(self) -> None:
-        tickers = [h.ticker for h in self._portfolio.holdings]
+        tickers = [holding.ticker for holding in self._portfolio.holdings]
         print_status(
             f"Starting {'dry run' if self._dry_run else 'live'} analysis "
             f"for {len(tickers)} tickers, polling every {self._poll_interval}s"
@@ -108,8 +108,8 @@ class LiveEngine:
                 df = self._provider.get_history(ticker, start, end)
                 price_history[ticker] = PriceHistory.from_dataframe(df)
                 price_data[ticker] = df
-            except Exception as e:
-                print_status(f"Warning: failed to fetch {ticker}: {e}")
+            except Exception as exc:
+                print_status(f"Warning: failed to fetch {ticker}: {exc}")
 
         if not price_data:
             return
@@ -117,7 +117,11 @@ class LiveEngine:
         # If any held position is missing from price_data, we can't compute an
         # accurate portfolio denominator for current_weights — skip the tick
         # rather than let Option A hold inflated weights based on partial info.
-        missing_held = [h.ticker for h in self._portfolio.holdings if h.shares > 0 and h.ticker not in price_data]
+        missing_held = [
+            holding.ticker
+            for holding in self._portfolio.holdings
+            if holding.shares > 0 and holding.ticker not in price_data
+        ]
         if missing_held:
             print_status(f"Skipping tick: missing price data for held positions {missing_held}. Will retry next poll.")
             return
@@ -127,20 +131,24 @@ class LiveEngine:
             if ticker in price_data and len(price_data[ticker]) > 0:
                 current_prices[ticker] = float(price_data[ticker]["close"].iloc[-1])
 
-        active_tickers = [t for t in tickers if t in price_data]
+        active_tickers = [ticker for ticker in tickers if ticker in price_data]
 
         # Current positions + weights (weights feed Option A: neutral=hold).
         positions = {}
-        for t in active_tickers:
-            holding = self._portfolio.get_holding(t)
-            positions[t] = holding.shares if holding else 0.0
+        for ticker in active_tickers:
+            held = self._portfolio.get_holding(ticker)
+            positions[ticker] = held.shares if held else 0.0
 
         # Pass None (not {}) when the denominator is zero so the allocator
         # falls back to its equal-weight baseline.
-        total_value = self._portfolio.available_cash + sum(positions[t] * current_prices[t] for t in active_tickers)
+        total_value = self._portfolio.available_cash + sum(
+            positions[ticker] * current_prices[ticker] for ticker in active_tickers
+        )
         current_weights: dict[str, float] | None = None
         if total_value > 0:
-            current_weights = {t: (positions[t] * current_prices[t]) / total_value for t in active_tickers}
+            current_weights = {
+                ticker: (positions[ticker] * current_prices[ticker]) / total_value for ticker in active_tickers
+            }
 
         # Phase 1: Allocator scores entry signals and blends to target weights.
         allocation = self._allocator.allocate(
@@ -193,9 +201,11 @@ class LiveEngine:
         )
         if self._restriction_tracker:
             exit_orders = [
-                o for o in exit_orders if not self._restriction_tracker.is_blocked(o.ticker, o.direction, today)
+                order
+                for order in exit_orders
+                if not self._restriction_tracker.is_blocked(order.ticker, order.direction, today)
             ]
-        sell_proceeds = sum(o.estimated_value for o in exit_orders)
+        sell_proceeds = sum(order.estimated_value for order in exit_orders)
         post_sell_cash = self._portfolio.available_cash + sell_proceeds
 
         clamped_allocation = AllocationResult(
@@ -214,13 +224,15 @@ class LiveEngine:
         )
         if self._restriction_tracker:
             buy_orders = [
-                o for o in buy_orders if not self._restriction_tracker.is_blocked(o.ticker, o.direction, today)
+                order
+                for order in buy_orders
+                if not self._restriction_tracker.is_blocked(order.ticker, order.direction, today)
             ]
 
         filtered = exit_orders + buy_orders
 
         # Emit alerts only when the order set changes
-        current_keys = {(o.ticker, o.direction, o.shares) for o in filtered if o.shares > 0}
+        current_keys = {(order.ticker, order.direction, order.shares) for order in filtered if order.shares > 0}
         if current_keys == self._last_order_keys:
             return
         self._last_order_keys = current_keys

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -70,7 +70,7 @@ class PortfolioConfig:
     trading_restrictions: TradingRestrictions | None = None
 
     def __post_init__(self) -> None:
-        self._by_ticker = {h.ticker: h for h in self.holdings}
+        self._by_ticker = {holding.ticker: holding for holding in self.holdings}
 
     def get_holding(self, ticker: str) -> Holding | None:
         return self._by_ticker.get(ticker)

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -240,7 +240,9 @@ def _run_trial(
             continue
         cls = STRATEGY_REGISTRY[name]
         weight = params.get("_weight", 1.0)
-        clean_params = {k: int(v) if k in INT_PARAMS else v for k, v in params.items() if k not in META_PARAMS}
+        clean_params = {
+            key: int(val) if key in INT_PARAMS else val for key, val in params.items() if key not in META_PARAMS
+        }
         strategy = cls(**clean_params)
 
         if isinstance(strategy, ExitRule):
@@ -252,7 +254,7 @@ def _run_trial(
             raise TypeError(msg)
 
     # Count tickers in portfolio
-    n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in portfolio.holdings if holding.shares > 0)
     constraints = AllocationConstraints(
         max_position_pct=global_params.get("max_position_pct"),
         min_cash_pct=min_cash_pct,
@@ -361,7 +363,7 @@ def max_warmup_for_search(
     ``warmup_period``.
     """
     names, ranges = _prepare_names_and_ranges(strategy_names, min_cash_pct, n_tickers)
-    max_w = 0
+    max_warmup_val = 0
     for name in names:
         if name == ALLOCATION_KEY:
             continue
@@ -378,8 +380,8 @@ def max_warmup_for_search(
         # Let TypeError propagate — if a search-range key doesn't match a
         # constructor param, that's a real configuration bug we want loud.
         instance = cls(**params)
-        max_w = max(max_w, instance.warmup_period)
-    return max_w
+        max_warmup_val = max(max_warmup_val, instance.warmup_period)
+    return max_warmup_val
 
 
 def _prepare_names_and_ranges(
@@ -388,8 +390,8 @@ def _prepare_names_and_ranges(
     n_tickers: int,
 ) -> tuple[list[str], dict[str, dict[str, tuple[float, float, float]]]]:
     """Resolve strategy names and build parameter ranges (shared by optimize/walk-forward)."""
-    names = strategy_names or [k for k in PARAM_RANGES if k != ALLOCATION_KEY]
-    names = [n for n in names if n in PARAM_RANGES]
+    names = strategy_names or [key for key in PARAM_RANGES if key != ALLOCATION_KEY]
+    names = [name for name in names if name in PARAM_RANGES]
 
     if not names:
         msg = "No optimizable strategies found"
@@ -403,7 +405,7 @@ def _prepare_names_and_ranges(
     if lo >= hi:
         lo, hi = 0.10, 0.80
     step = round((hi - lo) / 8, 2) or 0.01
-    ranges = {k: dict(PARAM_RANGES[k]) for k in names if k in PARAM_RANGES}
+    ranges = {name: dict(PARAM_RANGES[name]) for name in names if name in PARAM_RANGES}
     ranges.setdefault(ALLOCATION_KEY, {})
     ranges[ALLOCATION_KEY]["max_position_pct"] = (lo, hi, step)
 
@@ -430,12 +432,12 @@ def optimize(
     """
     log = log_fn or (lambda _: None)
 
-    n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in portfolio.holdings if holding.shares > 0)
     names, ranges = _prepare_names_and_ranges(strategy_names, min_cash_pct, n_tickers)
 
     max_workers = min((os.cpu_count() or 4) // 2, n_trials) or 1
 
-    strat_names = [n for n in names if n != ALLOCATION_KEY]
+    strat_names = [name for name in names if name != ALLOCATION_KEY]
     log(f"Optimizing {len(strat_names)} strategies over {start} to {end}")
     log(f"  {n_trials} trials across {max_workers} workers")
 
@@ -548,13 +550,13 @@ def walk_forward_optimize(
     """
     log = log_fn or (lambda _: None)
 
-    n_tickers = sum(1 for h in portfolio.holdings if h.shares > 0)
+    n_tickers = sum(1 for holding in portfolio.holdings if holding.shares > 0)
     names, ranges = _prepare_names_and_ranges(strategy_names, min_cash_pct, n_tickers)
 
     # Collect trading days across all tickers.
     all_dates: set[date] = set()
     for df in price_data.values():
-        all_dates.update(d for d in df.index if start <= d <= end)
+        all_dates.update(dt for dt in df.index if start <= dt <= end)
     trading_days = sorted(all_dates)
 
     n_days = len(trading_days)
@@ -575,7 +577,7 @@ def walk_forward_optimize(
     trials_per_fold = max(n_trials // n_folds, 10)
     max_workers = min((os.cpu_count() or 4) // 2, trials_per_fold) or 1
 
-    strat_names = [n for n in names if n != ALLOCATION_KEY]
+    strat_names = [name for name in names if name != ALLOCATION_KEY]
     log(f"Walk-forward optimization — {len(strat_names)} strategies, {start} to {end}")
     log(f"  {n_folds} folds, ~{test_size} trading days per test window, {trials_per_fold} trials/fold")
 
@@ -689,42 +691,42 @@ def walk_forward_optimize(
     finally:
         pool.shutdown(wait=True)
 
-    test_returns = [f.test_return for f in fold_results]
+    test_returns = [fold.test_return for fold in fold_results]
     mean_test = sum(test_returns) / len(test_returns)
-    variance = sum((r - mean_test) ** 2 for r in test_returns) / max(len(test_returns) - 1, 1)
+    variance = sum((ret - mean_test) ** 2 for ret in test_returns) / max(len(test_returns) - 1, 1)
     std_test = variance**0.5
 
     # CAGR: compound per-fold returns, then annualize over the OOS period.
     compounded = 1.0
-    for r in test_returns:
-        compounded *= 1.0 + r
+    for ret in test_returns:
+        compounded *= 1.0 + ret
     first_test_start = fold_results[0].test_start
     last_test_end = fold_results[-1].test_end
     years = (last_test_end - first_test_start).days / 365.25
     annualized = compounded ** (1.0 / years) - 1.0 if years > 0 and compounded > 0 else 0.0
 
-    winning_folds = sum(1 for r in test_returns if r > 0)
+    winning_folds = sum(1 for ret in test_returns if ret > 0)
     best_fold = max(test_returns)
     worst_fold = min(test_returns)
 
     # Efficiency ratio: how much in-sample performance survives out-of-sample.
     # Anchored IS windows overlap so we can't annualize them apples-to-apples
     # with OOS — only the ratio of mean raw returns is reported.
-    train_returns = [f.train_return for f in fold_results]
+    train_returns = [fold.train_return for fold in fold_results]
     mean_train = sum(train_returns) / len(train_returns)
     efficiency = mean_test / mean_train if mean_train != 0 else 0.0
 
-    n = len(fold_results)
-    mean_dd = sum(f.max_drawdown for f in fold_results) / n
-    mean_sharpe = sum(f.sharpe_ratio for f in fold_results) / n
-    mean_sortino = sum(f.sortino_ratio for f in fold_results) / n
-    mean_wr = sum(f.win_rate for f in fold_results) / n
+    num_folds = len(fold_results)
+    mean_dd = sum(fold.max_drawdown for fold in fold_results) / num_folds
+    mean_sharpe = sum(fold.sharpe_ratio for fold in fold_results) / num_folds
+    mean_sortino = sum(fold.sortino_ratio for fold in fold_results) / num_folds
+    mean_wr = sum(fold.win_rate for fold in fold_results) / num_folds
 
     log("")
     log("Walk-forward complete")
     log(f"  Annualized OOS return (CAGR): {annualized:.2%}")
     log(f"  Per-fold mean: {mean_test:.2%} ± {std_test:.2%}")
-    log(f"  Winning folds: {winning_folds}/{n} | Best: {best_fold:.2%} | Worst: {worst_fold:.2%}")
+    log(f"  Winning folds: {winning_folds}/{num_folds} | Best: {best_fold:.2%} | Worst: {worst_fold:.2%}")
     log(f"  Efficiency ratio: {efficiency:.0%}")
     log(f"  Mean max drawdown: {mean_dd:.2%} | Mean Sharpe: {mean_sharpe:.2f}")
 
@@ -738,7 +740,7 @@ def walk_forward_optimize(
         worst_fold_return=round(worst_fold, 4),
         efficiency_ratio=round(efficiency, 4),
         best_params=fold_results[-1].best_params,
-        total_trials=sum(f.trials_run for f in fold_results),
+        total_trials=sum(fold.trials_run for fold in fold_results),
         mean_max_drawdown=round(mean_dd, 4),
         mean_sharpe=round(mean_sharpe, 4),
         mean_sortino=round(mean_sortino, 4),
@@ -756,25 +758,25 @@ def write_strategies_yaml(
 
     # Emit global allocation knobs as top-level keys
     if ALLOCATION_KEY in params:
-        for k, v in params[ALLOCATION_KEY].items():
-            output[k] = round(v, 4)
+        for key, val in params[ALLOCATION_KEY].items():
+            output[key] = round(val, 4)
 
     # min_cash_pct is not optimized — preserve the user's configured value
     output["min_cash_pct"] = round(min_cash_pct, 4)
 
     strategies = []
-    for name, p in params.items():
+    for name, param_dict in params.items():
         if name == ALLOCATION_KEY:
             continue
         entry: dict[str, object] = {"name": name}
         clean_params: dict[str, object] = {}
-        for k, v in p.items():
-            if k == "_weight":
-                entry["weight"] = round(v, 4)
-            elif k in INT_PARAMS:
-                clean_params[k] = int(v)
+        for key, val in param_dict.items():
+            if key == "_weight":
+                entry["weight"] = round(val, 4)
+            elif key in INT_PARAMS:
+                clean_params[key] = int(val)
             else:
-                clean_params[k] = round(v, 4)
+                clean_params[key] = round(val, 4)
         if clean_params:
             entry["params"] = clean_params
         strategies.append(entry)

--- a/src/midas/order_sizer.py
+++ b/src/midas/order_sizer.py
@@ -75,8 +75,8 @@ class OrderSizer:
         current_weights: dict[str, float] = {}
         for ticker in allocation.targets:
             pos = positions.get(ticker, 0.0)
-            px = prices.get(ticker, 0.0)
-            current_weights[ticker] = (pos * px) / total_value
+            price = prices.get(ticker, 0.0)
+            current_weights[ticker] = (pos * price) / total_value
 
         # Circuit breaker: cap daily deployment.
         max_deploy = total_value * self._circuit_breaker_pct
@@ -92,8 +92,8 @@ class OrderSizer:
             if delta < constraints.min_buy_delta:
                 continue
 
-            px = prices.get(ticker, 0.0)
-            if px <= 0:
+            price = prices.get(ticker, 0.0)
+            if price <= 0:
                 continue
 
             # Every buy must be attributable to a positive entry-signal
@@ -104,7 +104,7 @@ class OrderSizer:
             # exactly the phantom-buy bug. Suppress and warn instead of
             # emitting an order with an empty source.
             contribs = allocation.contributions.get(ticker, {})
-            positive = {k: v for k, v in contribs.items() if v > 0}
+            positive = {name: val for name, val in contribs.items() if val > 0}
             if not positive:
                 logger.warning(
                     "Suppressing buy for %s: positive delta %.4f with no "
@@ -116,8 +116,8 @@ class OrderSizer:
                 continue
 
             buy_value = delta * total_value
-            slip_price = px * (1 + self._default_slippage)
-            shares = math.floor(buy_value / px)
+            slip_price = price * (1 + self._default_slippage)
+            shares = math.floor(buy_value / price)
 
             # Cash constraint.
             affordable = math.floor(available / slip_price)
@@ -177,18 +177,18 @@ class OrderSizer:
                 continue
 
             pos = positions.get(ticker, 0.0)
-            px = prices.get(ticker, 0.0)
-            if pos <= 0 or px <= 0:
+            price = prices.get(ticker, 0.0)
+            if pos <= 0 or price <= 0:
                 continue
 
-            current_w = (pos * px) / total_value
+            current_w = (pos * price) / total_value
             delta = current_w - clamped_w
             if delta <= 0:
                 continue
 
             sell_value = delta * total_value
-            slip_price = px * (1 - self._default_slippage)
-            shares = math.floor(sell_value / px)
+            slip_price = price * (1 - self._default_slippage)
+            shares = math.floor(sell_value / price)
             shares = min(shares, math.floor(pos))
             if shares <= 0:
                 continue
@@ -231,8 +231,8 @@ class OrderSizer:
         reason = (
             f"Buy {ticker}: target {target_weight:.1%} vs current {current_weight:.1%} (blended score {blended:+.3f})"
         )
-        positive = {k: v for k, v in contribs.items() if v > 0}
-        source = max(positive, key=lambda k: positive[k])
+        positive = {name: val for name, val in contribs.items() if val > 0}
+        source = max(positive, key=lambda name: positive[name])
         return OrderContext(
             contributions=contribs,
             blended_score=blended,

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -66,9 +66,9 @@ def print_strategy_table(strategies: list[Strategy]) -> None:
     table.add_column("Description")
     table.add_column("Suitability", style="cyan")
 
-    for s in strategies:
-        tags = ", ".join(t.value for t in s.suitability)
-        table.add_row(s.name, s.tier_label, s.description, tags)
+    for strat in strategies:
+        tags = ", ".join(tag.value for tag in strat.suitability)
+        table.add_row(strat.name, strat.tier_label, strat.description, tags)
 
     console.print(table, justify="center")
 
@@ -107,8 +107,8 @@ def print_centered(table: Table) -> None:
 def print_run_info(rows: list[tuple[str, str]], title: str = "Run Info") -> None:
     """Render a small key/value table for run metadata (trials, output path, etc)."""
     table = make_metric_table(title)
-    for k, v in rows:
-        table.add_row(k, v)
+    for label, value in rows:
+        table.add_row(label, value)
     print_centered(table)
 
 
@@ -125,25 +125,27 @@ def print_params_table(
     table = make_wide_table(title)
     table.add_column("Strategy", style="bold")
     table.add_column("Parameters")
-    for name, p in params.items():
+    for name, param_dict in params.items():
         display = "Global" if global_key is not None and name == global_key else name
-        table.add_row(display, ", ".join(f"{k}={v}" for k, v in p.items()))
+        table.add_row(display, ", ".join(f"{key}={val}" for key, val in param_dict.items()))
     print_centered(table)
 
 
 def print_backtest_summary(result: BacktestResult) -> None:
-    sv, fv, bhv = result.starting_value, result.final_value, result.buy_and_hold_value
-    total_return = (fv - sv) / sv if sv > 0 else 0
-    bh_return = (bhv - sv) / sv if sv > 0 else 0
+    starting_val = result.starting_value
+    final_val = result.final_value
+    bh_val = result.buy_and_hold_value
+    total_return = (final_val - starting_val) / starting_val if starting_val > 0 else 0
+    bh_return = (bh_val - starting_val) / starting_val if starting_val > 0 else 0
 
     # --- Performance ---
     perf = make_metric_table("Performance")
-    perf.add_row("Starting Value", f"${sv:,.2f}")
-    perf.add_row("Final Value", f"${fv:,.2f}")
+    perf.add_row("Starting Value", f"${starting_val:,.2f}")
+    perf.add_row("Final Value", f"${final_val:,.2f}")
     perf.add_row("Total Return", color_signed(total_return))
     perf.add_row("CAGR", color_signed(result.cagr))
     perf.add_row("Time-Weighted Return", color_signed(result.twr))
-    perf.add_row("Buy & Hold Value", f"${bhv:,.2f}")
+    perf.add_row("Buy & Hold Value", f"${bh_val:,.2f}")
     perf.add_row("Buy & Hold Return", color_signed(bh_return))
     perf.add_row("Total Trades", str(len(result.trades)))
     print_centered(perf)
@@ -169,7 +171,7 @@ def print_backtest_summary(result: BacktestResult) -> None:
     print_centered(risk_table)
 
     # --- Trade Quality ---
-    if any(t.direction == Direction.SELL for t in result.trades):
+    if any(trade.direction == Direction.SELL for trade in result.trades):
         trade_table = make_metric_table("Trade Quality")
         trade_table.add_row("Win Rate", color_signed(result.win_rate))
         pf_str = f"{result.profit_factor:.2f}" if not math.isinf(result.profit_factor) else "∞"
@@ -188,15 +190,15 @@ def print_backtest_summary(result: BacktestResult) -> None:
         agg_table.add_column("Win Rate", justify="right")
         agg_table.add_column("P&L", justify="right")
 
-        for a in aggregate_strategy_stats(result.strategy_stats):
-            pnl_style = "green" if a.pnl >= 0 else "red"
+        for agg in aggregate_strategy_stats(result.strategy_stats):
+            pnl_style = "green" if agg.pnl >= 0 else "red"
             agg_table.add_row(
-                a.name,
-                str(a.trades),
-                str(a.buys),
-                str(a.sells),
-                f"{a.win_rate:.0%}" if a.sells > 0 else "—",
-                f"[{pnl_style}]${a.pnl:,.2f}[/{pnl_style}]" if a.sells > 0 else "—",
+                agg.name,
+                str(agg.trades),
+                str(agg.buys),
+                str(agg.sells),
+                f"{agg.win_rate:.0%}" if agg.sells > 0 else "—",
+                f"[{pnl_style}]${agg.pnl:,.2f}[/{pnl_style}]" if agg.sells > 0 else "—",
             )
 
         unr = result.unrealized_pnl
@@ -222,16 +224,16 @@ def print_backtest_summary(result: BacktestResult) -> None:
         detail_table.add_column("Win Rate", justify="right")
         detail_table.add_column("P&L", justify="right")
 
-        for s in result.strategy_stats:
-            pnl_style = "green" if s.pnl >= 0 else "red"
+        for stat in result.strategy_stats:
+            pnl_style = "green" if stat.pnl >= 0 else "red"
             detail_table.add_row(
-                s.name,
-                s.ticker,
-                str(s.trades),
-                str(s.buys),
-                str(s.sells),
-                f"{s.win_rate:.0%}" if s.sells > 0 else "—",
-                f"[{pnl_style}]${s.pnl:,.2f}[/{pnl_style}]" if s.sells > 0 else "—",
+                stat.name,
+                stat.ticker,
+                str(stat.trades),
+                str(stat.buys),
+                str(stat.sells),
+                f"{stat.win_rate:.0%}" if stat.sells > 0 else "—",
+                f"[{pnl_style}]${stat.pnl:,.2f}[/{pnl_style}]" if stat.sells > 0 else "—",
             )
 
         detail_table.add_section()

--- a/src/midas/strategies/base.py
+++ b/src/midas/strategies/base.py
@@ -55,7 +55,7 @@ MIN_WARMUP_CALENDAR_DAYS = 30
 
 def max_warmup(strategies: Iterable[Strategy]) -> int:
     """Largest ``warmup_period`` across an iterable of strategies (0 if empty)."""
-    return max((s.warmup_period for s in strategies), default=0)
+    return max((strat.warmup_period for strat in strategies), default=0)
 
 
 def warmup_bars_to_calendar_days(bars: int) -> int:

--- a/src/midas/strategies/bollinger_band.py
+++ b/src/midas/strategies/bollinger_band.py
@@ -20,25 +20,25 @@ class BollingerBand(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w:
+        num_bars = len(prices)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window:
             return scores
-        cs = np.empty(n + 1)
+        cs = np.empty(num_bars + 1)
         cs[0] = 0.0
         np.cumsum(prices, out=cs[1:])
-        sq_cs = np.empty(n + 1)
+        sq_cs = np.empty(num_bars + 1)
         sq_cs[0] = 0.0
         np.cumsum(prices**2, out=sq_cs[1:])
-        rolling_sum = cs[w:] - cs[:-w]
-        rolling_sq = sq_cs[w:] - sq_cs[:-w]
-        ma = rolling_sum / w
-        variance = (rolling_sq / w - ma**2) * w / (w - 1)
+        rolling_sum = cs[window:] - cs[:-window]
+        rolling_sq = sq_cs[window:] - sq_cs[:-window]
+        ma = rolling_sum / window
+        variance = (rolling_sq / window - ma**2) * window / (window - 1)
         std = np.sqrt(np.maximum(variance, 0.0))
-        current = prices[w - 1 :]
-        z = np.where(std != 0, (current - ma) / std, 0.0)
-        scores[w - 1 :] = np.clip(-z / self._num_std, 0.0, 1.0)
+        current = prices[window - 1 :]
+        z_score = np.where(std != 0, (current - ma) / std, 0.0)
+        scores[window - 1 :] = np.clip(-z_score / self._num_std, 0.0, 1.0)
         return scores
 
     def score(
@@ -62,8 +62,8 @@ class BollingerBand(EntrySignal):
         # negative z (below MA) ramps from 0 at the MA to 1 at the lower band.
         # The bearish "above upper band" half is dropped — exits are handled
         # by ExitRule strategies.
-        z = (current - ma) / std
-        return self.clamp(-z / self._num_std, 0.0, 1.0)
+        z_score = (current - ma) / std
+        return self.clamp(-z_score / self._num_std, 0.0, 1.0)
 
     @property
     def suitability(self) -> list[AssetSuitability]:

--- a/src/midas/strategies/chandelier_stop.py
+++ b/src/midas/strategies/chandelier_stop.py
@@ -35,16 +35,16 @@ class ChandelierStop(ExitRule):
         simple mean (no iteration). With more, the exponential decay tail
         matches Wilder's original definition and most charting tools.
         """
-        n = len(close)
-        tr = np.empty(n)
+        num_bars = len(close)
+        tr = np.empty(num_bars)
         tr[0] = high[0] - low[0]
-        if n > 1:
+        if num_bars > 1:
             prev_c = close[:-1]
             tr[1:] = np.maximum.reduce([high[1:] - low[1:], np.abs(high[1:] - prev_c), np.abs(low[1:] - prev_c)])
-        w = self._window
-        atr = float(tr[:w].mean())
-        for t in range(w, n):
-            atr = ((w - 1) * atr + float(tr[t])) / w
+        window = self._window
+        atr = float(tr[:window].mean())
+        for idx in range(window, num_bars):
+            atr = ((window - 1) * atr + float(tr[idx])) / window
         return atr
 
     def _stop_level(self, price_history: PriceHistory) -> tuple[float, float, float] | None:

--- a/src/midas/strategies/donchian_breakout.py
+++ b/src/midas/strategies/donchian_breakout.py
@@ -21,18 +21,18 @@ class DonchianBreakout(EntrySignal):
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         highs = price_history.high
         close = price_history.close
-        n = len(close)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w + 1:
+        num_bars = len(close)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window + 1:
             return scores
-        windows = np.lib.stride_tricks.sliding_window_view(highs[:-1], w)
+        windows = np.lib.stride_tricks.sliding_window_view(highs[:-1], window)
         prior_highs = windows.max(axis=1)
-        current = close[w:]
+        current = close[window:]
         with np.errstate(divide="ignore", invalid="ignore"):
             excess_pct = np.where(prior_highs > 0, (current - prior_highs) / prior_highs, 0.0)
         raw = np.where(current > prior_highs, excess_pct / self._breakout_scale, 0.0)
-        scores[w:] = np.clip(raw, 0.0, 1.0)
+        scores[window:] = np.clip(raw, 0.0, 1.0)
         return scores
 
     def score(

--- a/src/midas/strategies/gap_down_recovery.py
+++ b/src/midas/strategies/gap_down_recovery.py
@@ -20,9 +20,9 @@ class GapDownRecovery(EntrySignal):
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         close = price_history.close
         opens = price_history.open
-        n = len(close)
-        scores = np.full(n, np.nan)
-        if n < 2:
+        num_bars = len(close)
+        scores = np.full(num_bars, np.nan)
+        if num_bars < 2:
             return scores
         prev_close = close[:-1]
         today_open = opens[1:]

--- a/src/midas/strategies/keltner_channel.py
+++ b/src/midas/strategies/keltner_channel.py
@@ -15,10 +15,10 @@ def _true_range_series(high: np.ndarray, low: np.ndarray, close: np.ndarray) -> 
     Bar 0 has no prior close available, so its TR falls back to H - L
     (Wilder convention). Bars 1..n-1 use max(H-L, |H-prevC|, |L-prevC|).
     """
-    n = len(close)
-    tr = np.empty(n)
+    num_bars = len(close)
+    tr = np.empty(num_bars)
     tr[0] = high[0] - low[0]
-    if n > 1:
+    if num_bars > 1:
         prev_c = close[:-1]
         tr[1:] = np.maximum.reduce([high[1:] - low[1:], np.abs(high[1:] - prev_c), np.abs(low[1:] - prev_c)])
     return tr
@@ -35,26 +35,26 @@ class KeltnerChannel(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         close = price_history.close
-        n = len(close)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w or w < 2:
+        num_bars = len(close)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window or window < 2:
             return scores
-        cs = np.empty(n + 1)
+        cs = np.empty(num_bars + 1)
         cs[0] = 0.0
         np.cumsum(close, out=cs[1:])
-        centerlines = (cs[w:] - cs[:-w]) / w
+        centerlines = (cs[window:] - cs[:-window]) / window
         tr = _true_range_series(price_history.high, price_history.low, close)
-        cs_tr = np.empty(n + 1)
+        cs_tr = np.empty(num_bars + 1)
         cs_tr[0] = 0.0
         np.cumsum(tr, out=cs_tr[1:])
-        atr_series = (cs_tr[w:] - cs_tr[:-w]) / w
+        atr_series = (cs_tr[window:] - cs_tr[:-window]) / window
         upper = centerlines + self._multiplier * atr_series
-        current = close[w - 1 :]
+        current = close[window - 1 :]
         with np.errstate(divide="ignore", invalid="ignore"):
             excess_atr = np.where(atr_series > 0, (current - upper) / atr_series, 0.0)
         raw = np.where(current > upper, excess_atr, 0.0)
-        scores[w - 1 :] = np.clip(raw, 0.0, 1.0)
+        scores[window - 1 :] = np.clip(raw, 0.0, 1.0)
         return scores
 
     def score(
@@ -63,26 +63,32 @@ class KeltnerChannel(EntrySignal):
         **kwargs: object,
     ) -> float | None:
         close = price_history.close
-        n = self._window
-        if len(close) < n:
+        window = self._window
+        if len(close) < window:
             return None
 
-        start = len(close) - n
+        start = len(close) - window
         recent = close[start:]
         centerline = float(recent.mean())
 
         high = price_history.high
         low = price_history.low
-        h = high[start:]
-        lo = low[start:]
+        high_slice = high[start:]
+        low_slice = low[start:]
         if start >= 1:
             prev_c = close[start - 1 : -1]
-            tr = np.maximum.reduce([h - lo, np.abs(h - prev_c), np.abs(lo - prev_c)])
+            tr = np.maximum.reduce([high_slice - low_slice, np.abs(high_slice - prev_c), np.abs(low_slice - prev_c)])
         else:
-            tr = np.empty(n)
-            tr[0] = h[0] - lo[0]
+            tr = np.empty(window)
+            tr[0] = high_slice[0] - low_slice[0]
             prev_c = close[:-1]
-            tr[1:] = np.maximum.reduce([h[1:] - lo[1:], np.abs(h[1:] - prev_c), np.abs(lo[1:] - prev_c)])
+            tr[1:] = np.maximum.reduce(
+                [
+                    high_slice[1:] - low_slice[1:],
+                    np.abs(high_slice[1:] - prev_c),
+                    np.abs(low_slice[1:] - prev_c),
+                ]
+            )
         atr = float(tr.mean())
 
         if atr <= 0:

--- a/src/midas/strategies/ma_crossover.py
+++ b/src/midas/strategies/ma_crossover.py
@@ -25,21 +25,21 @@ class MovingAverageCrossover(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
-        lw = self._long_window
-        sw = self._short_window
-        scores = np.full(n, np.nan)
-        if n < lw:
+        num_bars = len(prices)
+        long_win = self._long_window
+        short_win = self._short_window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < long_win:
             return scores
-        cs = np.empty(n + 1)
+        cs = np.empty(num_bars + 1)
         cs[0] = 0.0
         np.cumsum(prices, out=cs[1:])
-        short_rolling = (cs[sw:] - cs[:-sw]) / sw
-        long_rolling = (cs[lw:] - cs[:-lw]) / lw
-        short_at_day = short_rolling[lw - sw : n - sw + 1]
+        short_rolling = (cs[short_win:] - cs[:-short_win]) / short_win
+        long_rolling = (cs[long_win:] - cs[:-long_win]) / long_win
+        short_at_day = short_rolling[long_win - short_win : num_bars - short_win + 1]
         long_at_day = long_rolling
         spread = np.where(long_at_day != 0, (short_at_day - long_at_day) / long_at_day, 0.0)
-        scores[lw - 1 :] = np.clip(spread / self._spread_scale, 0.0, 1.0)
+        scores[long_win - 1 :] = np.clip(spread / self._spread_scale, 0.0, 1.0)
         return scores
 
     def score(

--- a/src/midas/strategies/macd_crossover.py
+++ b/src/midas/strategies/macd_crossover.py
@@ -43,10 +43,10 @@ class MACDCrossover(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
+        num_bars = len(prices)
         min_len = self._slow_period + self._signal_period
-        scores = np.full(n, np.nan)
-        if n < min_len:
+        scores = np.full(num_bars, np.nan)
+        if num_bars < min_len:
             return scores
         fast_ema = ema(prices, self._fast_period)
         slow_ema = ema(prices, self._slow_period)

--- a/src/midas/strategies/mean_reversion.py
+++ b/src/midas/strategies/mean_reversion.py
@@ -20,18 +20,18 @@ class MeanReversion(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w:
+        num_bars = len(prices)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window:
             return scores
-        cs = np.empty(n + 1)
+        cs = np.empty(num_bars + 1)
         cs[0] = 0.0
         np.cumsum(prices, out=cs[1:])
-        ma = (cs[w:] - cs[:-w]) / w
-        current = prices[w - 1 :]
+        ma = (cs[window:] - cs[:-window]) / window
+        current = prices[window - 1 :]
         pct_below = np.where(ma != 0, (ma - current) / ma, 0.0)
-        scores[w - 1 :] = np.clip(pct_below / self._threshold, 0.0, 1.0)
+        scores[window - 1 :] = np.clip(pct_below / self._threshold, 0.0, 1.0)
         return scores
 
     def score(

--- a/src/midas/strategies/momentum.py
+++ b/src/midas/strategies/momentum.py
@@ -20,19 +20,19 @@ class Momentum(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w:
+        num_bars = len(prices)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window:
             return scores
-        cs = np.empty(n + 1)
+        cs = np.empty(num_bars + 1)
         cs[0] = 0.0
         np.cumsum(prices, out=cs[1:])
-        ma = (cs[w:] - cs[:-w]) / w
-        current = prices[w - 1 :]
+        ma = (cs[window:] - cs[:-window]) / window
+        current = prices[window - 1 :]
         pct_from_ma = np.where(ma != 0, (current - ma) / ma, 0.0)
         raw = np.where(pct_from_ma > 0, pct_from_ma / self._momentum_scale, 0.0)
-        scores[w - 1 :] = np.clip(raw, 0.0, 1.0)
+        scores[window - 1 :] = np.clip(raw, 0.0, 1.0)
         return scores
 
     def score(

--- a/src/midas/strategies/parabolic_sar_exit.py
+++ b/src/midas/strategies/parabolic_sar_exit.py
@@ -35,8 +35,8 @@ class ParabolicSARExit(ExitRule):
         downtrend extreme point, and flips the trend when SAR crosses LOW
         (uptrend) or HIGH (downtrend).
         """
-        n = len(high)
-        if n < 2:
+        num_bars = len(high)
+        if num_bars < 2:
             return None
 
         h0, h1 = float(high[0]), float(high[1])
@@ -50,7 +50,7 @@ class ParabolicSARExit(ExitRule):
             ep = min(l0, l1)
         af = self._af_start
 
-        for i in range(2, n):
+        for i in range(2, num_bars):
             sar = sar + af * (ep - sar)
             hi = float(high[i])
             lo = float(low[i])

--- a/src/midas/strategies/rsi_oversold.py
+++ b/src/midas/strategies/rsi_oversold.py
@@ -22,10 +22,10 @@ class RSIOversold(EntrySignal):
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         prices = price_history.close
-        n = len(prices)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w + 1:
+        num_bars = len(prices)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window + 1:
             return scores
         deltas = np.diff(prices)
         gains = np.where(deltas > 0, deltas, 0.0)
@@ -36,8 +36,8 @@ class RSIOversold(EntrySignal):
         l_cs = np.empty(len(losses) + 1)
         l_cs[0] = 0.0
         np.cumsum(losses, out=l_cs[1:])
-        avg_gain = (g_cs[w:] - g_cs[:-w]) / w
-        avg_loss = (l_cs[w:] - l_cs[:-w]) / w
+        avg_gain = (g_cs[window:] - g_cs[:-window]) / window
+        avg_loss = (l_cs[window:] - l_cs[:-window]) / window
         result = np.zeros(len(avg_gain))
         valid = avg_loss != 0
         rs = np.where(valid, avg_gain / np.where(valid, avg_loss, 1.0), 0.0)
@@ -47,7 +47,7 @@ class RSIOversold(EntrySignal):
         if scale != 0:
             below_mid = valid & (rsi < midpoint)
             result[below_mid] = np.clip((midpoint - rsi[below_mid]) / scale, 0.0, 1.0)
-        scores[w:] = result
+        scores[window:] = result
         return scores
 
     def score(

--- a/src/midas/strategies/vwap_reversion.py
+++ b/src/midas/strategies/vwap_reversion.py
@@ -34,42 +34,42 @@ class VWAPReversion(EntrySignal):
         typical price.
         """
         close = price_history.close
-        n = len(close)
-        w = self._window
-        if n < w:
+        num_bars = len(close)
+        window = self._window
+        if num_bars < window:
             return None
         typical = (price_history.high + price_history.low + close) / 3.0
-        cs_t = np.empty(n + 1)
+        cs_t = np.empty(num_bars + 1)
         cs_t[0] = 0.0
         np.cumsum(typical, out=cs_t[1:])
-        typical_sum = cs_t[w:] - cs_t[:-w]
+        typical_sum = cs_t[window:] - cs_t[:-window]
         if price_history.volume is None:
-            return typical_sum / w
+            return typical_sum / window
         volume = price_history.volume
-        cs_pv = np.empty(n + 1)
+        cs_pv = np.empty(num_bars + 1)
         cs_pv[0] = 0.0
         np.cumsum(typical * volume, out=cs_pv[1:])
-        cs_v = np.empty(n + 1)
+        cs_v = np.empty(num_bars + 1)
         cs_v[0] = 0.0
         np.cumsum(volume, out=cs_v[1:])
-        pv_sum = cs_pv[w:] - cs_pv[:-w]
-        v_sum = cs_v[w:] - cs_v[:-w]
-        sma = typical_sum / w
+        pv_sum = cs_pv[window:] - cs_pv[:-window]
+        v_sum = cs_v[window:] - cs_v[:-window]
+        sma = typical_sum / window
         return np.where(v_sum > 0, pv_sum / np.where(v_sum > 0, v_sum, 1.0), sma)
 
     def precompute(self, price_history: PriceHistory) -> np.ndarray | None:
         close = price_history.close
-        n = len(close)
-        w = self._window
-        scores = np.full(n, np.nan)
-        if n < w:
+        num_bars = len(close)
+        window = self._window
+        scores = np.full(num_bars, np.nan)
+        if num_bars < window:
             return scores
         vwap = self._rolling_vwap(price_history)
-        assert vwap is not None  # n >= w
-        current = close[w - 1 :]
+        assert vwap is not None  # num_bars >= window
+        current = close[window - 1 :]
         with np.errstate(divide="ignore", invalid="ignore"):
             deviation = np.where(vwap != 0, (current - vwap) / vwap, 0.0)
-        scores[w - 1 :] = np.clip(-deviation / self._threshold, 0.0, 1.0)
+        scores[window - 1 :] = np.clip(-deviation / self._threshold, 0.0, 1.0)
         return scores
 
     def score(


### PR DESCRIPTION
## Summary
- Rename all single-character variables (except `i`/`j`/`k` counters) to descriptive names across 24 Python files per the Google Python Style Guide
- Key renames: `n` → `num_bars`, `w` → `window`, `h` → `holding`, `t` → `ticker`/`trade`, `s` → `strat`/`score`, `z` → `z_score`, `px` → `price`, `sv` → `starting_val`, and many more
- Add missing class/method docstrings to `BacktestEngine` and `run()`
- All 209 tests pass, ruff/mypy clean

## Test plan
- [x] Full test suite passes (`uv run pytest tests/ -x -q --tb=short` — 209 passed)
- [x] Pre-commit hooks pass (ruff lint, ruff format, mypy)
- [ ] Spot-check diffs in strategy files for correctness of variable references

🤖 Generated with [Claude Code](https://claude.com/claude-code)