### PR TITLE
Risk discipline: vol targeting + IDM + inverse-vol softmax offsets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,21 +98,7 @@ Finally, the allocator predicts portfolio vol as `sqrt(w · cov · w)` on the an
 
 Scaling down all weights proportionally (including held tickers) keeps the target-weight mix intact and pushes the extra budget into cash. Effectively disable this stage by setting `vol_target_annualized` to an unreachably large number.
 
-#### Risk Discipline Configuration
-
-All risk-phase parameters live under a top-level `risk:` block in the strategies YAML:
-
-```yaml
-risk:
-  weighting: inverse_vol      # or "equal" to disable Phase 1.5
-  vol_target_annualized: 0.20 # target annualized portfolio vol (Phase 3.7)
-  idm_cap: 2.5                # ceiling on the diversification multiplier
-  vol_lookback_days: 60       # window for per-ticker realized vol
-  corr_lookback_days: 252     # window for LedoitWolf correlation fit
-  vol_floor: 0.02             # min realized vol (annualized) to avoid divide-by-tiny
-```
-
-The block is optional — an omitted `risk:` block applies all defaults above. All six fields are **fixed policy**, not search parameters: the optimizer does not vary them. To try a different risk stance, edit the YAML directly and re-run. A degenerate input at any stage (insufficient history, NaN closes, singular covariance) causes that stage to pass through unchanged rather than raise, so the allocator degrades gracefully during warmup.
+All four risk phases are configured via the optional `risk:` block in the strategies YAML — see [Strategies: Risk Discipline](strategies.md#risk-discipline). A degenerate input at any stage (insufficient history, NaN closes, singular covariance) causes that stage to pass through unchanged rather than raise, so the allocator degrades gracefully during warmup.
 
 ### Exit Rules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,7 +45,7 @@ See [Strategies](strategies.md) for the full reference.
 
 ### Allocator
 
-The allocator turns entry-signal scores into target portfolio weights. It runs in three phases.
+The allocator turns entry-signal scores into target portfolio weights. It runs in three core phases (score-and-blend → softmax → soft cap) with optional risk-discipline phases interleaved: an inverse-vol score offset before softmax, and an instrument diversification multiplier + portfolio vol target after the cap. The risk phases are policy — they trim exposure, never inflate a conviction that wasn't there.
 
 #### Phase 1: Score and Blend
 
@@ -56,15 +56,21 @@ Tickers fall into two buckets:
 - **Active** — at least one entry signal scored > 0. The blended score is positive.
 - **Held** — every entry signal returned 0 or `None`. The allocator treats this as "no opinion" and holds the ticker at its current weight (or the equal-weight base on the very first allocation).
 
+#### Phase 1.5: Inverse-Vol Score Offset (optional)
+
+When `risk.weighting: inverse_vol` (the default), the allocator precomputes an additive score offset per ticker equal to `-log(max(realized_vol, vol_floor))`. This offset is added to the blended score *inside* the softmax exponent, which — because softmax normalizes — is mathematically equivalent to multiplying each ticker's weight by `1/realized_vol`. The result is an inverse-vol tilt: lower-vol tickers get larger target weights for the same conviction, higher-vol tickers get smaller ones. Realized vol is computed over `vol_lookback_days` (default 60) and floored at `vol_floor` (default 0.02) to keep ultra-quiet tickers from inhaling budget.
+
+Set `risk.weighting: equal` to disable this stage — the allocator then runs straight softmax over the blended scores.
+
 #### Phase 2: Softmax Budget Allocation
 
 The active tickers' blended scores need to become target portfolio weights that sum to the *active* budget — that is, the investable budget (`1 − min_cash_pct`) minus whatever the held tickers consume. The allocator uses softmax — the same construct-to-budget operator used by QuantConnect LEAN's `InsightWeightingPortfolioConstructionModel`, mean-variance optimizers, and risk-parity libraries.
 
 ```
-target_i = active_budget * exp(blended_i / T) / sum_j(exp(blended_j / T))
+target_i = active_budget * exp((blended_i + offset_i) / T) / sum_j(exp((blended_j + offset_j) / T))
 ```
 
-By construction, `sum(active targets) == active_budget` exactly, always. There is no separate normalize step — oversubscription is mathematically impossible. The `softmax_temperature` parameter `T` follows the standard ML softmax convention: low `T` concentrates budget on the highest-conviction ticker (winner-take-most, `T → 0` is argmax), `T = 1` is the unscaled softmax over raw scores, and high `T` approaches a uniform split. Midas defaults to `T = 0.5`, a mild concentration bias.
+The `offset` term is the Phase 1.5 inverse-vol offset (zero when `weighting: equal`). By construction, `sum(active targets) == active_budget` exactly, always. There is no separate normalize step — oversubscription is mathematically impossible. The `softmax_temperature` parameter `T` follows the standard ML softmax convention: low `T` concentrates budget on the highest-conviction ticker (winner-take-most, `T → 0` is argmax), `T = 1` is the unscaled softmax over raw scores, and high `T` approaches a uniform split. Midas defaults to `T = 0.5`, a mild concentration bias.
 
 **Neutral = hold.** When all entry signals abstain or score 0 for a ticker, the allocator holds that ticker's current weight rather than dragging it back to equal-weight. This avoids churn from drift-correction trades on days when no signal is firing on a held position.
 
@@ -75,6 +81,38 @@ Any active ticker whose softmax target exceeds `max_position_pct` is pinned at t
 The cap is **soft**: it can refuse to allocate *more* budget to an over-target ticker, but it never forces a sell. If a ticker drifts above the cap because of price appreciation, the allocator simply stops buying more — it does not generate a corrective sell. Sells are exclusively the domain of `ExitRule` strategies. This is the cleanest way to keep the buy-only allocator from accidentally producing exits.
 
 If `max_position_pct` is not configured, it's auto-computed as 2.5x the equal-weight baseline (capped at 25%), which allows meaningful overweighting without extreme concentration.
+
+#### Phase 3.5: Instrument Diversification Multiplier
+
+The allocator multiplies every active weight by `idm = min(1/sqrt(w · corr · w), idm_cap)`, where `w` is the normalized active-weight vector and `corr` is the LedoitWolf-shrunk correlation matrix of daily returns over `corr_lookback_days` (default 252). When holdings are uncorrelated, `idm ≈ sqrt(N_active)` — the portfolio can carry more gross exposure because diversification absorbs the single-name risk. When holdings are tightly correlated, `idm ≈ 1` — no diversification benefit, so no scale-up. This is Carver's IDM from *Systematic Trading*.
+
+The multiplier is capped at `idm_cap` (default 2.5) to keep a universe of uncorrelated names from levering the portfolio without bound. Setting `idm_cap: 1.0` disables this stage.
+
+#### Phase 3.6: Re-Cap After IDM
+
+Because IDM scaled weights up, a ticker that was below `max_position_pct` in Phase 3 can now exceed it. Phase 3.6 re-runs the cap-and-redistribute loop, this time taking its budget from the current sum of active targets (so the IDM scale-up is preserved wherever the caps aren't binding).
+
+#### Phase 3.7: Portfolio Vol Targeting
+
+Finally, the allocator predicts portfolio vol as `sqrt(w · cov · w)` on the annualized covariance matrix (LedoitWolf correlation composed with per-ticker realized vols). If the prediction exceeds `vol_target_annualized` (default 0.20 = 20%), every weight is scaled down by `target / predicted`. This stage **only scales down** — a portfolio predicted below target is left alone rather than levered up to hit it.
+
+Scaling down all weights proportionally (including held tickers) keeps the target-weight mix intact and pushes the extra budget into cash. Effectively disable this stage by setting `vol_target_annualized` to an unreachably large number.
+
+#### Risk Discipline Configuration
+
+All risk-phase parameters live under a top-level `risk:` block in the strategies YAML:
+
+```yaml
+risk:
+  weighting: inverse_vol      # or "equal" to disable Phase 1.5
+  vol_target_annualized: 0.20 # target annualized portfolio vol (Phase 3.7)
+  idm_cap: 2.5                # ceiling on the diversification multiplier
+  vol_lookback_days: 60       # window for per-ticker realized vol
+  corr_lookback_days: 252     # window for LedoitWolf correlation fit
+  vol_floor: 0.02             # min realized vol (annualized) to avoid divide-by-tiny
+```
+
+The block is optional — an omitted `risk:` block applies all defaults above. All six fields are **fixed policy**, not search parameters: the optimizer does not vary them. To try a different risk stance, edit the YAML directly and re-run. A degenerate input at any stage (insufficient history, NaN closes, singular covariance) causes that stage to pass through unchanged rather than raise, so the allocator degrades gracefully during warmup.
 
 ### Exit Rules
 
@@ -124,6 +162,8 @@ The optimizer uses Bayesian optimization (Optuna's TPE sampler) to search jointl
 | Max position % | Maximum weight for any single position | 0.15 to 0.50 |
 
 Default search ranges are defined in `PARAM_RANGES` in `optimizer.py`. Exit rules don't get a `weight` field — they fire on their own conditions, not as a contributor to a blended score.
+
+The `risk:` block fields (`weighting`, `vol_target_annualized`, `idm_cap`, `vol_lookback_days`, `corr_lookback_days`, `vol_floor`) are **not** searched — they're user-chosen risk policy. Whatever you set in the input YAML is passed through to the output YAML unchanged.
 
 **Standard Mode** -- Runs a configurable number of trials (default 200). Each trial suggests a parameter combination, runs a full backtest with train/test split, and returns the training return as the optimization objective. Trials are distributed across CPU cores via multiprocessing for parallel evaluation.
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -52,6 +52,37 @@ A strategy file needs at least one entry signal and at least one exit rule. With
 - **[Dip-Buying](../example-strategies/dip-buying.yaml)** — `BollingerBand` and `RSIOversold` for independent confirmation that an asset is oversold, protected by a `StopLoss` floor.
 - **[Balanced Growth](../example-strategies/balanced-growth.yaml)** — `Momentum` and `MeanReversion` give entries in both trending and recovering markets; `ProfitTaking` harvests gains at a fixed target and `ChandelierStop` provides a volatility-adjusted trailing stop that works whether the position is in profit or underwater.
 
+## Risk Discipline
+
+The allocator applies four optional risk phases on top of the softmax core: an inverse-vol tilt on per-ticker scores, an instrument diversification multiplier (IDM) that scales exposure up when holdings are uncorrelated, a re-cap pass to honor `max_position_pct` after IDM, and a portfolio vol target that scales everything down when predicted vol exceeds the cap. See [Architecture: Allocator](architecture.md#allocator) for the full phase-by-phase description.
+
+All four phases are configured by an optional top-level `risk:` block in the strategies YAML. Omit the block to accept the defaults shown:
+
+```yaml
+risk:
+  weighting: inverse_vol       # "equal" disables the inverse-vol score offset
+  vol_target_annualized: 0.20  # max annualized portfolio vol (scales weights down only)
+  idm_cap: 2.5                 # ceiling on the diversification multiplier (1.0 disables IDM)
+  vol_lookback_days: 60        # window for per-ticker realized vol
+  corr_lookback_days: 252      # window for the LedoitWolf correlation fit
+  vol_floor: 0.02              # min realized vol (annualized) to avoid divide-by-tiny
+```
+
+**Field reference:**
+
+| Field | Default | What it controls |
+|-------|---------|------------------|
+| `weighting` | `inverse_vol` | `inverse_vol` adds a `-log(vol)` offset to each blended score before softmax (low-vol tickers get more weight per unit conviction). `equal` skips the offset — the softmax runs on raw blended scores. |
+| `vol_target_annualized` | `0.20` | Upper bound on the portfolio's predicted annualized vol. If the prediction exceeds the target, every weight is scaled by `target / predicted`. Never scales up. Set unreachably high to disable. |
+| `idm_cap` | `2.5` | Ceiling on the instrument diversification multiplier. IDM equals `min(1/sqrt(w · corr · w), cap)` — it scales exposure up when holdings are uncorrelated, capped here to prevent a universe of uncorrelated names from levering without bound. Set to `1.0` to disable IDM entirely. |
+| `vol_lookback_days` | `60` | Trailing window for realized-vol calculations (used by the inverse-vol offset and the covariance diagonals). |
+| `corr_lookback_days` | `252` | Trailing window for the LedoitWolf-shrunk correlation fit used by IDM and portfolio-vol prediction. |
+| `vol_floor` | `0.02` | Minimum annualized realized vol applied before the inverse-vol offset and covariance composition. Prevents quiet tickers from inhaling budget and keeps the covariance matrix well-conditioned. |
+
+**Fixed policy, not searched.** The optimizer does not vary any of these fields — they're a risk stance you choose. Whatever you put in the input YAML is passed through to the output YAML unchanged. To try a different risk stance, edit the YAML and re-run.
+
+**Graceful warmup.** Each phase falls back to a pass-through when it can't compute (insufficient history, NaN closes, singular covariance). The allocator degrades to its pre-risk behavior rather than raising, so the first N bars of a backtest just produce unscaled weights until enough history accumulates.
+
 ## Entry Signals
 
 Entry signals score a ticker's bullishness in `[0, 1]`. They contribute to the allocator's per-ticker blend via a configurable `weight` (default 1.0). A signal returning `None` is excluded from the blend entirely — it doesn't pull the average toward zero, it simply doesn't participate. A signal returning 0 means "no opinion" — the ticker is treated as held at its current weight rather than as an active buy candidate.

--- a/docs/superpowers/plans/2026-04-20-risk-discipline.md
+++ b/docs/superpowers/plans/2026-04-20-risk-discipline.md
@@ -1,0 +1,2218 @@
+# Risk Discipline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship portfolio volatility targeting (#52 Part 1), per-ticker volatility scaling (#53), and Instrument Diversification Multiplier (#55) as a single cohesive risk-discipline layer woven into `Allocator.allocate`.
+
+**Architecture:** New pure-function module `src/midas/risk.py`. Config via new `RiskConfig` dataclass and a `risk:` YAML block. Integration inside `Allocator` at phases 1.5 (cov/vol precompute), 2 (vol offset in softmax), 3.5 (IDM), 3.6 (re-cap), 3.7 (vol targeting). Risk-on defaults. No CLI overrides.
+
+**Tech Stack:** Python 3.14, NumPy, pandas, `sklearn.covariance.LedoitWolf` (new dep), pytest, mypy strict, ruff.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-risk-discipline-design.md`
+
+## File Structure
+
+**New files:**
+- `src/midas/risk.py` — five pure functions (`realized_vol`, `covariance_matrix`, `apply_instrument_diversification_multiplier`, `apply_vol_targeting`, `predict_portfolio_vol`)
+- `tests/test_risk.py` — unit tests for the five functions
+
+**Modified files:**
+- `pyproject.toml` — add `scikit-learn` to `[project].dependencies`
+- `src/midas/models.py` — add `RiskConfig` dataclass + `DEFAULT_*` constants
+- `src/midas/config.py` — parse `risk:` YAML block, return `RiskConfig` from `load_strategies`
+- `src/midas/allocator.py` — accept `RiskConfig`, add risk cache + phases 1.5/3.5/3.6/3.7
+- `src/midas/cli.py` — thread `RiskConfig` through `_build_components` and the two call sites
+- `tests/test_config.py` — cover `risk:` parsing + defaults + validation errors
+- `tests/test_allocator.py` — risk-off regression + active-stage integration tests
+- `tests/test_backtest.py` — end-to-end change-detector for default risk config
+
+---
+
+### Task 1: Add `scikit-learn` dependency
+
+**Files:**
+- Modify: `pyproject.toml:5-12`
+
+- [ ] **Step 1: Add dependency**
+
+Edit `pyproject.toml`:
+
+```toml
+dependencies = [
+    "click>=8.1",
+    "pandas>=2.2",
+    "pyyaml>=6.0",
+    "rich>=13.0",
+    "yfinance>=0.2",
+    "optuna>=4.0",
+    "scikit-learn>=1.5",
+]
+```
+
+- [ ] **Step 2: Install the new dep**
+
+Run: `uv sync`
+Expected: resolves and installs scikit-learn and its transitive deps (scipy, joblib, threadpoolctl).
+
+- [ ] **Step 3: Verify import works**
+
+Run: `uv run python -c "from sklearn.covariance import LedoitWolf; print(LedoitWolf().__class__.__name__)"`
+Expected: `LedoitWolf`
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `uv run pytest -q`
+Expected: all tests pass, no collection errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "Add scikit-learn dep for LedoitWolf covariance shrinkage"
+```
+
+---
+
+### Task 2: `RiskConfig` dataclass with config-time validation
+
+**Files:**
+- Modify: `src/midas/models.py` (append to bottom, add DEFAULT constants near top)
+- Modify: `tests/test_models.py` (new test class for RiskConfig)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_models.py`:
+
+```python
+import pytest
+
+from midas.models import RiskConfig
+
+
+class TestRiskConfig:
+    def test_defaults_are_risk_on(self):
+        cfg = RiskConfig()
+        assert cfg.weighting == "inverse_vol"
+        assert cfg.vol_target_annualized == 0.20
+        assert cfg.idm_cap == 2.5
+        assert cfg.vol_lookback_days == 60
+        assert cfg.corr_lookback_days == 252
+        assert cfg.vol_floor == 0.02
+
+    def test_is_frozen(self):
+        cfg = RiskConfig()
+        with pytest.raises((AttributeError, Exception)):
+            cfg.idm_cap = 1.0  # type: ignore[misc]
+
+    def test_rejects_non_positive_vol_target(self):
+        with pytest.raises(ValueError, match="vol_target_annualized"):
+            RiskConfig(vol_target_annualized=0.0)
+        with pytest.raises(ValueError, match="vol_target_annualized"):
+            RiskConfig(vol_target_annualized=-0.10)
+
+    def test_rejects_idm_cap_below_one(self):
+        with pytest.raises(ValueError, match="idm_cap"):
+            RiskConfig(idm_cap=0.99)
+
+    def test_accepts_idm_cap_exactly_one(self):
+        RiskConfig(idm_cap=1.0)  # disables IDM — valid
+
+    def test_rejects_small_vol_lookback(self):
+        with pytest.raises(ValueError, match="vol_lookback_days"):
+            RiskConfig(vol_lookback_days=1)
+
+    def test_rejects_small_corr_lookback(self):
+        with pytest.raises(ValueError, match="corr_lookback_days"):
+            RiskConfig(corr_lookback_days=1)
+
+    def test_rejects_negative_vol_floor(self):
+        with pytest.raises(ValueError, match="vol_floor"):
+            RiskConfig(vol_floor=-0.01)
+
+    def test_accepts_zero_vol_floor(self):
+        RiskConfig(vol_floor=0.0)  # edge case — valid
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_models.py -q`
+Expected: `ImportError` or `ModuleNotFoundError` on `RiskConfig`.
+
+- [ ] **Step 3: Add RiskConfig to models.py**
+
+In `src/midas/models.py`, near the top with the other defaults add:
+
+```python
+DEFAULT_VOL_TARGET_ANNUALIZED = 0.20
+DEFAULT_IDM_CAP = 2.5
+DEFAULT_VOL_LOOKBACK_DAYS = 60
+DEFAULT_CORR_LOOKBACK_DAYS = 252
+DEFAULT_VOL_FLOOR = 0.02
+```
+
+Update the existing import line `from dataclasses import dataclass, field` to also import `Literal` from `typing`:
+
+```python
+from typing import Literal
+```
+
+At the bottom of the file append:
+
+```python
+@dataclass(frozen=True)
+class RiskConfig:
+    """Portfolio-level risk-discipline parameters.
+
+    See docs/superpowers/specs/2026-04-20-risk-discipline-design.md.
+    """
+
+    weighting: Literal["inverse_vol", "equal"] = "inverse_vol"
+    vol_target_annualized: float = DEFAULT_VOL_TARGET_ANNUALIZED
+    idm_cap: float = DEFAULT_IDM_CAP
+    vol_lookback_days: int = DEFAULT_VOL_LOOKBACK_DAYS
+    corr_lookback_days: int = DEFAULT_CORR_LOOKBACK_DAYS
+    vol_floor: float = DEFAULT_VOL_FLOOR
+
+    def __post_init__(self) -> None:
+        if self.vol_target_annualized <= 0:
+            msg = f"vol_target_annualized must be > 0, got {self.vol_target_annualized}"
+            raise ValueError(msg)
+        if self.idm_cap < 1.0:
+            msg = f"idm_cap must be >= 1.0 (IDM is always >= 1), got {self.idm_cap}"
+            raise ValueError(msg)
+        if self.vol_lookback_days < 2:
+            msg = f"vol_lookback_days must be >= 2, got {self.vol_lookback_days}"
+            raise ValueError(msg)
+        if self.corr_lookback_days < 2:
+            msg = f"corr_lookback_days must be >= 2, got {self.corr_lookback_days}"
+            raise ValueError(msg)
+        if self.vol_floor < 0:
+            msg = f"vol_floor must be >= 0, got {self.vol_floor}"
+            raise ValueError(msg)
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_models.py -q`
+Expected: new RiskConfig tests pass; existing tests unaffected.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/models.py tests/test_models.py --fix
+uv run ruff format src/midas/models.py tests/test_models.py
+uv run mypy src
+git add src/midas/models.py tests/test_models.py
+git commit -m "Add RiskConfig dataclass with config-time validation"
+```
+
+---
+
+### Task 3: Parse `risk:` YAML block and return `RiskConfig` from `load_strategies`
+
+**Files:**
+- Modify: `src/midas/config.py` (extend `load_strategies` return type)
+- Modify: `src/midas/cli.py` (update unpack at call sites)
+- Modify: `tests/test_integration.py` (update unpack)
+- Modify: `tests/test_config.py` (extend test + add new test cases)
+
+- [ ] **Step 1: Write failing tests**
+
+Edit `tests/test_config.py`. Update the existing `test_load_strategies` to unpack a 3-tuple and assert defaults, and add two new tests:
+
+Change the existing `test_load_strategies` body to:
+
+```python
+def test_load_strategies(strategy_yaml: Path) -> None:
+    configs, constraints, risk = load_strategies(strategy_yaml)
+    assert len(configs) == 3
+
+    assert configs[0].name == "MeanReversion"
+    assert configs[0].params["window"] == 20
+    assert configs[0].weight == 1.5
+
+    assert configs[1].name == "StopLoss"
+    assert configs[1].params["loss_threshold"] == 0.10
+
+    assert configs[2].name == "Momentum"
+    assert configs[2].params == {}
+    assert configs[2].weight == 1.0  # default
+
+    # Allocation knobs
+    assert constraints.softmax_temperature == 0.25
+    assert constraints.min_buy_delta == 0.03
+    assert constraints.min_cash_pct == 0.10
+    assert constraints.max_position_pct is None
+
+    # Risk config defaults (no risk: block in fixture)
+    assert risk.weighting == "inverse_vol"
+    assert risk.vol_target_annualized == 0.20
+    assert risk.idm_cap == 2.5
+```
+
+Add below it:
+
+```python
+def test_load_strategies_parses_risk_block(tmp_path: Path) -> None:
+    data = {
+        "strategies": [{"name": "Momentum"}],
+        "risk": {
+            "weighting": "equal",
+            "vol_target_annualized": 0.15,
+            "idm_cap": 2.0,
+            "vol_lookback_days": 30,
+            "corr_lookback_days": 120,
+            "vol_floor": 0.05,
+        },
+    }
+    p = tmp_path / "strategies.yaml"
+    p.write_text(yaml.dump(data))
+    _, _, risk = load_strategies(p)
+    assert risk.weighting == "equal"
+    assert risk.vol_target_annualized == 0.15
+    assert risk.idm_cap == 2.0
+    assert risk.vol_lookback_days == 30
+    assert risk.corr_lookback_days == 120
+    assert risk.vol_floor == 0.05
+
+
+def test_load_strategies_risk_validation_surfaces(tmp_path: Path) -> None:
+    data = {
+        "strategies": [{"name": "Momentum"}],
+        "risk": {"idm_cap": 0.5},
+    }
+    p = tmp_path / "strategies.yaml"
+    p.write_text(yaml.dump(data))
+    with pytest.raises(ValueError, match="idm_cap"):
+        load_strategies(p)
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_config.py -q`
+Expected: tests fail with `ValueError: too many values to unpack` or similar (load_strategies currently returns a 2-tuple).
+
+- [ ] **Step 3: Update `load_strategies`**
+
+Edit `src/midas/config.py`. Replace the import block and the `load_strategies` function:
+
+```python
+from midas.models import (
+    DEFAULT_MIN_BUY_DELTA,
+    DEFAULT_MIN_CASH_PCT,
+    DEFAULT_SOFTMAX_TEMPERATURE,
+    AllocationConstraints,
+    CashInfusion,
+    Holding,
+    PortfolioConfig,
+    RiskConfig,
+    StrategyConfig,
+    TradingRestrictions,
+)
+```
+
+Replace the function signature and body:
+
+```python
+def load_strategies(
+    path: Path,
+) -> tuple[list[StrategyConfig], AllocationConstraints, RiskConfig]:
+    """Load strategy configs, allocation-level knobs, and risk policy from YAML.
+
+    Returns (strategies, constraints, risk) tuple. Top-level keys:
+      * ``softmax_temperature``, ``min_buy_delta``, ``min_cash_pct``,
+        ``max_position_pct`` — meta-strategy knobs.
+      * ``risk:`` — nested mapping forwarded to :class:`RiskConfig`. Missing
+        block defaults to risk-on.
+    """
+    raw = _load_yaml(path)
+
+    configs = []
+    for strat in raw["strategies"]:
+        configs.append(
+            StrategyConfig(
+                name=strat["name"],
+                params=strat.get("params", {}),
+                tickers=strat.get("tickers"),
+                weight=float(strat.get("weight", 1.0)),
+            )
+        )
+
+    max_pos = raw.get("max_position_pct")
+    constraints = AllocationConstraints(
+        max_position_pct=float(max_pos) if max_pos is not None else None,
+        min_cash_pct=float(raw.get("min_cash_pct", DEFAULT_MIN_CASH_PCT)),
+        softmax_temperature=float(
+            raw.get("softmax_temperature", DEFAULT_SOFTMAX_TEMPERATURE),
+        ),
+        min_buy_delta=float(
+            raw.get("min_buy_delta", DEFAULT_MIN_BUY_DELTA),
+        ),
+    )
+
+    risk_raw = raw.get("risk", {}) or {}
+    risk = RiskConfig(
+        weighting=risk_raw.get("weighting", "inverse_vol"),
+        vol_target_annualized=float(risk_raw.get("vol_target_annualized", 0.20)),
+        idm_cap=float(risk_raw.get("idm_cap", 2.5)),
+        vol_lookback_days=int(risk_raw.get("vol_lookback_days", 60)),
+        corr_lookback_days=int(risk_raw.get("corr_lookback_days", 252)),
+        vol_floor=float(risk_raw.get("vol_floor", 0.02)),
+    )
+    return configs, constraints, risk
+```
+
+- [ ] **Step 4: Update call sites**
+
+Edit `src/midas/cli.py`. Update the three call sites:
+
+Line 153 (in `backtest`):
+```python
+    strat_configs, constraints, risk_config = (
+        load_strategies(Path(strategies))
+        if strategies
+        else (None, AllocationConstraints(), RiskConfig())
+    )
+```
+
+Line 214 (in `live`):
+```python
+    strat_configs, constraints, risk_config = (
+        load_strategies(Path(strategies))
+        if strategies
+        else (None, AllocationConstraints(), RiskConfig())
+    )
+```
+
+Line 333 (in optimize):
+```python
+        strat_configs, strat_constraints, _ = load_strategies(Path(strategies))
+```
+
+Update the import block in `src/midas/cli.py`:
+```python
+from midas.models import (
+    AllocationConstraints,
+    PortfolioConfig,
+    RiskConfig,
+    StrategyConfig,
+)
+```
+
+Edit `tests/test_integration.py` line 57:
+```python
+    strat_configs, constraints, _ = load_strategies(strategy_path)
+```
+
+- [ ] **Step 5: Run and verify pass**
+
+Run: `uv run pytest tests/test_config.py tests/test_integration.py -q`
+Expected: all pass.
+
+- [ ] **Step 6: Lint, type-check, commit**
+
+```bash
+uv run ruff check src tests --fix
+uv run ruff format src tests
+uv run mypy src
+git add src/midas/config.py src/midas/cli.py tests/test_config.py tests/test_integration.py
+git commit -m "Thread RiskConfig through strategy YAML loader"
+```
+
+---
+
+### Task 4: `realized_vol` function (TDD)
+
+**Files:**
+- Create: `src/midas/risk.py`
+- Create: `tests/test_risk.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_risk.py`:
+
+```python
+"""Tests for the risk-discipline module."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
+
+from midas.risk import realized_vol
+
+
+class TestRealizedVol:
+    def test_constant_series_returns_zero(self):
+        history = ph(np.full(100, 100.0))
+        vol = realized_vol(history, window=30)
+        assert vol == 0.0
+
+    def test_known_series_matches_hand_computed(self):
+        # Daily returns: exactly +1% and -1% alternating over 30 bars (29 returns).
+        # Each daily return is ±0.01 (computed from ratio p_i / p_{i-1}).
+        prices = [100.0]
+        for i in range(1, 31):
+            prices.append(prices[-1] * (1.01 if i % 2 == 1 else 1 / 1.01))
+        history = ph(np.asarray(prices))
+
+        vol = realized_vol(history, window=30)
+        # daily std of ±0.01 (equal-sized up/down moves) ≈ 0.01; annualized × sqrt(252)
+        assert vol is not None
+        assert math.isclose(vol, 0.01 * math.sqrt(252), rel_tol=1e-2)
+
+    def test_insufficient_history_returns_none(self):
+        history = ph(np.full(10, 100.0))
+        assert realized_vol(history, window=30) is None
+
+    def test_annualize_false_returns_daily_vol(self):
+        prices = [100.0]
+        for i in range(1, 31):
+            prices.append(prices[-1] * (1.01 if i % 2 == 1 else 1 / 1.01))
+        history = ph(np.asarray(prices))
+        daily = realized_vol(history, window=30, annualize=False)
+        annual = realized_vol(history, window=30, annualize=True)
+        assert daily is not None and annual is not None
+        assert math.isclose(annual / daily, math.sqrt(252), rel_tol=1e-6)
+
+    def test_nan_in_window_returns_none(self):
+        prices = np.full(60, 100.0)
+        prices[-5] = float("nan")
+        history = ph(prices)
+        # Window includes the NaN → insufficient clean history.
+        assert realized_vol(history, window=30) is None
+
+    def test_exact_window_size_is_sufficient(self):
+        # Window == len(history) should succeed (not fail with off-by-one).
+        history = ph(np.full(30, 100.0))
+        assert realized_vol(history, window=30) == 0.0
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_risk.py -q`
+Expected: `ModuleNotFoundError: No module named 'midas.risk'`.
+
+- [ ] **Step 3: Create `src/midas/risk.py` with `realized_vol`**
+
+```python
+"""Risk-discipline primitives: realized vol, covariance, IDM, vol targeting.
+
+Pure functions only — no class state. All functions return new objects
+(dicts, DataFrames) and never mutate their inputs. Degenerate inputs are
+handled by returning a sentinel (``None`` or an unchanged result) rather
+than raising, so the allocator can degrade gracefully at runtime.
+
+See docs/superpowers/specs/2026-04-20-risk-discipline-design.md.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from midas.data.price_history import PriceHistory
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+def realized_vol(
+    history: PriceHistory,
+    window: int,
+    annualize: bool = True,
+) -> float | None:
+    """Realized volatility over the last ``window`` closes.
+
+    Args:
+        history: OHLCV bars for a single ticker.
+        window: Number of most-recent bars to consider. The vol is computed
+            over ``window - 1`` daily simple returns.
+        annualize: Multiply by sqrt(252) when True.
+
+    Returns:
+        Volatility as a fraction (0.20 == 20% annualized), or None when
+        there is insufficient clean history (fewer than ``window`` bars or
+        any NaN inside the window).
+    """
+    if window < 2:
+        msg = f"window must be >= 2, got {window}"
+        raise ValueError(msg)
+    if len(history) < window:
+        return None
+    closes = history.close[-window:]
+    if not np.all(np.isfinite(closes)):
+        return None
+    returns = closes[1:] / closes[:-1] - 1.0
+    if returns.size < 2:
+        return None
+    daily = float(np.std(returns, ddof=1))
+    return daily * math.sqrt(TRADING_DAYS_PER_YEAR) if annualize else daily
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_risk.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/risk.py tests/test_risk.py --fix
+uv run ruff format src/midas/risk.py tests/test_risk.py
+uv run mypy src
+git add src/midas/risk.py tests/test_risk.py
+git commit -m "Add realized_vol to risk module"
+```
+
+---
+
+### Task 5: `covariance_matrix` function (TDD)
+
+**Files:**
+- Modify: `src/midas/risk.py`
+- Modify: `tests/test_risk.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_risk.py`:
+
+```python
+import pandas as pd
+
+from midas.risk import covariance_matrix
+
+
+def _prices_from_returns(daily_returns: np.ndarray, base: float = 100.0) -> np.ndarray:
+    """Build a close array from daily returns."""
+    out = np.empty(len(daily_returns) + 1)
+    out[0] = base
+    for i, ret in enumerate(daily_returns):
+        out[i + 1] = out[i] * (1.0 + ret)
+    return out
+
+
+class TestCovarianceMatrix:
+    def test_uncorrelated_series_give_diagonal_correlation(self):
+        rng = np.random.default_rng(42)
+        # 260 bars each — enough for 252-day corr window + slack.
+        rets_a = rng.normal(0.0, 0.01, 260)
+        rets_b = rng.normal(0.0, 0.02, 260)
+        hist_a = ph(_prices_from_returns(rets_a))
+        hist_b = ph(_prices_from_returns(rets_b))
+
+        cov = covariance_matrix(
+            {"A": hist_a, "B": hist_b},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+
+        assert cov is not None
+        # Diagonals should be ~ (realized vol ** 2)
+        # Off-diagonal correlation should be near zero.
+        corr_ab = cov.loc["A", "B"] / math.sqrt(cov.loc["A", "A"] * cov.loc["B", "B"])
+        assert abs(corr_ab) < 0.2  # shrinkage may pull slightly toward 0 or away
+
+    def test_perfectly_correlated_series_give_unit_correlation(self):
+        rng = np.random.default_rng(7)
+        base_rets = rng.normal(0.0, 0.01, 260)
+        # B is identical to A — scaled vol by 2× to make the math nontrivial.
+        hist_a = ph(_prices_from_returns(base_rets))
+        hist_b = ph(_prices_from_returns(base_rets * 2.0))
+
+        cov = covariance_matrix(
+            {"A": hist_a, "B": hist_b},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+
+        assert cov is not None
+        corr_ab = cov.loc["A", "B"] / math.sqrt(cov.loc["A", "A"] * cov.loc["B", "B"])
+        # LedoitWolf shrinks correlation toward the mean off-diagonal, which
+        # for a 2-asset system with one off-diagonal = 1.0 still stays near 1.
+        assert corr_ab > 0.9
+
+    def test_vol_floor_clamps_low_vol_ticker(self):
+        rng = np.random.default_rng(3)
+        rets_normal = rng.normal(0.0, 0.01, 260)
+        rets_tiny = rng.normal(0.0, 0.0001, 260)  # well below floor
+        hist_normal = ph(_prices_from_returns(rets_normal))
+        hist_tiny = ph(_prices_from_returns(rets_tiny))
+
+        cov = covariance_matrix(
+            {"N": hist_normal, "T": hist_tiny},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.05,  # 5% annualized
+        )
+
+        assert cov is not None
+        vol_t = math.sqrt(cov.loc["T", "T"])
+        # Vol floor is annualized 5% → variance ≈ 0.0025 on the diagonal.
+        assert vol_t >= 0.05 - 1e-9
+
+    def test_insufficient_history_returns_none(self):
+        short = ph(np.full(50, 100.0))  # < corr_window of 252
+        cov = covariance_matrix(
+            {"A": short, "B": short},
+            vol_window=30,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+        assert cov is None
+
+    def test_output_is_psd(self):
+        rng = np.random.default_rng(99)
+        hists = {
+            name: ph(_prices_from_returns(rng.normal(0, 0.01, 260)))
+            for name in ("A", "B", "C", "D")
+        }
+        cov = covariance_matrix(hists, vol_window=60, corr_window=252, vol_floor=0.001)
+        assert cov is not None
+        eigenvalues = np.linalg.eigvalsh(cov.values)
+        assert (eigenvalues >= -1e-9).all()
+
+    def test_index_and_columns_match_ticker_order(self):
+        rng = np.random.default_rng(1)
+        hists = {
+            name: ph(_prices_from_returns(rng.normal(0, 0.01, 260)))
+            for name in ("Z", "A", "M")
+        }
+        cov = covariance_matrix(hists, vol_window=60, corr_window=252, vol_floor=0.001)
+        assert cov is not None
+        # Deterministic order for downstream matmul correctness.
+        assert list(cov.index) == ["A", "M", "Z"]
+        assert list(cov.columns) == ["A", "M", "Z"]
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_risk.py::TestCovarianceMatrix -q`
+Expected: `ImportError: cannot import name 'covariance_matrix'`.
+
+- [ ] **Step 3: Add `covariance_matrix` to `src/midas/risk.py`**
+
+Add imports:
+
+```python
+from collections.abc import Mapping
+
+import pandas as pd
+from sklearn.covariance import LedoitWolf
+```
+
+Add function:
+
+```python
+def covariance_matrix(
+    histories: Mapping[str, PriceHistory],
+    vol_window: int,
+    corr_window: int,
+    vol_floor: float,
+) -> pd.DataFrame | None:
+    """Composed covariance: vols (short window) × corr (long window, shrunk).
+
+    Correlation is fit with :class:`sklearn.covariance.LedoitWolf` on the
+    last ``corr_window`` returns across the universe. Per-ticker vols are
+    realized over ``vol_window`` and floored at ``vol_floor`` before the
+    outer-product composition.
+
+    Returns:
+        NxN covariance DataFrame indexed by ticker (sorted), or None when
+        any ticker has fewer than ``corr_window + 1`` clean bars or the
+        LedoitWolf fit fails.
+    """
+    if corr_window < 2 or vol_window < 2:
+        msg = f"vol_window and corr_window must be >= 2, got {vol_window}, {corr_window}"
+        raise ValueError(msg)
+
+    tickers = sorted(histories.keys())
+    if len(tickers) < 1:
+        return None
+
+    returns_cols: list[np.ndarray] = []
+    for ticker in tickers:
+        history = histories[ticker]
+        if len(history) < corr_window + 1:
+            return None
+        closes = history.close[-(corr_window + 1):]
+        if not np.all(np.isfinite(closes)):
+            return None
+        returns_cols.append(closes[1:] / closes[:-1] - 1.0)
+
+    returns_matrix = np.column_stack(returns_cols)  # shape (corr_window, N)
+
+    try:
+        lw = LedoitWolf().fit(returns_matrix)
+    except Exception:  # noqa: BLE001 — any LW failure degrades gracefully
+        return None
+
+    daily_cov = lw.covariance_
+    # Derive correlation from LedoitWolf's daily covariance.
+    daily_std = np.sqrt(np.diag(daily_cov))
+    # Guard against zero diag from a degenerate constant series.
+    if not np.all(daily_std > 0):
+        return None
+    corr = daily_cov / np.outer(daily_std, daily_std)
+
+    # Per-ticker realized (annualized) vol over the short window. None-fallback
+    # = floor so the composition always has a defined scale.
+    vols: list[float] = []
+    for ticker in tickers:
+        v = realized_vol(histories[ticker], window=vol_window, annualize=True)
+        vols.append(max(v if v is not None else vol_floor, vol_floor))
+    vols_arr = np.asarray(vols)
+
+    cov_composed = corr * np.outer(vols_arr, vols_arr)
+    # Numerical safety: symmetrize.
+    cov_composed = 0.5 * (cov_composed + cov_composed.T)
+    return pd.DataFrame(cov_composed, index=tickers, columns=tickers)
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_risk.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/risk.py tests/test_risk.py --fix
+uv run ruff format src/midas/risk.py tests/test_risk.py
+uv run mypy src
+git add src/midas/risk.py tests/test_risk.py
+git commit -m "Add covariance_matrix with LedoitWolf-shrunk correlation"
+```
+
+---
+
+### Task 6: `apply_instrument_diversification_multiplier` (TDD)
+
+**Files:**
+- Modify: `src/midas/risk.py`
+- Modify: `tests/test_risk.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_risk.py`:
+
+```python
+from midas.risk import apply_instrument_diversification_multiplier
+
+
+def _corr_frame(tickers: list[str], matrix: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame(matrix, index=tickers, columns=tickers)
+
+
+class TestApplyInstrumentDiversificationMultiplier:
+    def test_uncorrelated_equal_weights_give_idm_approx_sqrt_n(self):
+        tickers = ["A", "B", "C", "D"]
+        weights = {t: 0.25 for t in tickers}
+        corr = _corr_frame(tickers, np.eye(4))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=5.0)
+        # IDM = 1/sqrt(0.25 * 4 * 0.25) = 1/sqrt(0.25) = 2.0 = sqrt(4).
+        total = sum(out.values())
+        assert math.isclose(total, sum(weights.values()) * 2.0, rel_tol=1e-9)
+
+    def test_perfect_correlation_gives_idm_one(self):
+        tickers = ["A", "B"]
+        weights = {"A": 0.4, "B": 0.4}
+        corr = _corr_frame(tickers, np.ones((2, 2)))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=5.0)
+        assert math.isclose(out["A"], 0.4, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.4, rel_tol=1e-9)
+
+    def test_cap_binds_when_raw_idm_exceeds(self):
+        tickers = ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
+        weights = dict.fromkeys(tickers, 1.0 / 9.0)
+        corr = _corr_frame(tickers, np.eye(9))
+        # raw IDM = sqrt(9) = 3.0; cap at 2.0 → multiplier = 2.0 / 3.0 of raw, so scale = 2.0.
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.0)
+        total = sum(out.values())
+        assert math.isclose(total, sum(weights.values()) * 2.0, rel_tol=1e-9)
+
+    def test_empty_weights_returns_empty(self):
+        corr = _corr_frame(["A"], np.eye(1))
+        assert apply_instrument_diversification_multiplier({}, corr, cap=2.5) == {}
+
+    def test_single_ticker_weights_unchanged(self):
+        weights = {"A": 0.5}
+        corr = _corr_frame(["A"], np.eye(1))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        assert out == {"A": 0.5}
+
+    def test_zero_weights_returns_unchanged(self):
+        tickers = ["A", "B"]
+        weights = dict.fromkeys(tickers, 0.0)
+        corr = _corr_frame(tickers, np.eye(2))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        assert out == weights
+
+    def test_weights_referencing_missing_ticker_are_ignored(self):
+        # "A" is in weights but absent from the correlation matrix — treat as
+        # uncorrelated (contributes to sum but not to the diversification math).
+        weights = {"A": 0.3, "B": 0.3}
+        corr = _corr_frame(["B"], np.eye(1))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        # A passes through with multiplier 1.0; B scales by its own IDM which
+        # for a 1-asset "portfolio" is trivially 1.0.
+        assert math.isclose(out["A"], 0.3, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.3, rel_tol=1e-9)
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_risk.py::TestApplyInstrumentDiversificationMultiplier -q`
+Expected: `ImportError`.
+
+- [ ] **Step 3: Add the function to `src/midas/risk.py`**
+
+```python
+def apply_instrument_diversification_multiplier(
+    weights: dict[str, float],
+    corr: pd.DataFrame,
+    cap: float,
+) -> dict[str, float]:
+    """Scale all weights by ``min(1/sqrt(w·corr·w), cap)``.
+
+    Args:
+        weights: Ticker -> weight before IDM.
+        corr: Symmetric correlation matrix. Tickers in ``weights`` but not
+            in ``corr`` are left unscaled (treated as uncorrelated singletons).
+        cap: Upper bound on the multiplier. Must be >= 1.0 (checked by
+            :class:`RiskConfig`).
+
+    Returns:
+        New dict with scaled weights. Returns inputs unchanged on degenerate
+        inputs (empty weights, single ticker, zero weights, or numerical
+        w·corr·w <= 0).
+    """
+    if not weights:
+        return {}
+    if sum(weights.values()) == 0:
+        return dict(weights)
+
+    # Intersect weights with corr index — only covered tickers participate.
+    covered = [t for t in weights if t in corr.index]
+    if len(covered) <= 1:
+        return dict(weights)
+
+    w = np.asarray([weights[t] for t in covered])
+    sub_corr = corr.loc[covered, covered].values
+    quad = float(w @ sub_corr @ w)
+    if quad <= 0:
+        return dict(weights)
+
+    raw_idm = 1.0 / math.sqrt(quad)
+    multiplier = min(raw_idm, cap)
+    if multiplier <= 1.0:
+        # min(idm, cap) == 1.0 exactly happens only when idm<=1 (perfect
+        # correlation) or cap==1.0 (IDM stage disabled). Return unchanged.
+        return dict(weights)
+
+    return {t: weight * multiplier if t in set(covered) else weight for t, weight in weights.items()}
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_risk.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/risk.py tests/test_risk.py --fix
+uv run ruff format src/midas/risk.py tests/test_risk.py
+uv run mypy src
+git add src/midas/risk.py tests/test_risk.py
+git commit -m "Add apply_instrument_diversification_multiplier"
+```
+
+---
+
+### Task 7: `apply_vol_targeting` (TDD)
+
+**Files:**
+- Modify: `src/midas/risk.py`
+- Modify: `tests/test_risk.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_risk.py`:
+
+```python
+from midas.risk import apply_vol_targeting
+
+
+def _cov_frame(tickers: list[str], matrix: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame(matrix, index=tickers, columns=tickers)
+
+
+class TestApplyVolTargeting:
+    def test_below_target_returns_unchanged(self):
+        # diag(cov) = 0.01 (10% ann vol), w = 0.5,0.5 uncorrelated → portfolio vol ≈ 7.07%
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.diag([0.01, 0.01]))
+        weights = {"A": 0.5, "B": 0.5}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_exactly_at_target_returns_unchanged(self):
+        # Single asset, vol ≈ 20%; weight = 1 → portfolio vol = 20%.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        weights = {"A": 1.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert math.isclose(out["A"], 1.0, rel_tol=1e-9)
+
+    def test_double_target_halves_weights(self):
+        # Single asset, vol = 40% (variance 0.16), target = 20% → scale by 0.5.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.16]]))
+        weights = {"A": 1.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert math.isclose(out["A"], 0.5, rel_tol=1e-9)
+
+    def test_zero_weights_returns_zero(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.eye(2))
+        weights = {"A": 0.0, "B": 0.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_degenerate_cov_returns_unchanged(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.zeros((2, 2)))
+        weights = {"A": 0.5, "B": 0.5}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_weights_missing_from_cov_pass_through_unscaled(self):
+        # "B" isn't in cov. "A" dominates the vol calculation.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.16]]))  # 40% vol
+        weights = {"A": 1.0, "B": 0.3}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        # A scales by 0.5; B is uncovered → passes through scaled by the same
+        # portfolio-wide multiplier so the downscaling remains coherent.
+        assert math.isclose(out["A"], 0.5, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.15, rel_tol=1e-9)
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_risk.py::TestApplyVolTargeting -q`
+Expected: `ImportError`.
+
+- [ ] **Step 3: Add `apply_vol_targeting` and `predict_portfolio_vol` to `src/midas/risk.py`**
+
+Note: `predict_portfolio_vol` is defined here because `apply_vol_targeting` uses it. Task 8 then adds tests for it separately.
+
+```python
+def predict_portfolio_vol(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+) -> float:
+    """Ex-ante portfolio vol: ``sqrt(w · cov · w) * sqrt(252)``.
+
+    Tickers in ``weights`` but not in ``cov`` are ignored. Returns 0.0 on
+    empty weights, all-zero weights, or when the quadratic form is
+    non-positive (degenerate covariance).
+    """
+    covered = [t for t in weights if t in cov.index]
+    if not covered:
+        return 0.0
+    w = np.asarray([weights[t] for t in covered])
+    sub_cov = cov.loc[covered, covered].values
+    quad = float(w @ sub_cov @ w)
+    if quad <= 0:
+        return 0.0
+    # cov is already annualized (composed from annualized vols), so sqrt(252)
+    # is NOT reapplied here. The function name says "annualized" implicitly.
+    return math.sqrt(quad)
+
+
+def apply_vol_targeting(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+    target_annualized_vol: float,
+) -> dict[str, float]:
+    """Scale weights down so predicted vol does not exceed the target.
+
+    Never scales up — if predicted vol is below target, weights are
+    returned unchanged. Degenerate cov matrices (w·cov·w <= 0) also
+    pass through unchanged.
+    """
+    if not weights:
+        return {}
+    if sum(weights.values()) == 0:
+        return dict(weights)
+
+    predicted = predict_portfolio_vol(weights, cov)
+    if predicted <= 0 or predicted <= target_annualized_vol:
+        return dict(weights)
+
+    scale = target_annualized_vol / predicted
+    return {t: weight * scale for t, weight in weights.items()}
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_risk.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/risk.py tests/test_risk.py --fix
+uv run ruff format src/midas/risk.py tests/test_risk.py
+uv run mypy src
+git add src/midas/risk.py tests/test_risk.py
+git commit -m "Add apply_vol_targeting and predict_portfolio_vol"
+```
+
+---
+
+### Task 8: `predict_portfolio_vol` direct tests
+
+**Files:**
+- Modify: `tests/test_risk.py`
+
+The function is already implemented (Task 7). This task adds focused unit tests.
+
+- [ ] **Step 1: Write tests**
+
+Append to `tests/test_risk.py`:
+
+```python
+from midas.risk import predict_portfolio_vol
+
+
+class TestPredictPortfolioVol:
+    def test_two_asset_uncorrelated_equal_weight(self):
+        # var_a = var_b = 0.04 (20% vol), w = (0.5, 0.5), uncorrelated.
+        # portfolio_var = 0.25 * 0.04 + 0.25 * 0.04 = 0.02 → vol ≈ sqrt(0.02) ≈ 0.1414
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.diag([0.04, 0.04]))
+        vol = predict_portfolio_vol({"A": 0.5, "B": 0.5}, cov)
+        assert math.isclose(vol, math.sqrt(0.02), rel_tol=1e-9)
+
+    def test_zero_weights_return_zero(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        assert predict_portfolio_vol({"A": 0.0}, cov) == 0.0
+
+    def test_empty_weights_return_zero(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        assert predict_portfolio_vol({}, cov) == 0.0
+
+    def test_weights_outside_cov_index_ignored(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        # Only A contributes; B is ignored.
+        vol = predict_portfolio_vol({"A": 1.0, "B": 5.0}, cov)
+        assert math.isclose(vol, 0.20, rel_tol=1e-9)
+
+    def test_degenerate_cov_returns_zero(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, -np.eye(2))  # non-PSD, forces quad <= 0
+        assert predict_portfolio_vol({"A": 1.0, "B": 1.0}, cov) == 0.0
+```
+
+- [ ] **Step 2: Run and verify pass**
+
+Run: `uv run pytest tests/test_risk.py::TestPredictPortfolioVol -q`
+Expected: all tests pass (no implementation change — function already exists from Task 7).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_risk.py
+git commit -m "Add direct unit tests for predict_portfolio_vol"
+```
+
+---
+
+### Task 9: Thread `RiskConfig` through `Allocator` constructor (no behavior change)
+
+**Files:**
+- Modify: `src/midas/allocator.py`
+- Modify: `src/midas/cli.py:35-60` (`_build_components`)
+- Modify: `tests/test_allocator.py` (one new test)
+
+The allocator accepts `RiskConfig` but stores it without using it yet. This isolates the signature change from the stage integrations that follow.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+from midas.models import RiskConfig
+
+
+class TestAllocatorRiskConfig:
+    def test_accepts_risk_config_kwarg(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05)
+        risk = RiskConfig()
+        allocator = Allocator([(mr, 1.0)], constraints, n_tickers=2, risk_config=risk)
+        # Verify it's stored on the instance for later phases to read.
+        assert allocator._risk_config is risk
+
+    def test_defaults_to_risk_config_when_omitted(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05)
+        allocator = Allocator([(mr, 1.0)], constraints, n_tickers=2)
+        # Default matches RiskConfig() exactly.
+        assert allocator._risk_config == RiskConfig()
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_allocator.py::TestAllocatorRiskConfig -q`
+Expected: `TypeError` — unexpected keyword `risk_config`.
+
+- [ ] **Step 3: Update `Allocator.__init__`**
+
+Edit `src/midas/allocator.py`. Add import:
+
+```python
+from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints, RiskConfig
+```
+
+Change the signature and add storage:
+
+```python
+    def __init__(
+        self,
+        entries: list[tuple[EntrySignal, float]],
+        constraints: AllocationConstraints,
+        n_tickers: int,
+        *,
+        risk_config: RiskConfig | None = None,
+    ) -> None:
+        self._entries: list[_ScoredEntry] = [_ScoredEntry(strat, wt) for strat, wt in entries]
+        self._constraints = constraints
+        self._risk_config = risk_config if risk_config is not None else RiskConfig()
+        self._n_tickers = n_tickers
+        self._signal_cache: dict[int, dict[str, np.ndarray]] = {}
+        self._risk_cache: dict[str, Any] = {}
+        # ... rest of existing __init__ body unchanged
+```
+
+Leave everything else unchanged for now.
+
+- [ ] **Step 4: Thread through `_build_components`**
+
+Edit `src/midas/cli.py:35-60`. Change the signature and pass through:
+
+```python
+def _build_components(
+    strategy_configs: list[StrategyConfig] | None,
+    constraints: AllocationConstraints,
+    n_tickers: int,
+    risk_config: RiskConfig | None = None,
+) -> tuple[Allocator, OrderSizer, list[ExitRule]]:
+    """Build allocator, order sizer, and exit rules from config."""
+    configs = strategy_configs or [StrategyConfig(name=name) for name in STRATEGY_REGISTRY]
+
+    entries: list[tuple[EntrySignal, float]] = []
+    exits: list[ExitRule] = []
+
+    for cfg in configs:
+        strategy = _build_strategy(cfg)
+
+        if isinstance(strategy, ExitRule):
+            exits.append(strategy)
+        elif isinstance(strategy, EntrySignal):
+            entries.append((strategy, cfg.weight))
+        else:
+            msg = f"Strategy {cfg.name!r} is neither EntrySignal nor ExitRule"
+            raise click.ClickException(msg)
+
+    allocator = Allocator(entries, constraints, n_tickers, risk_config=risk_config)
+    order_sizer = OrderSizer()
+
+    return allocator, order_sizer, exits
+```
+
+Update the two call sites in `backtest` (line 158) and `live` (line 218):
+
+```python
+    allocator, order_sizer, exit_rules = _build_components(
+        strat_configs,
+        constraints,
+        n_tickers,
+        risk_config=risk_config,
+    )
+```
+
+- [ ] **Step 5: Run tests and verify pass**
+
+Run: `uv run pytest -q`
+Expected: all tests pass — including the new ones and all existing integration/backtest tests (no behavior change).
+
+- [ ] **Step 6: Lint, type-check, commit**
+
+```bash
+uv run ruff check src tests --fix
+uv run ruff format src tests
+uv run mypy src
+git add src/midas/allocator.py src/midas/cli.py tests/test_allocator.py
+git commit -m "Thread RiskConfig through Allocator constructor"
+```
+
+---
+
+### Task 10: Phase 1.5 — build risk cache in `precompute_signals`
+
+**Files:**
+- Modify: `src/midas/allocator.py`
+- Modify: `tests/test_allocator.py`
+
+Precompute populates `self._risk_cache` but no allocation phase consumes it yet. This isolates cache correctness from phase integration.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_allocator.py`:
+
+```python
+import pandas as pd
+
+
+class TestAllocatorRiskCache:
+    def test_cache_populated_with_sufficient_history(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        rng = np.random.default_rng(0)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 1, 260)))
+            for name in ("A", "B", "C")
+        }
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(vol_lookback_days=60, corr_lookback_days=252),
+        )
+        allocator.precompute_signals(histories)
+
+        cache = allocator._risk_cache
+        assert cache["cov"] is not None
+        assert isinstance(cache["cov"], pd.DataFrame)
+        assert cache["corr"] is not None
+        assert set(cache["per_ticker_vol"].keys()) == {"A", "B", "C"}
+
+    def test_cache_none_when_insufficient_history(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # Only 30 bars — less than default corr_lookback_days=252.
+        histories = {name: ph(np.full(30, 100.0)) for name in ("A", "B")}
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),
+        )
+        allocator.precompute_signals(histories)
+
+        cache = allocator._risk_cache
+        assert cache["cov"] is None
+        assert cache["corr"] is None
+        # Per-ticker vols also None when window not met.
+        assert cache["per_ticker_vol"] == {"A": None, "B": None}
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_allocator.py::TestAllocatorRiskCache -q`
+Expected: KeyError on `"cov"` (cache currently initialized to `{}`).
+
+- [ ] **Step 3: Implement cache build**
+
+Edit `src/midas/allocator.py`. Add imports:
+
+```python
+from midas.risk import covariance_matrix, realized_vol
+```
+
+Replace the existing `precompute_signals` method:
+
+```python
+    def precompute_signals(self, price_data: dict[str, PriceHistory]) -> None:
+        """Precompute entry-signal scores and risk cache over the full price arrays."""
+        self._signal_cache = {}
+        for entry in self._entries:
+            cache: dict[str, np.ndarray] = {}
+            for ticker, history in price_data.items():
+                result = entry.strategy.precompute(history)
+                if result is not None:
+                    cache[ticker] = result
+            if cache:
+                self._signal_cache[id(entry.strategy)] = cache
+
+        self._risk_cache = self._build_risk_cache(price_data)
+
+    def _build_risk_cache(
+        self,
+        price_data: dict[str, PriceHistory],
+    ) -> dict[str, Any]:
+        rc = self._risk_config
+        per_ticker_vol: dict[str, float | None] = {
+            ticker: realized_vol(history, window=rc.vol_lookback_days, annualize=True)
+            for ticker, history in price_data.items()
+        }
+        cov = covariance_matrix(
+            price_data,
+            vol_window=rc.vol_lookback_days,
+            corr_window=rc.corr_lookback_days,
+            vol_floor=rc.vol_floor,
+        )
+        if cov is None:
+            corr = None
+        else:
+            diag = np.sqrt(np.diag(cov.values))
+            if np.all(diag > 0):
+                corr_vals = cov.values / np.outer(diag, diag)
+                corr = pd.DataFrame(corr_vals, index=cov.index, columns=cov.columns)
+            else:
+                corr = None
+                cov = None
+        return {"cov": cov, "corr": corr, "per_ticker_vol": per_ticker_vol}
+```
+
+Add pandas import near the existing numpy import:
+
+```python
+import pandas as pd
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py -q`
+Expected: all tests pass. No allocation behavior change — just a new cache field.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/allocator.py tests/test_allocator.py --fix
+uv run ruff format src/midas/allocator.py tests/test_allocator.py
+uv run mypy src
+git add src/midas/allocator.py tests/test_allocator.py
+git commit -m "Phase 1.5: build risk cache in precompute_signals"
+```
+
+---
+
+### Task 11: Phase 2 — per-ticker vol offset in softmax
+
+**Files:**
+- Modify: `src/midas/allocator.py`
+- Modify: `tests/test_allocator.py`
+
+When `weighting == "inverse_vol"` and a ticker has a known vol, add `-log(max(vol, vol_floor))` to its blended score before softmax. Low-vol tickers get higher effective scores.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+class TestPerTickerVolScaling:
+    def test_low_vol_ticker_gets_more_weight_than_high_vol(self):
+        """With equal signals, inverse-vol scaling should overweight low-vol ticker."""
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(0)
+        # LOW vol — tiny daily noise.
+        low = 100.0 + np.cumsum(rng.normal(0, 0.05, 260))
+        # HIGH vol — large daily noise.
+        high = 100.0 + np.cumsum(rng.normal(0, 2.0, 260))
+        # Both end with an identical "buy" signal: 10% drop on last bar.
+        low[-1] = low[-2] * 0.90
+        high[-1] = high[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(weighting="inverse_vol"),
+        )
+        histories = {"LOW": ph(low), "HIGH": ph(high)}
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["LOW", "HIGH"],
+            histories,
+            current_weights={"LOW": 0.0, "HIGH": 0.0},
+        )
+        assert result.targets["LOW"] > result.targets["HIGH"]
+
+    def test_equal_weighting_disables_offset(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(1)
+        low = 100.0 + np.cumsum(rng.normal(0, 0.05, 260))
+        high = 100.0 + np.cumsum(rng.normal(0, 2.0, 260))
+        low[-1] = low[-2] * 0.90
+        high[-1] = high[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(weighting="equal"),
+        )
+        histories = {"LOW": ph(low), "HIGH": ph(high)}
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["LOW", "HIGH"],
+            histories,
+            current_weights={"LOW": 0.0, "HIGH": 0.0},
+        )
+        # Without vol offset, equal signals → equal softmax weights (within 1e-9).
+        assert math.isclose(result.targets["LOW"], result.targets["HIGH"], rel_tol=1e-6)
+```
+
+Add `import math` at the top of `test_allocator.py` if not already present.
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_allocator.py::TestPerTickerVolScaling -q`
+Expected: `test_low_vol_ticker_gets_more_weight_than_high_vol` fails (weights roughly equal without offset).
+
+- [ ] **Step 3: Modify `_softmax_allocate` to accept per-ticker offsets**
+
+Edit `src/midas/allocator.py`. Change `_softmax_allocate` to accept an optional offset map and use it:
+
+```python
+    def _softmax_allocate(
+        self,
+        tickers: list[str],
+        blended_scores: dict[str, float],
+        budget: float,
+        temperature: float,
+        targets: dict[str, float],
+        score_offsets: dict[str, float] | None = None,
+    ) -> None:
+        """Distribute `budget` across `tickers` via softmax((blended_scores + offsets) / T).
+
+        Temperature semantics:
+            T → 0   winner-take-all (budget to the argmax ticker)
+            T = 1   standard softmax over raw scores
+            T → ∞   uniform split regardless of conviction
+        """
+        if not tickers or budget <= 0:
+            for ticker in tickers:
+                targets[ticker] = 0.0
+            return
+        temp_safe = max(temperature, MIN_TEMPERATURE)
+        offsets = score_offsets or {}
+        adjusted = {ticker: blended_scores[ticker] + offsets.get(ticker, 0.0) for ticker in tickers}
+        max_score = max(adjusted.values())
+        exps = {ticker: math.exp((adjusted[ticker] - max_score) / temp_safe) for ticker in tickers}
+        total_exp = sum(exps.values())
+        for ticker in tickers:
+            targets[ticker] = budget * exps[ticker] / total_exp
+```
+
+Update `_apply_cap_with_redistribution` to accept and forward the offsets:
+
+```python
+    def _apply_cap_with_redistribution(
+        self,
+        active: list[str],
+        blended_scores: dict[str, float],
+        initial_budget: float,
+        temperature: float,
+        targets: dict[str, float],
+        score_offsets: dict[str, float] | None = None,
+    ) -> None:
+        """Clamp targets exceeding max_position_pct; re-softmax the survivors."""
+        cap = self._max_position_pct
+        survivors = list(active)
+        budget = initial_budget
+        for _ in range(len(active) + 1):
+            over = [ticker for ticker in survivors if targets[ticker] > cap + 1e-12]
+            if not over:
+                return
+            for ticker in over:
+                targets[ticker] = cap
+                budget -= cap
+                survivors.remove(ticker)
+            if not survivors or budget <= 0:
+                for ticker in survivors:
+                    targets[ticker] = 0.0
+                return
+            self._softmax_allocate(
+                survivors, blended_scores, budget, temperature, targets, score_offsets=score_offsets,
+            )
+```
+
+In `allocate`, build the offsets and pass them in phase 2 and phase 3's cap:
+
+After the Phase 1 block (just before "Phase 2: Softmax construct-to-budget"), add:
+
+```python
+        # Phase 1.5a: Compute per-ticker vol offsets for softmax (inverse-vol weighting).
+        score_offsets = self._vol_score_offsets(active)
+
+        # Phase 2: Softmax construct-to-budget over active tickers.
+        self._softmax_allocate(
+            active, blended_scores, budget_for_active, temperature, targets, score_offsets=score_offsets,
+        )
+
+        # Phase 3: Soft position cap.
+        self._apply_cap_with_redistribution(
+            active, blended_scores, budget_for_active, temperature, targets, score_offsets=score_offsets,
+        )
+```
+
+And add the helper method:
+
+```python
+    def _vol_score_offsets(self, active: list[str]) -> dict[str, float]:
+        """Per-ticker score offsets for inverse-vol weighting.
+
+        Returns an empty dict when the weighting is ``"equal"`` or when a
+        ticker has no known vol (warmup). Missing entries default to 0 in
+        ``_softmax_allocate``.
+        """
+        if self._risk_config.weighting != "inverse_vol":
+            return {}
+        offsets: dict[str, float] = {}
+        vol_floor = self._risk_config.vol_floor
+        per_ticker_vol = self._risk_cache.get("per_ticker_vol") or {}
+        for ticker in active:
+            vol = per_ticker_vol.get(ticker)
+            if vol is None:
+                continue  # warmup — no offset
+            offsets[ticker] = -math.log(max(vol, vol_floor))
+        return offsets
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py -q`
+Expected: all tests pass, including the new per-ticker scaling tests.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/allocator.py tests/test_allocator.py --fix
+uv run ruff format src/midas/allocator.py tests/test_allocator.py
+uv run mypy src
+git add src/midas/allocator.py tests/test_allocator.py
+git commit -m "Phase 2: inverse-vol score offset in softmax"
+```
+
+---
+
+### Task 12: Phase 3.5 — apply IDM after the cap
+
+**Files:**
+- Modify: `src/midas/allocator.py`
+- Modify: `tests/test_allocator.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+class TestIDMStage:
+    def test_three_uncorrelated_tickers_scale_up_by_sqrt3(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,  # loose cap — won't bind after IDM
+        )
+        rng = np.random.default_rng(42)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260)))
+            for name in ("A", "B", "C")
+        }
+        # Final bar identical-size drop on all three → equal signals.
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=5.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        pre_idm_sum = (1 - 0.05)
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Roughly sqrt(3) × pre_idm_sum, with some slack from LW shrinkage
+        # pulling correlations slightly off-zero.
+        assert total > 1.3 * pre_idm_sum
+        assert total < 1.8 * pre_idm_sum
+
+    def test_idm_cap_binds_at_1_0_disables_stage(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(42)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260)))
+            for name in ("A", "B", "C")
+        }
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=1.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result.targets.values())
+        # idm_cap=1.0 → multiplier capped at 1.0 → no scale-up.
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)
+
+    def test_idm_then_recap_clips_overshoots(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        # Tight cap: IDM will push at least one ticker past it.
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.40,
+        )
+        rng = np.random.default_rng(42)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260)))
+            for name in ("A", "B", "C")
+        }
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=3.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        # Re-cap (phase 3.6) must pull everything back to max_position_pct.
+        for ticker, weight in result.targets.items():
+            assert weight <= 0.40 + 1e-9, f"{ticker} exceeded cap after re-cap"
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_allocator.py::TestIDMStage -q`
+Expected: `test_three_uncorrelated_tickers_scale_up_by_sqrt3` fails — totals stay at 0.95.
+
+- [ ] **Step 3: Integrate phases 3.5 and 3.6**
+
+Edit `src/midas/allocator.py`. Add import:
+
+```python
+from midas.risk import (
+    apply_instrument_diversification_multiplier,
+    apply_vol_targeting,
+    covariance_matrix,
+    realized_vol,
+)
+```
+
+After the existing phase-3 call in `allocate`, add phases 3.5 and 3.6:
+
+```python
+        # Phase 3.5: Instrument Diversification Multiplier.
+        corr = self._risk_cache.get("corr")
+        if corr is not None and active:
+            active_weights = {ticker: targets[ticker] for ticker in active}
+            scaled = apply_instrument_diversification_multiplier(
+                active_weights, corr, cap=self._risk_config.idm_cap,
+            )
+            for ticker, weight in scaled.items():
+                targets[ticker] = weight
+
+        # Phase 3.6: Re-cap after IDM (IDM can push single positions past the cap).
+        self._apply_cap_with_redistribution(
+            active, blended_scores, budget_for_active, temperature, targets, score_offsets=score_offsets,
+        )
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/allocator.py tests/test_allocator.py --fix
+uv run ruff format src/midas/allocator.py tests/test_allocator.py
+uv run mypy src
+git add src/midas/allocator.py tests/test_allocator.py
+git commit -m "Phases 3.5 and 3.6: apply IDM and re-cap"
+```
+
+---
+
+### Task 13: Phase 3.7 — apply portfolio vol targeting
+
+**Files:**
+- Modify: `src/midas/allocator.py`
+- Modify: `tests/test_allocator.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+class TestVolTargetingStage:
+    def test_high_vol_portfolio_scaled_down_to_target(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(3)
+        # Very volatile: daily sigma 5% each → annualized vol ≈ 80%.
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 5.0, 260)))
+            for name in ("A", "B")
+        }
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90  # buy signal
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,                     # disable IDM
+                vol_target_annualized=0.20,
+            ),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Vol targeting clamps down — total should be well below 0.95.
+        assert total < 0.60
+
+    def test_low_vol_portfolio_not_scaled_up(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(5)
+        # Tame daily noise — well below 20% annualized.
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.1, 260)))
+            for name in ("A", "B")
+        }
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,
+                vol_target_annualized=0.20,
+            ),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Below target vol → no scaling down.
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)
+```
+
+- [ ] **Step 2: Run and verify failure**
+
+Run: `uv run pytest tests/test_allocator.py::TestVolTargetingStage -q`
+Expected: `test_high_vol_portfolio_scaled_down_to_target` fails.
+
+- [ ] **Step 3: Integrate phase 3.7**
+
+Edit `src/midas/allocator.py`. After phase 3.6, append:
+
+```python
+        # Phase 3.7: Portfolio vol targeting. Only scales down.
+        cov = self._risk_cache.get("cov")
+        if cov is not None and active:
+            active_weights = {ticker: targets[ticker] for ticker in active}
+            scaled = apply_vol_targeting(
+                active_weights, cov,
+                target_annualized_vol=self._risk_config.vol_target_annualized,
+            )
+            for ticker, weight in scaled.items():
+                targets[ticker] = weight
+```
+
+- [ ] **Step 4: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py -q`
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+uv run ruff check src/midas/allocator.py tests/test_allocator.py --fix
+uv run ruff format src/midas/allocator.py tests/test_allocator.py
+uv run mypy src
+git add src/midas/allocator.py tests/test_allocator.py
+git commit -m "Phase 3.7: portfolio vol targeting"
+```
+
+---
+
+### Task 14: Risk-off regression test (safety net)
+
+**Files:**
+- Modify: `tests/test_allocator.py`
+
+Lock in that an explicitly risk-off `RiskConfig` produces the same targets as a pre-risk allocator would have.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+class TestRiskOffRegression:
+    def test_risk_off_matches_pre_risk_behavior(self):
+        """weighting=equal, idm_cap=1.0, vol_target=999 → no risk stage moves weights."""
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.50,
+        )
+        rng = np.random.default_rng(11)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260)))
+            for name in ("A", "B", "C")
+        }
+        # Only A gets a real buy signal; B and C are flat-ish.
+        histories["A"].close[-1] = histories["A"].close[-2] * 0.90
+
+        # Risk-off version.
+        risk_off = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,
+                vol_target_annualized=999.0,
+            ),
+        )
+        risk_off.precompute_signals(histories)
+        result_off = risk_off.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result_off.targets.values())
+        # Investable budget preserved — no scale-up (IDM disabled), no scale-down
+        # (target vol 999% never binds).
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-9)
+        # A should still dominate the softmax with its buy signal.
+        assert result_off.targets["A"] > result_off.targets["B"]
+        assert result_off.targets["A"] > result_off.targets["C"]
+```
+
+- [ ] **Step 2: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py::TestRiskOffRegression -q`
+Expected: passes on first run (all risk stages defined to no-op in this config).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_allocator.py
+git commit -m "Add risk-off regression test as safety net"
+```
+
+---
+
+### Task 15: Warmup integration test
+
+**Files:**
+- Modify: `tests/test_allocator.py`
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_allocator.py`:
+
+```python
+class TestWarmupProgression:
+    def test_short_history_disables_all_risk_stages(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # Only 30 bars — below any default lookback window.
+        histories = {name: ph(np.full(30, 100.0)) for name in ("A", "B")}
+        # Last-bar drop to generate signals.
+        histories["A"].close[-1] = 90.0
+        histories["B"].close[-1] = 90.0
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),  # defaults
+        )
+        allocator.precompute_signals(histories)
+        # Cache should be fully None.
+        assert allocator._risk_cache["cov"] is None
+        assert allocator._risk_cache["corr"] is None
+        assert allocator._risk_cache["per_ticker_vol"] == {"A": None, "B": None}
+
+        # Allocation still works — falls through all risk stages cleanly.
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-9)
+
+    def test_mid_window_enables_per_ticker_vol_only(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # 120 bars — enough for vol_lookback_days=60 but not corr_lookback_days=252.
+        rng = np.random.default_rng(22)
+        histories = {
+            name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 120)))
+            for name in ("A", "B")
+        }
+        histories["A"].close[-1] = histories["A"].close[-2] * 0.90
+        histories["B"].close[-1] = histories["B"].close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),  # defaults (vol=60, corr=252)
+        )
+        allocator.precompute_signals(histories)
+        # Per-ticker vol defined; cov/corr still None.
+        assert allocator._risk_cache["per_ticker_vol"]["A"] is not None
+        assert allocator._risk_cache["per_ticker_vol"]["B"] is not None
+        assert allocator._risk_cache["cov"] is None
+        assert allocator._risk_cache["corr"] is None
+
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        # IDM and vol targeting skipped → total ≈ investable.
+        total = sum(result.targets.values())
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)
+```
+
+- [ ] **Step 2: Run and verify pass**
+
+Run: `uv run pytest tests/test_allocator.py::TestWarmupProgression -q`
+Expected: passes — warmup paths already guard all three stages.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_allocator.py
+git commit -m "Add warmup progression integration test"
+```
+
+---
+
+### Task 16: End-to-end backtest change-detector
+
+**Files:**
+- Modify: `tests/test_backtest.py` (append a new test)
+
+Lock in the default risk-on behavior against a canned fixture so accidental changes surface immediately.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/test_backtest.py`:
+
+```python
+class TestRiskDisciplineEndToEnd:
+    def test_default_risk_config_produces_stable_summary(self, tmp_path):
+        """End-to-end smoke test: default RiskConfig + canned fixture → stable summary.
+
+        Change-detector, not a correctness test. If this breaks, confirm the
+        drift is intentional before updating the golden numbers.
+        """
+        from datetime import date as dt_date
+
+        from midas.allocator import Allocator
+        from midas.backtest import BacktestEngine
+        from midas.models import (
+            AllocationConstraints,
+            Holding,
+            PortfolioConfig,
+            RiskConfig,
+        )
+        from midas.order_sizer import OrderSizer
+        from midas.strategies.mean_reversion import MeanReversion
+
+        # Deterministic synthetic: 2 tickers, 400 bars, mild drift + noise.
+        rng = np.random.default_rng(2026)
+        days = 400
+        start = dt_date(2023, 1, 2)
+        frames: dict[str, pd.DataFrame] = {}
+        for name, sigma in [("AAA", 0.01), ("BBB", 0.02)]:
+            returns = rng.normal(0.0003, sigma, days).tolist()
+            frames[name] = make_price_series(start, days, 100.0, returns, name=name)
+
+        portfolio = PortfolioConfig(
+            holdings=[
+                Holding(ticker="AAA", shares=0),
+                Holding(ticker="BBB", shares=0),
+            ],
+            available_cash=10_000.0,
+        )
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.60,
+        )
+        allocator = Allocator(
+            [(MeanReversion(window=20, threshold=0.03), 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),  # defaults — risk-on
+        )
+        engine = BacktestEngine(
+            allocator=allocator,
+            order_sizer=OrderSizer(),
+            exit_rules=[],
+            constraints=constraints,
+            train_pct=1.0,
+            enable_split=False,
+        )
+        result = engine.run(portfolio, frames, start, start + timedelta(days=days))
+
+        # Change-detector: lock in a few stable numbers. Update deliberately.
+        assert result.total_days > 0
+        assert math.isfinite(result.final_value)
+        assert result.final_value > 0
+        # Default risk-on pipeline should produce at least one trade on this
+        # 400-day synthetic — guards against the pipeline no-op'ing silently.
+        assert len(result.trades) >= 1
+```
+
+Add imports at the top of `tests/test_backtest.py` if not already present: `import math`, `import numpy as np`, `import pandas as pd`, `from datetime import timedelta`, `from conftest import make_price_series`.
+
+- [ ] **Step 2: Run and verify pass**
+
+Run: `uv run pytest tests/test_backtest.py::TestRiskDisciplineEndToEnd -q`
+Expected: passes.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass.
+
+- [ ] **Step 4: Lint, type-check, final commit**
+
+```bash
+uv run ruff check src tests --fix
+uv run ruff format src tests
+uv run mypy src
+git add tests/test_backtest.py
+git commit -m "Add end-to-end change-detector for default risk config"
+```
+
+---
+
+## Closing checks
+
+- [ ] **Final validation**
+
+Run all of the following and confirm clean:
+
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy src
+uv run pytest -q
+```
+
+Expected: all green.
+
+- [ ] **Review commit history**
+
+```bash
+git log --oneline $(git merge-base HEAD master)..HEAD
+```
+
+Expected: 16 focused commits mapping 1:1 to the tasks above.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Section 1 (phase ordering): Tasks 10–13 implement 1.5/2/3.5/3.6/3.7 ✓
+- Section 2 (cov estimator): Task 5 uses `sklearn.covariance.LedoitWolf` on correlation, composes via outer-product ✓
+- Section 3 (module organization): Tasks 4–8 build all five public functions in `src/midas/risk.py` ✓
+- Section 4 (config shape): Task 2 `RiskConfig`; Task 3 YAML parsing; Task 9 thread-through ✓
+- Section 5 (data flow): Task 10 builds `_risk_cache` in `precompute_signals` ✓
+- Section 6 (error handling): Task 2 config-time `ValueError`s; Tasks 4–8 include degenerate-input tests; Tasks 10 + 15 cover warmup `None` sentinels ✓
+- Section 7 (testing): All unit categories covered in Tasks 4–8, integration in Tasks 11–15, end-to-end in Task 16; risk-off regression in Task 14 ✓
+- Dependencies (§"Dependencies"): Task 1 adds scikit-learn ✓
+
+**Placeholder scan:** No TBDs, TODOs, or "add appropriate X" phrases.
+
+**Type/signature consistency:**
+- `realized_vol(history, window, annualize=True) -> float | None` — Task 4, used in Task 5 and Task 10 ✓
+- `covariance_matrix(histories, vol_window, corr_window, vol_floor) -> pd.DataFrame | None` — Task 5, used in Task 10 ✓
+- `apply_instrument_diversification_multiplier(weights, corr, cap) -> dict[str, float]` — Task 6, used in Task 12 ✓
+- `apply_vol_targeting(weights, cov, target_annualized_vol) -> dict[str, float]` — Task 7, used in Task 13 ✓
+- `predict_portfolio_vol(weights, cov) -> float` — Task 7, tests added Task 8 ✓
+- `RiskConfig` kwargs match across Tasks 2, 3, 9, 10–15 ✓
+- `Allocator.__init__(..., *, risk_config: RiskConfig | None = None)` — Task 9 establishes; all later tasks use `risk_config=...` keyword ✓

--- a/docs/superpowers/specs/2026-04-20-risk-discipline-design.md
+++ b/docs/superpowers/specs/2026-04-20-risk-discipline-design.md
@@ -1,0 +1,214 @@
+# Risk Discipline Design
+
+**Date:** 2026-04-20
+**Scope:** Issues #52 (portfolio volatility targeting), #53 (per-ticker volatility scaling), #55 (Instrument Diversification Multiplier)
+**Status:** Design approved, ready for implementation plan
+
+## Motivation
+
+Carver's `pysystemtrade` philosophy treats risk discipline as **policy at design time**, not as an optimization target. The three issues above compose into a single cohesive layer that sits between signal scoring and order generation:
+
+- **#53 (per-ticker vol scaling)** reshapes weights so low-vol assets can absorb larger notional shares.
+- **#55 (IDM)** scales the whole portfolio up when holdings are genuinely diversified, recapturing capital that would otherwise sit idle.
+- **#52 (portfolio vol targeting)** enforces a ceiling on ex-ante portfolio volatility, scaling down when the forecast exceeds the target.
+
+Shipping these together — with risk-on defaults and no way to "search over" risk parameters via the optimizer — makes midas opinionated where existing tools are permissive. This document specifies the architecture for that cohesive addition.
+
+## Non-goals
+
+- CPPI / drawdown-triggered de-risking (listed in #52 as "Part 2", explicitly deferred).
+- Per-regime risk policies (crisis detection, volatility forecasting models beyond realized).
+- Exposing risk parameters as optimizer search dimensions. Risk is policy, not a dial.
+- CLI overrides for risk parameters. Strategy-level YAML only.
+
+## Design Decisions
+
+### 1. Phase ordering inside `Allocator.allocate`
+
+Risk stages interleave with the existing 3-phase allocator:
+
+```
+Phase 1    Score entry signals                         (existing)
+Phase 1.5  Precompute per-ticker vol + cov/corr        (NEW)
+Phase 2    Softmax allocate with optional vol offset   (MODIFIED: consumes per-ticker vol)
+Phase 3    Cap + redistribute                          (existing)
+Phase 3.5  Apply Instrument Diversification Multiplier (NEW)
+Phase 3.6  Re-cap + redistribute                       (existing helper, 2nd call)
+Phase 3.7  Apply portfolio vol targeting               (NEW)
+```
+
+Rationale:
+
+- Per-ticker vol scaling belongs inside softmax (phase 2) as an offset `-log(vol_i)` on the score exponent, so the existing normalization still produces a valid weight simplex.
+- IDM scales weights up; it can push single positions over `max_position_pct`, so phase 3.6 reapplies the per-position cap.
+- Vol targeting runs last because it only ever scales down — no cap interaction possible.
+
+### 2. Covariance estimator
+
+`sklearn.covariance.LedoitWolf` applied to the **correlation matrix** over `corr_lookback_days`. The covariance matrix is then composed:
+
+```
+cov = vols[:, None] * corr * vols[None, :]
+```
+
+where `vols` is the realized annualized vol per ticker over `vol_lookback_days`. This separation (Engle-Sheppard 2001, DCC-GARCH family) lets volatility react faster than correlation, which matches empirical behavior: vol spikes on news, correlation shifts regimes.
+
+Defaults: `vol_lookback_days=60`, `corr_lookback_days=252`.
+
+### 3. Module organization
+
+New module `src/midas/risk.py` with five pure functions. No class state. All functions operate on already-computed frames rather than raw history (where applicable), keeping the hot path cheap:
+
+```python
+def realized_vol(
+    history: PriceHistory,
+    window: int,
+    annualize: bool = True,
+) -> float | None
+
+def covariance_matrix(
+    histories: Mapping[str, PriceHistory],
+    vol_window: int,
+    corr_window: int,
+    vol_floor: float,
+) -> pd.DataFrame
+
+def apply_instrument_diversification_multiplier(
+    weights: dict[str, float],
+    corr: pd.DataFrame,
+    cap: float,
+) -> dict[str, float]
+
+def apply_vol_targeting(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+    target_annualized_vol: float,
+) -> dict[str, float]
+
+def predict_portfolio_vol(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+) -> float
+```
+
+All functions return new dicts/frames (no mutation), and short-circuit on degenerate inputs.
+
+### 4. Config shape
+
+New `RiskConfig` dataclass colocated with `AllocationConstraints` in `src/midas/models.py`:
+
+```python
+@dataclass(frozen=True)
+class RiskConfig:
+    weighting: Literal["inverse_vol", "equal"] = "inverse_vol"
+    vol_target_annualized: float = 0.20
+    idm_cap: float = 2.5
+    vol_lookback_days: int = 60
+    corr_lookback_days: int = 252
+    vol_floor: float = 0.02
+```
+
+`StrategyConfig` gains `risk: RiskConfig = field(default_factory=RiskConfig)`. Missing `risk:` block in YAML → all defaults (risk-on baseline).
+
+YAML surface:
+
+```yaml
+risk:
+  weighting: inverse_vol          # or "equal"
+  vol_target_annualized: 0.20
+  idm_cap: 2.5
+  vol_lookback_days: 60
+  corr_lookback_days: 252
+  vol_floor: 0.02
+```
+
+No on/off flags. To disable a stage, set its knob to the neutral value (`weighting: equal`, `idm_cap: 1.0`, `vol_target_annualized: 999.0`). Keeps the pipeline uniform.
+
+Note: `weighting: equal` disables the phase-2 per-ticker offset only. The correlation and covariance matrices are still computed each bar and remain available for IDM (phase 3.5) and vol targeting (phase 3.7).
+
+### 5. Data flow and caching
+
+Risk precompute piggybacks on the existing `Allocator.precompute_signals` method. Per bar:
+
+1. Build per-ticker realized vol map.
+2. Build correlation matrix (LedoitWolf-shrunk).
+3. Compose covariance matrix.
+4. Stash on `self._risk_cache` as `{"cov": DataFrame | None, "corr": DataFrame | None, "per_ticker_vol": dict[str, float]}`.
+
+Cache is read-only inside allocation phases. Rebuilt every bar — LedoitWolf on 252×N (N ≤ ~50) is sub-millisecond, so staleness is not worth optimizing around.
+
+### 6. Error handling
+
+**Config-time (raises):**
+- `vol_target_annualized <= 0` → `ValueError`
+- `idm_cap < 1.0` → `ValueError` (IDM is always ≥ 1; cap < 1 is incoherent)
+- `vol_lookback_days < 2` or `corr_lookback_days < 2` → `ValueError`
+- `vol_floor < 0` → `ValueError`
+- Unknown `weighting` value → caught by `Literal` + config parser
+
+**Runtime (degrades silently, logs reason):**
+
+| Condition | Behavior |
+|---|---|
+| `sum(weights) == 0` (nothing selected) | All phases no-op |
+| Single ticker in weights | IDM trivially 1.0, vol targeting still applies |
+| Ticker has NaN in window | Treated as insufficient history for that ticker |
+| Ticker's realized vol < `vol_floor` | Clamped to `vol_floor` |
+| `w·cov·w <= 0` (numerical zero) | Skip vol targeting |
+| `w·corr·w <= 0` (near-singular) | Skip IDM (treat as 1.0) |
+| LedoitWolf fails to converge | Catch, set `corr`/`cov` to `None`, skip stages |
+
+**Logging:**
+- Warmup → active transition: one-time info via `print_status`.
+- Runtime degradation (LW failure): `print_status` with reason.
+- Routine scaling events (cap hit, targeting fired): DEBUG only.
+
+**Warmup:**
+- `bars_available < vol_lookback_days` for a ticker → per-ticker vol is `None`; per-ticker offset is 0 for that ticker.
+- `bars_available < corr_lookback_days` portfolio-wide → `corr`/`cov` both `None`; phases 3.5 and 3.7 no-op for that bar.
+
+### 7. Testing strategy
+
+Bottom-up, TDD-driven.
+
+**Unit (`tests/test_risk.py`, new):**
+- `realized_vol`: constant series → 0, known series → hand-computed value, short history → None, NaN → insufficient.
+- `covariance_matrix`: uncorrelated synthetic → diagonal cov; perfectly correlated → corr all 1; vol floor clamps low-vol ticker; short history → None; output PSD.
+- `apply_instrument_diversification_multiplier`: uncorrelated + equal weights → IDM ≈ √N; perfect correlation → IDM = 1; cap binding → scale exactly `cap / raw_idm`; empty weights → empty; single ticker → unchanged; degenerate `w·corr·w` → unchanged.
+- `apply_vol_targeting`: below target → unchanged; 2× target → halved; at target → unchanged; zero weights → zero; degenerate `w·cov·w` → unchanged.
+- `predict_portfolio_vol`: hand-computed 2-asset case; zero weights → 0.
+
+**Integration (`tests/test_allocator.py`, extend):**
+- **Risk-off regression:** `weighting="equal"`, `idm_cap=1.0`, `vol_target=999.0` → bit-identical to current allocator output. Safety net for the refactor.
+- Per-ticker vol scaling active: high-vol ticker gets less weight than equal-signal low-vol ticker.
+- IDM active: three uncorrelated tickers, weights scale up; sum matches `original * min(√N, cap)`.
+- Vol targeting active: synthetic high-vol portfolio scaled down to hit target.
+- Phase ordering: IDM pushes position past cap → phase 3.6 pulls it back.
+- Warmup: `<60` bars → equal weighting; `60–252` → per-ticker active, IDM/targeting off; `≥253` → all active.
+
+**End-to-end (`tests/test_backtest.py`, extend):**
+- Canned-fixture run with default risk config → asserts stable `summary.json` (change-detector).
+
+**Out of scope:**
+- Ledoit-Wolf internals (sklearn's responsibility).
+- Performance microbenchmarks.
+- Cross-platform numerical parity beyond `abs_tol=1e-9`.
+
+## Dependencies
+
+New runtime dependency: `scikit-learn` (for `sklearn.covariance.LedoitWolf`). Added to `pyproject.toml` under the main dep group.
+
+## Implementation order
+
+The writing-plans skill will produce a task-level plan. Suggested ordering:
+
+1. Add `scikit-learn` dependency.
+2. `RiskConfig` dataclass + YAML parsing + validation (config-time errors).
+3. `src/midas/risk.py` pure functions (TDD, one function at a time).
+4. Risk cache build in `Allocator.precompute_signals`.
+5. Phase 2 modification: per-ticker offset in softmax.
+6. Phase 3.5 and 3.7 integration.
+7. Phase 3.6 reuse of existing cap helper.
+8. Risk-off regression test (must pass before any default change).
+9. Flip defaults to risk-on.
+10. End-to-end backtest smoke test.

--- a/example-strategies/balanced-growth.yaml
+++ b/example-strategies/balanced-growth.yaml
@@ -2,6 +2,17 @@ softmax_temperature: 0.5
 min_buy_delta: 0.02
 min_cash_pct: 0.05
 
+# Optional risk-discipline block. Omit it to accept the defaults shown below.
+# See docs/architecture.md#risk-discipline-configuration for the semantics of
+# each field. These values are fixed policy — the optimizer does not search them.
+# risk:
+#   weighting: inverse_vol       # "equal" disables the inverse-vol tilt
+#   vol_target_annualized: 0.20  # 20% annualized portfolio vol cap
+#   idm_cap: 2.5                 # ceiling on diversification multiplier (1.0 disables IDM)
+#   vol_lookback_days: 60
+#   corr_lookback_days: 252
+#   vol_floor: 0.02
+
 strategies:
   # -- Entry signals --
   - name: Momentum

--- a/example-strategies/balanced-growth.yaml
+++ b/example-strategies/balanced-growth.yaml
@@ -3,8 +3,8 @@ min_buy_delta: 0.02
 min_cash_pct: 0.05
 
 # Optional risk-discipline block. Omit it to accept the defaults shown below.
-# See docs/architecture.md#risk-discipline-configuration for the semantics of
-# each field. These values are fixed policy — the optimizer does not search them.
+# See docs/strategies.md#risk-discipline for the semantics of each field.
+# These values are fixed policy — the optimizer does not search them.
 # risk:
 #   weighting: inverse_vol       # "equal" disables the inverse-vol tilt
 #   vol_target_annualized: 0.20  # 20% annualized portfolio vol cap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "rich>=13.0",
     "yfinance>=0.2",
     "optuna>=4.0",
+    "scikit-learn>=1.5",
 ]
 
 [project.scripts]

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -25,6 +25,7 @@ from midas.data.price_history import PriceHistory
 from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints, RiskConfig
 from midas.risk import (
     apply_instrument_diversification_multiplier,
+    apply_vol_targeting,
     covariance_matrix,
     realized_vol,
 )
@@ -303,6 +304,18 @@ class Allocator:
             targets,
             score_offsets=score_offsets,
         )
+
+        # Phase 3.7: Portfolio vol targeting. Only scales down.
+        cov = self._risk_cache.get("cov")
+        if cov is not None and active:
+            active_weights = {ticker: targets[ticker] for ticker in active}
+            scaled = apply_vol_targeting(
+                active_weights,
+                cov,
+                target_annualized_vol=self._risk_config.vol_target_annualized,
+            )
+            for ticker, weight in scaled.items():
+                targets[ticker] = weight
 
         return AllocationResult(targets, contributions, blended_scores)
 

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -23,7 +23,11 @@ import pandas as pd
 
 from midas.data.price_history import PriceHistory
 from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints, RiskConfig
-from midas.risk import covariance_matrix, realized_vol
+from midas.risk import (
+    apply_instrument_diversification_multiplier,
+    covariance_matrix,
+    realized_vol,
+)
 from midas.strategies.base import EntrySignal
 
 log = logging.getLogger(__name__)
@@ -267,6 +271,30 @@ class Allocator:
         # max_position_pct and re-softmax the survivors over the reduced
         # remaining budget. Cap *never* forces a sell — it just refuses to
         # allocate more budget. Sells are exclusively ExitRule territory.
+        self._apply_cap_with_redistribution(
+            active,
+            blended_scores,
+            budget_for_active,
+            temperature,
+            targets,
+            score_offsets=score_offsets,
+        )
+
+        # Phase 3.5: Instrument Diversification Multiplier. Scale up per-ticker
+        # weights by 1/sqrt(w'·corr·w), capped at risk_config.idm_cap. Skip
+        # entirely during warmup (no correlation matrix yet).
+        corr = self._risk_cache.get("corr")
+        if corr is not None and active:
+            active_weights = {ticker: targets[ticker] for ticker in active}
+            scaled = apply_instrument_diversification_multiplier(
+                active_weights,
+                corr,
+                cap=self._risk_config.idm_cap,
+            )
+            for ticker, weight in scaled.items():
+                targets[ticker] = weight
+
+        # Phase 3.6: Re-cap after IDM (IDM can push a single position past the cap).
         self._apply_cap_with_redistribution(
             active,
             blended_scores,

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -19,9 +19,11 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+import pandas as pd
 
 from midas.data.price_history import PriceHistory
 from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints, RiskConfig
+from midas.risk import covariance_matrix, realized_vol
 from midas.strategies.base import EntrySignal
 
 log = logging.getLogger(__name__)
@@ -99,7 +101,7 @@ class Allocator:
         return [entry.strategy for entry in self._entries]
 
     def precompute_signals(self, price_data: dict[str, PriceHistory]) -> None:
-        """Precompute entry-signal scores for all tickers over the full price arrays."""
+        """Precompute entry-signal scores and risk cache over the full price arrays."""
         self._signal_cache = {}
         for entry in self._entries:
             cache: dict[str, np.ndarray] = {}
@@ -109,6 +111,46 @@ class Allocator:
                     cache[ticker] = result
             if cache:
                 self._signal_cache[id(entry.strategy)] = cache
+
+        self._risk_cache = self._build_risk_cache(price_data)
+
+    def _build_risk_cache(
+        self,
+        price_data: dict[str, PriceHistory],
+    ) -> dict[str, Any]:
+        """Build the risk cache from price histories.
+
+        Args:
+            price_data: Ticker -> PriceHistory mapping.
+
+        Returns:
+            Dict with keys ``cov``, ``corr``, and ``per_ticker_vol``.
+            ``cov`` and ``corr`` are DataFrames or None when there is
+            insufficient history. ``per_ticker_vol`` maps each ticker to its
+            annualized realized vol (or None when the window is not met).
+        """
+        rc = self._risk_config
+        per_ticker_vol: dict[str, float | None] = {
+            ticker: realized_vol(history, window=rc.vol_lookback_days, annualize=True)
+            for ticker, history in price_data.items()
+        }
+        cov = covariance_matrix(
+            price_data,
+            vol_window=rc.vol_lookback_days,
+            corr_window=rc.corr_lookback_days,
+            vol_floor=rc.vol_floor,
+        )
+        if cov is None:
+            corr = None
+        else:
+            diag = np.sqrt(np.diag(cov.values))
+            if np.all(diag > 0):
+                corr_vals = cov.values / np.outer(diag, diag)
+                corr = pd.DataFrame(corr_vals, index=cov.index, columns=cov.columns)
+            else:
+                corr = None
+                cov = None
+        return {"cov": cov, "corr": corr, "per_ticker_vol": per_ticker_vol}
 
     def _lookup_score(self, strategy: EntrySignal, ticker: str, history_len: int) -> tuple[bool, float | None]:
         """Look up a precomputed score.  Returns (hit, score)."""

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -250,14 +250,31 @@ class Allocator:
 
         budget_for_active = max(investable - held_total, 0.0)
 
+        # Phase 1.5a: Compute per-ticker vol offsets for softmax (inverse-vol weighting).
+        score_offsets = self._vol_score_offsets(active)
+
         # Phase 2: Softmax construct-to-budget over active tickers.
-        self._softmax_allocate(active, blended_scores, budget_for_active, temperature, targets)
+        self._softmax_allocate(
+            active,
+            blended_scores,
+            budget_for_active,
+            temperature,
+            targets,
+            score_offsets=score_offsets,
+        )
 
         # Phase 3: Soft position cap. Iteratively clamp any ticker that exceeds
         # max_position_pct and re-softmax the survivors over the reduced
         # remaining budget. Cap *never* forces a sell — it just refuses to
         # allocate more budget. Sells are exclusively ExitRule territory.
-        self._apply_cap_with_redistribution(active, blended_scores, budget_for_active, temperature, targets)
+        self._apply_cap_with_redistribution(
+            active,
+            blended_scores,
+            budget_for_active,
+            temperature,
+            targets,
+            score_offsets=score_offsets,
+        )
 
         return AllocationResult(targets, contributions, blended_scores)
 
@@ -268,8 +285,9 @@ class Allocator:
         budget: float,
         temperature: float,
         targets: dict[str, float],
+        score_offsets: dict[str, float] | None = None,
     ) -> None:
-        """Distribute `budget` across `tickers` via softmax(blended_scores / T).
+        """Distribute `budget` across `tickers` via softmax((blended_scores + offsets) / T).
 
         Temperature semantics:
             T → 0   winner-take-all (budget to the argmax ticker)
@@ -281,9 +299,10 @@ class Allocator:
                 targets[ticker] = 0.0
             return
         temp_safe = max(temperature, MIN_TEMPERATURE)
-        # Subtract max for numerical stability — softmax is translation-invariant.
-        max_score = max(blended_scores[ticker] for ticker in tickers)
-        exps = {ticker: math.exp((blended_scores[ticker] - max_score) / temp_safe) for ticker in tickers}
+        offsets = score_offsets or {}
+        adjusted = {ticker: blended_scores[ticker] + offsets.get(ticker, 0.0) for ticker in tickers}
+        max_score = max(adjusted.values())
+        exps = {ticker: math.exp((adjusted[ticker] - max_score) / temp_safe) for ticker in tickers}
         total_exp = sum(exps.values())
         for ticker in tickers:
             targets[ticker] = budget * exps[ticker] / total_exp
@@ -295,6 +314,7 @@ class Allocator:
         initial_budget: float,
         temperature: float,
         targets: dict[str, float],
+        score_offsets: dict[str, float] | None = None,
     ) -> None:
         """Clamp targets exceeding max_position_pct; re-softmax the survivors.
 
@@ -321,4 +341,30 @@ class Allocator:
                 for ticker in survivors:
                     targets[ticker] = 0.0
                 return
-            self._softmax_allocate(survivors, blended_scores, budget, temperature, targets)
+            self._softmax_allocate(
+                survivors,
+                blended_scores,
+                budget,
+                temperature,
+                targets,
+                score_offsets=score_offsets,
+            )
+
+    def _vol_score_offsets(self, active: list[str]) -> dict[str, float]:
+        """Per-ticker score offsets for inverse-vol weighting.
+
+        Returns an empty dict when the weighting is ``"equal"`` or when a
+        ticker has no known vol (warmup). Missing entries default to 0 in
+        ``_softmax_allocate``.
+        """
+        if self._risk_config.weighting != "inverse_vol":
+            return {}
+        offsets: dict[str, float] = {}
+        vol_floor = self._risk_config.vol_floor
+        per_ticker_vol = self._risk_cache.get("per_ticker_vol") or {}
+        for ticker in active:
+            vol = per_ticker_vol.get(ticker)
+            if vol is None:
+                continue  # warmup — no offset
+            offsets[ticker] = -math.log(max(vol, vol_floor))
+        return offsets

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -21,7 +21,7 @@ from typing import Any
 import numpy as np
 
 from midas.data.price_history import PriceHistory
-from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints
+from midas.models import DEFAULT_MAX_POSITION_PCT, AllocationConstraints, RiskConfig
 from midas.strategies.base import EntrySignal
 
 log = logging.getLogger(__name__)
@@ -61,11 +61,15 @@ class Allocator:
         entries: list[tuple[EntrySignal, float]],
         constraints: AllocationConstraints,
         n_tickers: int,
+        *,
+        risk_config: RiskConfig | None = None,
     ) -> None:
         self._entries: list[_ScoredEntry] = [_ScoredEntry(strat, wt) for strat, wt in entries]
         self._constraints = constraints
+        self._risk_config = risk_config if risk_config is not None else RiskConfig()
         self._n_tickers = n_tickers
         self._signal_cache: dict[int, dict[str, np.ndarray]] = {}
+        self._risk_cache: dict[str, Any] = {}
 
         # Auto-compute max_position_pct if not set.
         equal_weight = (1.0 - constraints.min_cash_pct) / max(n_tickers, 1)

--- a/src/midas/allocator.py
+++ b/src/midas/allocator.py
@@ -275,7 +275,6 @@ class Allocator:
         self._apply_cap_with_redistribution(
             active,
             blended_scores,
-            budget_for_active,
             temperature,
             targets,
             score_offsets=score_offsets,
@@ -299,7 +298,6 @@ class Allocator:
         self._apply_cap_with_redistribution(
             active,
             blended_scores,
-            budget_for_active,
             temperature,
             targets,
             score_offsets=score_offsets,
@@ -352,7 +350,6 @@ class Allocator:
         self,
         active: list[str],
         blended_scores: dict[str, float],
-        initial_budget: float,
         temperature: float,
         targets: dict[str, float],
         score_offsets: dict[str, float] | None = None,
@@ -362,10 +359,14 @@ class Allocator:
         Soft cap: when a ticker hits the cap, the freed budget is redistributed
         to uncapped tickers in proportion to their softmax weight. The cap
         never forces a sell — it can only refuse to allocate more buy budget.
+
+        Budget is derived from the current sum of active targets at entry. That
+        keeps phase 3 (post-softmax sum == ``budget_for_active``) identical and
+        lets phase 3.6 preserve IDM's scaled-up gross exposure when caps bind.
         """
         cap = self._max_position_pct
         survivors = list(active)
-        budget = initial_budget
+        budget = sum(targets[ticker] for ticker in survivors)
         # At most one iteration per ticker (each pass pins at least one).
         for _ in range(len(active) + 1):
             over = [ticker for ticker in survivors if targets[ticker] > cap + 1e-12]

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -37,6 +37,7 @@ def _build_components(
     strategy_configs: list[StrategyConfig] | None,
     constraints: AllocationConstraints,
     n_tickers: int,
+    risk_config: RiskConfig | None = None,
 ) -> tuple[Allocator, OrderSizer, list[ExitRule]]:
     """Build allocator, order sizer, and exit rules from config."""
     configs = strategy_configs or [StrategyConfig(name=name) for name in STRATEGY_REGISTRY]
@@ -55,7 +56,7 @@ def _build_components(
             msg = f"Strategy {cfg.name!r} is neither EntrySignal nor ExitRule"
             raise click.ClickException(msg)
 
-    allocator = Allocator(entries, constraints, n_tickers)
+    allocator = Allocator(entries, constraints, n_tickers, risk_config=risk_config)
     order_sizer = OrderSizer()
 
     return allocator, order_sizer, exits
@@ -151,7 +152,7 @@ def backtest(
 ) -> None:
     """Run a backtest over historical data."""
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints, _risk_config = (
+    strat_configs, constraints, risk_config = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
     )
 
@@ -162,6 +163,7 @@ def backtest(
         strat_configs,
         constraints,
         n_tickers,
+        risk_config=risk_config,
     )
 
     warmup_bars = max_warmup([*allocator.strategies, *exit_rules])
@@ -214,7 +216,7 @@ def live(
     from midas.live import LiveEngine
 
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints, _risk_config = (
+    strat_configs, constraints, risk_config = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
     )
     provider = CachedYFinanceProvider()
@@ -224,6 +226,7 @@ def live(
         strat_configs,
         constraints,
         n_tickers,
+        risk_config=risk_config,
     )
 
     engine = LiveEngine(

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -15,6 +15,7 @@ from midas.data import CachedYFinanceProvider
 from midas.models import (
     AllocationConstraints,
     PortfolioConfig,
+    RiskConfig,
     StrategyConfig,
 )
 from midas.order_sizer import OrderSizer
@@ -150,7 +151,9 @@ def backtest(
 ) -> None:
     """Run a backtest over historical data."""
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints = load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints())
+    strat_configs, constraints, _risk_config = (
+        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
+    )
 
     start_d, end_d = _to_date(start), _to_date(end)
 
@@ -211,7 +214,9 @@ def live(
     from midas.live import LiveEngine
 
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints = load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints())
+    strat_configs, constraints, _risk_config = (
+        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
+    )
     provider = CachedYFinanceProvider()
 
     n_tickers = sum(1 for holding in port.holdings if holding.shares > 0)
@@ -330,7 +335,7 @@ def optimize(
     strategy_names: list[str] | None = None
     min_cash_pct = AllocationConstraints().min_cash_pct
     if strategies:
-        strat_configs, strat_constraints = load_strategies(Path(strategies))
+        strat_configs, strat_constraints, _ = load_strategies(Path(strategies))
         strategy_names = [cfg.name for cfg in strat_configs]
         min_cash_pct = strat_constraints.min_cash_pct
 

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -16,6 +16,7 @@ from midas.models import (
     CashInfusion,
     Holding,
     PortfolioConfig,
+    RiskConfig,
     StrategyConfig,
     TradingRestrictions,
 )
@@ -76,12 +77,14 @@ def load_portfolio(path: Path) -> PortfolioConfig:
 
 def load_strategies(
     path: Path,
-) -> tuple[list[StrategyConfig], AllocationConstraints]:
-    """Load strategy configs and allocation-level knobs from YAML.
+) -> tuple[list[StrategyConfig], AllocationConstraints, RiskConfig]:
+    """Load strategy configs, allocation-level knobs, and risk policy from YAML.
 
-    Returns (strategies, constraints) tuple. ``softmax_temperature`` and
-    ``min_buy_delta`` live at the top level of the strategies file because
-    they are meta-strategy knobs (how scores are blended/acted on).
+    Returns (strategies, constraints, risk) tuple. Top-level keys:
+      * ``softmax_temperature``, ``min_buy_delta``, ``min_cash_pct``,
+        ``max_position_pct`` — meta-strategy knobs.
+      * ``risk:`` — nested mapping forwarded to :class:`RiskConfig`. Missing
+        block defaults to risk-on.
     """
     raw = _load_yaml(path)
 
@@ -107,4 +110,14 @@ def load_strategies(
             raw.get("min_buy_delta", DEFAULT_MIN_BUY_DELTA),
         ),
     )
-    return configs, constraints
+
+    risk_raw = raw.get("risk", {}) or {}
+    risk = RiskConfig(
+        weighting=risk_raw.get("weighting", "inverse_vol"),
+        vol_target_annualized=float(risk_raw.get("vol_target_annualized", 0.20)),
+        idm_cap=float(risk_raw.get("idm_cap", 2.5)),
+        vol_lookback_days=int(risk_raw.get("vol_lookback_days", 60)),
+        corr_lookback_days=int(risk_raw.get("corr_lookback_days", 252)),
+        vol_floor=float(risk_raw.get("vol_floor", 0.02)),
+    )
+    return configs, constraints, risk

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -9,9 +9,14 @@ from typing import Any
 import yaml
 
 from midas.models import (
+    DEFAULT_CORR_LOOKBACK_DAYS,
+    DEFAULT_IDM_CAP,
     DEFAULT_MIN_BUY_DELTA,
     DEFAULT_MIN_CASH_PCT,
     DEFAULT_SOFTMAX_TEMPERATURE,
+    DEFAULT_VOL_FLOOR,
+    DEFAULT_VOL_LOOKBACK_DAYS,
+    DEFAULT_VOL_TARGET_ANNUALIZED,
     AllocationConstraints,
     CashInfusion,
     Holding,
@@ -114,10 +119,16 @@ def load_strategies(
     risk_raw = raw.get("risk", {}) or {}
     risk = RiskConfig(
         weighting=risk_raw.get("weighting", "inverse_vol"),
-        vol_target_annualized=float(risk_raw.get("vol_target_annualized", 0.20)),
-        idm_cap=float(risk_raw.get("idm_cap", 2.5)),
-        vol_lookback_days=int(risk_raw.get("vol_lookback_days", 60)),
-        corr_lookback_days=int(risk_raw.get("corr_lookback_days", 252)),
-        vol_floor=float(risk_raw.get("vol_floor", 0.02)),
+        vol_target_annualized=float(
+            risk_raw.get("vol_target_annualized", DEFAULT_VOL_TARGET_ANNUALIZED),
+        ),
+        idm_cap=float(risk_raw.get("idm_cap", DEFAULT_IDM_CAP)),
+        vol_lookback_days=int(
+            risk_raw.get("vol_lookback_days", DEFAULT_VOL_LOOKBACK_DAYS),
+        ),
+        corr_lookback_days=int(
+            risk_raw.get("corr_lookback_days", DEFAULT_CORR_LOOKBACK_DAYS),
+        ),
+        vol_floor=float(risk_raw.get("vol_floor", DEFAULT_VOL_FLOOR)),
     )
     return configs, constraints, risk

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from enum import Enum
+from typing import Literal
 
 DEFAULT_MIN_CASH_PCT = 0.05
 DEFAULT_MIN_BUY_DELTA = 0.02
 DEFAULT_SOFTMAX_TEMPERATURE = 0.5
 DEFAULT_MAX_POSITION_PCT = 0.25
 DEFAULT_ENTRY_WEIGHT = 1
+DEFAULT_VOL_TARGET_ANNUALIZED = 0.20
+DEFAULT_IDM_CAP = 2.5
+DEFAULT_VOL_LOOKBACK_DAYS = 60
+DEFAULT_CORR_LOOKBACK_DAYS = 252
+DEFAULT_VOL_FLOOR = 0.02
 
 FREQUENCY_DAYS: dict[str, int] = {
     "weekly": 7,
@@ -139,3 +145,35 @@ class StrategyConfig:
     params: dict[str, float | int | str] = field(default_factory=dict)
     tickers: list[str] | None = None
     weight: float = DEFAULT_ENTRY_WEIGHT
+
+
+@dataclass(frozen=True)
+class RiskConfig:
+    """Portfolio-level risk-discipline parameters.
+
+    See docs/superpowers/specs/2026-04-20-risk-discipline-design.md.
+    """
+
+    weighting: Literal["inverse_vol", "equal"] = "inverse_vol"
+    vol_target_annualized: float = DEFAULT_VOL_TARGET_ANNUALIZED
+    idm_cap: float = DEFAULT_IDM_CAP
+    vol_lookback_days: int = DEFAULT_VOL_LOOKBACK_DAYS
+    corr_lookback_days: int = DEFAULT_CORR_LOOKBACK_DAYS
+    vol_floor: float = DEFAULT_VOL_FLOOR
+
+    def __post_init__(self) -> None:
+        if self.vol_target_annualized <= 0:
+            msg = f"vol_target_annualized must be > 0, got {self.vol_target_annualized}"
+            raise ValueError(msg)
+        if self.idm_cap < 1.0:
+            msg = f"idm_cap must be >= 1.0 (IDM is always >= 1), got {self.idm_cap}"
+            raise ValueError(msg)
+        if self.vol_lookback_days < 2:
+            msg = f"vol_lookback_days must be >= 2, got {self.vol_lookback_days}"
+            raise ValueError(msg)
+        if self.corr_lookback_days < 2:
+            msg = f"corr_lookback_days must be >= 2, got {self.corr_lookback_days}"
+            raise ValueError(msg)
+        if self.vol_floor < 0:
+            msg = f"vol_floor must be >= 0, got {self.vol_floor}"
+            raise ValueError(msg)

--- a/src/midas/risk.py
+++ b/src/midas/risk.py
@@ -127,3 +127,52 @@ def covariance_matrix(
     # Numerical safety: symmetrize.
     cov_composed = 0.5 * (cov_composed + cov_composed.T)
     return pd.DataFrame(cov_composed, index=tickers, columns=tickers)
+
+
+def apply_instrument_diversification_multiplier(
+    weights: dict[str, float],
+    corr: pd.DataFrame,
+    cap: float,
+) -> dict[str, float]:
+    """Scale all weights by ``min(1/sqrt(w·corr·w), cap)``.
+
+    Args:
+        weights: Ticker -> weight before IDM.
+        corr: Symmetric correlation matrix. Tickers in ``weights`` but not
+            in ``corr`` are left unscaled (treated as uncorrelated singletons).
+        cap: Upper bound on the multiplier. Must be >= 1.0 (checked by
+            :class:`RiskConfig`).
+
+    Returns:
+        New dict with scaled weights. Returns inputs unchanged on degenerate
+        inputs (empty weights, single ticker, zero weights, or numerical
+        w·corr·w <= 0).
+    """
+    if not weights:
+        return {}
+    if sum(weights.values()) == 0:
+        return dict(weights)
+
+    # Intersect weights with corr index — only covered tickers participate.
+    covered = [t for t in weights if t in corr.index]
+    if len(covered) <= 1:
+        return dict(weights)
+
+    w_raw = np.asarray([weights[t] for t in covered])
+    w_sum = float(w_raw.sum())
+    if w_sum <= 0:
+        return dict(weights)
+    w = w_raw / w_sum
+    sub_corr = corr.loc[covered, covered].values
+    quad = float(w @ sub_corr @ w)
+    if quad <= 0:
+        return dict(weights)
+
+    raw_idm = 1.0 / math.sqrt(quad)
+    multiplier = min(raw_idm, cap)
+    if multiplier <= 1.0:
+        # min(idm, cap) == 1.0 exactly happens only when idm<=1 (perfect
+        # correlation) or cap==1.0 (IDM stage disabled). Return unchanged.
+        return dict(weights)
+
+    return {t: weight * multiplier if t in set(covered) else weight for t, weight in weights.items()}

--- a/src/midas/risk.py
+++ b/src/midas/risk.py
@@ -176,3 +176,67 @@ def apply_instrument_diversification_multiplier(
         return dict(weights)
 
     return {t: weight * multiplier if t in set(covered) else weight for t, weight in weights.items()}
+
+
+def predict_portfolio_vol(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+) -> float:
+    """Ex-ante portfolio vol: ``sqrt(w · cov · w) * sqrt(252)``.
+
+    Tickers in ``weights`` but not in ``cov`` are ignored. Returns 0.0 on
+    empty weights, all-zero weights, or when the quadratic form is
+    non-positive (degenerate covariance).
+
+    Args:
+        weights: Ticker -> weight mapping.
+        cov: Annualized covariance matrix indexed by ticker symbol.
+
+    Returns:
+        Annualized portfolio volatility as a fraction (0.20 == 20%),
+        or 0.0 on degenerate inputs.
+    """
+    covered = [t for t in weights if t in cov.index]
+    if not covered:
+        return 0.0
+    w = np.asarray([weights[t] for t in covered])
+    sub_cov = cov.loc[covered, covered].values
+    quad = float(w @ sub_cov @ w)
+    if quad <= 0:
+        return 0.0
+    return math.sqrt(quad)
+
+
+def apply_vol_targeting(
+    weights: dict[str, float],
+    cov: pd.DataFrame,
+    target_annualized_vol: float,
+) -> dict[str, float]:
+    """Scale weights down so predicted vol does not exceed the target.
+
+    Never scales up — if predicted vol is below target, weights are
+    returned unchanged. Degenerate cov matrices (w·cov·w <= 0) also
+    pass through unchanged.
+
+    Args:
+        weights: Ticker -> weight mapping before vol targeting.
+        cov: Annualized covariance matrix indexed by ticker symbol.
+        target_annualized_vol: Maximum allowable annualized portfolio vol
+            as a fraction (e.g. 0.20 for 20%).
+
+    Returns:
+        New dict with weights scaled by ``target / predicted`` when
+        predicted vol exceeds the target; otherwise the original weights
+        (as a new dict).
+    """
+    if not weights:
+        return {}
+    if sum(weights.values()) == 0:
+        return dict(weights)
+
+    predicted = predict_portfolio_vol(weights, cov)
+    if predicted <= 0 or predicted <= target_annualized_vol:
+        return dict(weights)
+
+    scale = target_annualized_vol / predicted
+    return {t: weight * scale for t, weight in weights.items()}

--- a/src/midas/risk.py
+++ b/src/midas/risk.py
@@ -1,0 +1,52 @@
+"""Risk-discipline primitives: realized vol, covariance, IDM, vol targeting.
+
+Pure functions only — no class state. All functions return new objects
+(dicts, DataFrames) and never mutate their inputs. Degenerate inputs are
+handled by returning a sentinel (``None`` or an unchanged result) rather
+than raising, so the allocator can degrade gracefully at runtime.
+
+See docs/superpowers/specs/2026-04-20-risk-discipline-design.md.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from midas.data.price_history import PriceHistory
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+def realized_vol(
+    history: PriceHistory,
+    window: int,
+    annualize: bool = True,
+) -> float | None:
+    """Realized volatility over the last ``window`` closes.
+
+    Args:
+        history: OHLCV bars for a single ticker.
+        window: Number of most-recent bars to consider. The vol is computed
+            over ``window - 1`` daily simple returns.
+        annualize: Multiply by sqrt(252) when True.
+
+    Returns:
+        Volatility as a fraction (0.20 == 20% annualized), or None when
+        there is insufficient clean history (fewer than ``window`` bars or
+        any NaN inside the window).
+    """
+    if window < 2:
+        msg = f"window must be >= 2, got {window}"
+        raise ValueError(msg)
+    if len(history) < window:
+        return None
+    closes = history.close[-window:]
+    if not np.all(np.isfinite(closes)):
+        return None
+    returns = closes[1:] / closes[:-1] - 1.0
+    if returns.size < 2:
+        return None
+    daily = float(np.std(returns, ddof=1))
+    return daily * math.sqrt(TRADING_DAYS_PER_YEAR) if annualize else daily

--- a/src/midas/risk.py
+++ b/src/midas/risk.py
@@ -11,8 +11,11 @@ See docs/superpowers/specs/2026-04-20-risk-discipline-design.md.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 
 import numpy as np
+import pandas as pd
+from sklearn.covariance import LedoitWolf  # type: ignore[import-untyped]
 
 from midas.data.price_history import PriceHistory
 
@@ -50,3 +53,77 @@ def realized_vol(
         return None
     daily = float(np.std(returns, ddof=1))
     return daily * math.sqrt(TRADING_DAYS_PER_YEAR) if annualize else daily
+
+
+def covariance_matrix(
+    histories: Mapping[str, PriceHistory],
+    vol_window: int,
+    corr_window: int,
+    vol_floor: float,
+) -> pd.DataFrame | None:
+    """Composed covariance: vols (short window) x corr (long window, shrunk).
+
+    Correlation is fit with :class:`sklearn.covariance.LedoitWolf` on the
+    last ``corr_window`` returns across the universe. Per-ticker vols are
+    realized over ``vol_window`` and floored at ``vol_floor`` before the
+    outer-product composition.
+
+    Args:
+        histories: Mapping of ticker symbol to PriceHistory.
+        vol_window: Number of bars for realized vol calculation.
+        corr_window: Number of returns for LedoitWolf correlation fit.
+        vol_floor: Minimum annualized vol applied after realized vol computation.
+
+    Returns:
+        NxN covariance DataFrame indexed by ticker (sorted), or None when
+        any ticker has fewer than ``corr_window + 1`` clean bars or the
+        LedoitWolf fit fails.
+
+    Raises:
+        ValueError: If vol_window or corr_window is less than 2.
+    """
+    if corr_window < 2 or vol_window < 2:
+        msg = f"vol_window and corr_window must be >= 2, got {vol_window}, {corr_window}"
+        raise ValueError(msg)
+
+    tickers = sorted(histories.keys())
+    if len(tickers) < 1:
+        return None
+
+    returns_cols: list[np.ndarray] = []
+    for ticker in tickers:
+        history = histories[ticker]
+        if len(history) < corr_window + 1:
+            return None
+        closes = history.close[-(corr_window + 1) :]
+        if not np.all(np.isfinite(closes)):
+            return None
+        returns_cols.append(closes[1:] / closes[:-1] - 1.0)
+
+    returns_matrix = np.column_stack(returns_cols)  # shape (corr_window, N)
+
+    try:
+        lw = LedoitWolf().fit(returns_matrix)
+    except Exception:
+        return None
+
+    daily_cov = lw.covariance_
+    # Derive correlation from LedoitWolf's daily covariance.
+    daily_std = np.sqrt(np.diag(daily_cov))
+    # Guard against zero diag from a degenerate constant series.
+    if not np.all(daily_std > 0):
+        return None
+    corr = daily_cov / np.outer(daily_std, daily_std)
+
+    # Per-ticker realized (annualized) vol over the short window. None-fallback
+    # = floor so the composition always has a defined scale.
+    vols: list[float] = []
+    for ticker in tickers:
+        v = realized_vol(histories[ticker], window=vol_window, annualize=True)
+        vols.append(max(v if v is not None else vol_floor, vol_floor))
+    vols_arr = np.asarray(vols)
+
+    cov_composed = corr * np.outer(vols_arr, vols_arr)
+    # Numerical safety: symmetrize.
+    cov_composed = 0.5 * (cov_composed + cov_composed.T)
+    return pd.DataFrame(cov_composed, index=tickers, columns=tickers)

--- a/src/midas/risk.py
+++ b/src/midas/risk.py
@@ -182,8 +182,10 @@ def predict_portfolio_vol(
     weights: dict[str, float],
     cov: pd.DataFrame,
 ) -> float:
-    """Ex-ante portfolio vol: ``sqrt(w · cov · w) * sqrt(252)``.
+    """Ex-ante annualized portfolio vol: ``sqrt(w · cov · w)``.
 
+    The cov matrix is assumed to already be annualized (as produced by
+    :func:`covariance_matrix`), so no additional sqrt(252) factor is applied.
     Tickers in ``weights`` but not in ``cov`` are ignored. Returns 0.0 on
     empty weights, all-zero weights, or when the quadratic form is
     non-positive (degenerate covariance).
@@ -216,7 +218,9 @@ def apply_vol_targeting(
 
     Never scales up — if predicted vol is below target, weights are
     returned unchanged. Degenerate cov matrices (w·cov·w <= 0) also
-    pass through unchanged.
+    pass through unchanged. The portfolio-wide multiplier is applied to
+    every weight in the input dict, including tickers that are absent from
+    ``cov``. This keeps the downscaling coherent across the full portfolio.
 
     Args:
         weights: Ticker -> weight mapping before vol targeting.

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -491,3 +491,42 @@ class TestVolTargetingStage:
         total = sum(result.targets.values())
         # Below target vol → no scaling down.
         assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)
+
+
+class TestRiskOffRegression:
+    def test_risk_off_matches_pre_risk_behavior(self):
+        """weighting=equal, idm_cap=1.0, vol_target=999 → no risk stage moves weights."""
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.50,
+        )
+        rng = np.random.default_rng(11)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260))) for name in ("A", "B", "C")}
+        # Only A gets a real buy signal; B and C are flat-ish.
+        histories["A"].close[-1] = histories["A"].close[-2] * 0.90
+
+        risk_off = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,
+                vol_target_annualized=999.0,
+            ),
+        )
+        risk_off.precompute_signals(histories)
+        result_off = risk_off.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result_off.targets.values())
+        # Investable budget preserved — no scale-up (IDM disabled), no scale-down
+        # (target vol 999% never binds).
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-9)
+        # A should still dominate the softmax with its buy signal.
+        assert result_off.targets["A"] > result_off.targets["B"]
+        assert result_off.targets["A"] > result_off.targets["C"]

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -423,6 +423,9 @@ class TestIDMStage:
         # Re-cap (phase 3.6) must pull everything back to max_position_pct.
         for ticker, weight in result.targets.items():
             assert weight <= 0.40 + 1e-9, f"{ticker} exceeded cap after re-cap"
+        # Gross exposure must not exceed N * max_position_pct (no phantom lift
+        # from a stale budget in the re-cap loop).
+        assert sum(result.targets.values()) <= 3 * 0.40 + 1e-9
 
 
 class TestVolTargetingStage:

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -530,3 +530,66 @@ class TestRiskOffRegression:
         # A should still dominate the softmax with its buy signal.
         assert result_off.targets["A"] > result_off.targets["B"]
         assert result_off.targets["A"] > result_off.targets["C"]
+
+
+class TestWarmupProgression:
+    def test_short_history_disables_all_risk_stages(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # Only 30 bars — below any default lookback window.
+        histories = {name: ph(np.full(30, 100.0)) for name in ("A", "B")}
+        # Last-bar drop to generate signals.
+        histories["A"].close[-1] = 90.0
+        histories["B"].close[-1] = 90.0
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),
+        )
+        allocator.precompute_signals(histories)
+        # Cache should be fully None.
+        assert allocator._risk_cache["cov"] is None
+        assert allocator._risk_cache["corr"] is None
+        assert allocator._risk_cache["per_ticker_vol"] == {"A": None, "B": None}
+
+        # Allocation still works — falls through all risk stages cleanly.
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-9)
+
+    def test_mid_window_enables_per_ticker_vol_only(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # 120 bars — enough for vol_lookback_days=60 but not corr_lookback_days=252.
+        rng = np.random.default_rng(22)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 120))) for name in ("A", "B")}
+        histories["A"].close[-1] = histories["A"].close[-2] * 0.90
+        histories["B"].close[-1] = histories["B"].close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),
+        )
+        allocator.precompute_signals(histories)
+        # Per-ticker vol defined; cov/corr still None.
+        assert allocator._risk_cache["per_ticker_vol"]["A"] is not None
+        assert allocator._risk_cache["per_ticker_vol"]["B"] is not None
+        assert allocator._risk_cache["cov"] is None
+        assert allocator._risk_cache["corr"] is None
+
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        # IDM and vol targeting skipped → total ≈ investable.
+        total = sum(result.targets.values())
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -332,3 +332,94 @@ class TestPerTickerVolScaling:
             current_weights={"LOW": 0.0, "HIGH": 0.0},
         )
         assert math.isclose(result.targets["LOW"], result.targets["HIGH"], rel_tol=1e-6)
+
+
+class TestIDMStage:
+    def test_three_uncorrelated_tickers_scale_up_by_sqrt3(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,  # loose cap — won't bind after IDM
+        )
+        rng = np.random.default_rng(42)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260))) for name in ("A", "B", "C")}
+        # Final bar identical-size drop on all three → equal signals.
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=5.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        pre_idm_sum = 1 - 0.05
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Roughly sqrt(3) x pre_idm_sum, with some slack from LW shrinkage
+        # pulling correlations slightly off-zero.
+        assert total > 1.3 * pre_idm_sum
+        assert total < 1.8 * pre_idm_sum
+
+    def test_idm_cap_binds_at_1_0_disables_stage(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(42)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260))) for name in ("A", "B", "C")}
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=1.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        total = sum(result.targets.values())
+        # idm_cap=1.0 → multiplier capped at 1.0 → no scale-up.
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)
+
+    def test_idm_then_recap_clips_overshoots(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        # Tight cap: IDM will push at least one ticker past it.
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.40,
+        )
+        rng = np.random.default_rng(42)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.5, 260))) for name in ("A", "B", "C")}
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(weighting="equal", idm_cap=3.0, vol_target_annualized=99.0),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B", "C"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0, "C": 0.0},
+        )
+        # Re-cap (phase 3.6) must pull everything back to max_position_pct.
+        for ticker, weight in result.targets.items():
+            assert weight <= 0.40 + 1e-9, f"{ticker} exceeded cap after re-cap"

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 from conftest import ph
 
 from midas.allocator import Allocator
@@ -224,3 +225,43 @@ class TestAllocatorRiskConfig:
         allocator = Allocator([(mr, 1.0)], constraints, n_tickers=2)
         # Default matches RiskConfig() exactly.
         assert allocator._risk_config == RiskConfig()
+
+
+class TestAllocatorRiskCache:
+    def test_cache_populated_with_sufficient_history(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        rng = np.random.default_rng(0)
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 1, 260))) for name in ("A", "B", "C")}
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=3,
+            risk_config=RiskConfig(vol_lookback_days=60, corr_lookback_days=252),
+        )
+        allocator.precompute_signals(histories)
+
+        cache = allocator._risk_cache
+        assert cache["cov"] is not None
+        assert isinstance(cache["cov"], pd.DataFrame)
+        assert cache["corr"] is not None
+        assert set(cache["per_ticker_vol"].keys()) == {"A", "B", "C"}
+
+    def test_cache_none_when_insufficient_history(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05, max_position_pct=0.90)
+        # Only 30 bars — less than default corr_lookback_days=252.
+        histories = {name: ph(np.full(30, 100.0)) for name in ("A", "B")}
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),
+        )
+        allocator.precompute_signals(histories)
+
+        cache = allocator._risk_cache
+        assert cache["cov"] is None
+        assert cache["corr"] is None
+        # Per-ticker vols also None when window not met.
+        assert cache["per_ticker_vol"] == {"A": None, "B": None}

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -303,15 +303,15 @@ class TestPerTickerVolScaling:
         assert result.targets["LOW"] > result.targets["HIGH"]
 
     def test_equal_weighting_disables_offset(self):
+        """Equal weighting must ignore per-ticker vol even when vols differ sharply."""
         mr = MeanReversion(window=5, threshold=0.20)
         constraints = AllocationConstraints(
             min_cash_pct=0.05,
             softmax_temperature=0.5,
             max_position_pct=0.90,
         )
+        # Same underlying prices -> identical blended scores.
         rng = np.random.default_rng(1)
-        # Use the same underlying prices for both tickers so blended scores are
-        # identical, isolating the vol-offset effect.
         shared = 100.0 + np.cumsum(rng.normal(0, 0.5, 260))
         shared[-1] = shared[-2] * 0.90
 
@@ -323,10 +323,12 @@ class TestPerTickerVolScaling:
         )
         histories = {"LOW": ph(shared.copy()), "HIGH": ph(shared.copy())}
         allocator.precompute_signals(histories)
+        # Inject wildly different per-ticker vols: under inverse_vol this would
+        # skew weights by a factor of log(100) ≈ 4.6; under equal it must not.
+        allocator._risk_cache["per_ticker_vol"] = {"LOW": 0.01, "HIGH": 1.0}
         result = allocator.allocate(
             ["LOW", "HIGH"],
             histories,
             current_weights={"LOW": 0.0, "HIGH": 0.0},
         )
-        # Without vol offset, equal signals → equal softmax weights (within 1e-9).
         assert math.isclose(result.targets["LOW"], result.targets["HIGH"], rel_tol=1e-6)

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -423,3 +423,71 @@ class TestIDMStage:
         # Re-cap (phase 3.6) must pull everything back to max_position_pct.
         for ticker, weight in result.targets.items():
             assert weight <= 0.40 + 1e-9, f"{ticker} exceeded cap after re-cap"
+
+
+class TestVolTargetingStage:
+    def test_high_vol_portfolio_scaled_down_to_target(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(3)
+        # Very volatile: daily sigma 5% each → annualized vol ≈ 80%.
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 5.0, 260))) for name in ("A", "B")}
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90  # buy signal
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,  # disable IDM
+                vol_target_annualized=0.20,
+            ),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Vol targeting clamps down — total should be well below 0.95.
+        assert total < 0.60
+
+    def test_low_vol_portfolio_not_scaled_up(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(5)
+        # Tame daily noise — well below 20% annualized.
+        histories = {name: ph(100.0 + np.cumsum(rng.normal(0, 0.1, 260))) for name in ("A", "B")}
+        for h in histories.values():
+            h.close[-1] = h.close[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(
+                weighting="equal",
+                idm_cap=1.0,
+                vol_target_annualized=0.20,
+            ),
+        )
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["A", "B"],
+            histories,
+            current_weights={"A": 0.0, "B": 0.0},
+        )
+        total = sum(result.targets.values())
+        # Below target vol → no scaling down.
+        assert math.isclose(total, 1 - 0.05, rel_tol=1e-6)

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pandas as pd
 from conftest import ph
@@ -265,3 +267,66 @@ class TestAllocatorRiskCache:
         assert cache["corr"] is None
         # Per-ticker vols also None when window not met.
         assert cache["per_ticker_vol"] == {"A": None, "B": None}
+
+
+class TestPerTickerVolScaling:
+    def test_low_vol_ticker_gets_more_weight_than_high_vol(self):
+        """With equal signals, inverse-vol scaling should overweight low-vol ticker."""
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(0)
+        # LOW vol — tiny daily noise.
+        low = 100.0 + np.cumsum(rng.normal(0, 0.05, 260))
+        # HIGH vol — large daily noise.
+        high = 100.0 + np.cumsum(rng.normal(0, 2.0, 260))
+        # Both end with an identical "buy" signal: 10% drop on last bar.
+        low[-1] = low[-2] * 0.90
+        high[-1] = high[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(weighting="inverse_vol"),
+        )
+        histories = {"LOW": ph(low), "HIGH": ph(high)}
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["LOW", "HIGH"],
+            histories,
+            current_weights={"LOW": 0.0, "HIGH": 0.0},
+        )
+        assert result.targets["LOW"] > result.targets["HIGH"]
+
+    def test_equal_weighting_disables_offset(self):
+        mr = MeanReversion(window=5, threshold=0.20)
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.90,
+        )
+        rng = np.random.default_rng(1)
+        # Use the same underlying prices for both tickers so blended scores are
+        # identical, isolating the vol-offset effect.
+        shared = 100.0 + np.cumsum(rng.normal(0, 0.5, 260))
+        shared[-1] = shared[-2] * 0.90
+
+        allocator = Allocator(
+            [(mr, 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(weighting="equal"),
+        )
+        histories = {"LOW": ph(shared.copy()), "HIGH": ph(shared.copy())}
+        allocator.precompute_signals(histories)
+        result = allocator.allocate(
+            ["LOW", "HIGH"],
+            histories,
+            current_weights={"LOW": 0.0, "HIGH": 0.0},
+        )
+        # Without vol offset, equal signals → equal softmax weights (within 1e-9).
+        assert math.isclose(result.targets["LOW"], result.targets["HIGH"], rel_tol=1e-6)

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -7,7 +7,7 @@ from conftest import ph
 
 from midas.allocator import Allocator
 from midas.data.price_history import PriceHistory
-from midas.models import AllocationConstraints
+from midas.models import AllocationConstraints, RiskConfig
 from midas.strategies.mean_reversion import MeanReversion
 from midas.strategies.momentum import Momentum
 
@@ -207,3 +207,20 @@ class TestAllocator:
         # redistribution loop runs twice.
         assert abs(result.targets["A"] - 0.35) < 1e-9
         assert abs(result.targets["B"] - 0.35) < 1e-9
+
+
+class TestAllocatorRiskConfig:
+    def test_accepts_risk_config_kwarg(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05)
+        risk = RiskConfig()
+        allocator = Allocator([(mr, 1.0)], constraints, n_tickers=2, risk_config=risk)
+        # Verify it's stored on the instance for later phases to read.
+        assert allocator._risk_config is risk
+
+    def test_defaults_to_risk_config_when_omitted(self):
+        mr = MeanReversion(window=5, threshold=0.01)
+        constraints = AllocationConstraints(min_cash_pct=0.05)
+        allocator = Allocator([(mr, 1.0)], constraints, n_tickers=2)
+        # Default matches RiskConfig() exactly.
+        assert allocator._risk_config == RiskConfig()

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -3,7 +3,7 @@
 import csv as csv_mod
 import json
 import math
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import numpy as np
@@ -1551,3 +1551,72 @@ def test_sell_mixed_basis_within_single_period() -> None:
     assert trade.holding_period == HoldingPeriod.SHORT_TERM
     assert trade.shares == 10.0
     assert basis == 92.0
+
+
+class TestRiskDisciplineEndToEnd:
+    def test_default_risk_config_produces_stable_summary(self, tmp_path):
+        """End-to-end smoke test: default RiskConfig + canned fixture -> stable summary.
+
+        Change-detector, not a correctness test. If this breaks, confirm the
+        drift is intentional before updating the golden numbers.
+        """
+        from datetime import date as dt_date
+
+        from midas.allocator import Allocator
+        from midas.backtest import BacktestEngine
+        from midas.models import (
+            AllocationConstraints,
+            Holding,
+            PortfolioConfig,
+            RiskConfig,
+        )
+        from midas.order_sizer import OrderSizer
+        from midas.strategies.mean_reversion import MeanReversion
+
+        # Deterministic synthetic: 2 tickers, 400 bars, mild drift + noise.
+        rng = np.random.default_rng(2026)
+        days = 400
+        start = dt_date(2023, 1, 2)
+        frames: dict[str, pd.DataFrame] = {}
+        for name, sigma in [("AAA", 0.01), ("BBB", 0.02)]:
+            returns = rng.normal(0.0003, sigma, days).tolist()
+            frames[name] = make_price_series(start, days, 100.0, returns, name=name)
+
+        # Seed 1 share per ticker so the backtest admits them into
+        # ``state.positions``; zero-share holdings are dropped at init and
+        # would leave ``_decide`` with no active tickers on every bar.
+        portfolio = PortfolioConfig(
+            holdings=[
+                Holding(ticker="AAA", shares=1),
+                Holding(ticker="BBB", shares=1),
+            ],
+            available_cash=10_000.0,
+        )
+        constraints = AllocationConstraints(
+            min_cash_pct=0.05,
+            softmax_temperature=0.5,
+            max_position_pct=0.60,
+        )
+        allocator = Allocator(
+            [(MeanReversion(window=20, threshold=0.03), 1.0)],
+            constraints,
+            n_tickers=2,
+            risk_config=RiskConfig(),
+        )
+        engine = BacktestEngine(
+            allocator=allocator,
+            order_sizer=OrderSizer(),
+            exit_rules=[],
+            constraints=constraints,
+            train_pct=1.0,
+            enable_split=False,
+        )
+        result = engine.run(portfolio, frames, start, start + timedelta(days=days))
+
+        # Change-detector: lock in a few stable numbers. Update deliberately.
+        assert result.total_days > 0
+        assert math.isfinite(result.final_value)
+        assert result.final_value > 0
+        # Default risk-on pipeline should produce at least one trade on this
+        # 400-day synthetic — guards against the pipeline no-op'ing silently.
+        assert len(result.trades) >= 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_load_portfolio_minimal(tmp_path: Path) -> None:
 
 
 def test_load_strategies(strategy_yaml: Path) -> None:
-    configs, constraints = load_strategies(strategy_yaml)
+    configs, constraints, risk = load_strategies(strategy_yaml)
     assert len(configs) == 3
 
     assert configs[0].name == "MeanReversion"
@@ -95,4 +95,43 @@ def test_load_strategies(strategy_yaml: Path) -> None:
     assert constraints.softmax_temperature == 0.25
     assert constraints.min_buy_delta == 0.03
     assert constraints.min_cash_pct == 0.10
-    assert constraints.max_position_pct is None  # not specified -> None
+    assert constraints.max_position_pct is None
+
+    # Risk config defaults (no risk: block in fixture)
+    assert risk.weighting == "inverse_vol"
+    assert risk.vol_target_annualized == 0.20
+    assert risk.idm_cap == 2.5
+
+
+def test_load_strategies_parses_risk_block(tmp_path: Path) -> None:
+    data = {
+        "strategies": [{"name": "Momentum"}],
+        "risk": {
+            "weighting": "equal",
+            "vol_target_annualized": 0.15,
+            "idm_cap": 2.0,
+            "vol_lookback_days": 30,
+            "corr_lookback_days": 120,
+            "vol_floor": 0.05,
+        },
+    }
+    p = tmp_path / "strategies.yaml"
+    p.write_text(yaml.dump(data))
+    _, _, risk = load_strategies(p)
+    assert risk.weighting == "equal"
+    assert risk.vol_target_annualized == 0.15
+    assert risk.idm_cap == 2.0
+    assert risk.vol_lookback_days == 30
+    assert risk.corr_lookback_days == 120
+    assert risk.vol_floor == 0.05
+
+
+def test_load_strategies_risk_validation_surfaces(tmp_path: Path) -> None:
+    data = {
+        "strategies": [{"name": "Momentum"}],
+        "risk": {"idm_cap": 0.5},
+    }
+    p = tmp_path / "strategies.yaml"
+    p.write_text(yaml.dump(data))
+    with pytest.raises(ValueError, match="idm_cap"):
+        load_strategies(p)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,7 +54,7 @@ def test_full_pipeline(tmp_path: Path) -> None:
     assert len(portfolio.holdings) == 2
     assert portfolio.available_cash == 3000.0
 
-    strat_configs, constraints = load_strategies(strategy_path)
+    strat_configs, constraints, _ = load_strategies(strategy_path)
     assert len(strat_configs) == 3
 
     # 4. Build allocator + order_sizer + exit rules

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,3 +116,65 @@ class TestCashInfusion:
         infusion = CashInfusion(amount=1500.0, next_date=date(2025, 1, 3), frequency="quarterly")
         with pytest.raises(ValueError, match="Unknown cash_infusion frequency"):
             infusion.advance()
+
+
+class TestRiskConfig:
+    def test_defaults_are_risk_on(self) -> None:
+        from midas.models import RiskConfig
+
+        cfg = RiskConfig()
+        assert cfg.weighting == "inverse_vol"
+        assert cfg.vol_target_annualized == 0.20
+        assert cfg.idm_cap == 2.5
+        assert cfg.vol_lookback_days == 60
+        assert cfg.corr_lookback_days == 252
+        assert cfg.vol_floor == 0.02
+
+    def test_is_frozen(self) -> None:
+        from midas.models import RiskConfig
+
+        cfg = RiskConfig()
+        with pytest.raises((AttributeError, Exception)):
+            cfg.idm_cap = 1.0  # type: ignore[misc]
+
+    def test_rejects_non_positive_vol_target(self) -> None:
+        from midas.models import RiskConfig
+
+        with pytest.raises(ValueError, match="vol_target_annualized"):
+            RiskConfig(vol_target_annualized=0.0)
+        with pytest.raises(ValueError, match="vol_target_annualized"):
+            RiskConfig(vol_target_annualized=-0.10)
+
+    def test_rejects_idm_cap_below_one(self) -> None:
+        from midas.models import RiskConfig
+
+        with pytest.raises(ValueError, match="idm_cap"):
+            RiskConfig(idm_cap=0.99)
+
+    def test_accepts_idm_cap_exactly_one(self) -> None:
+        from midas.models import RiskConfig
+
+        RiskConfig(idm_cap=1.0)
+
+    def test_rejects_small_vol_lookback(self) -> None:
+        from midas.models import RiskConfig
+
+        with pytest.raises(ValueError, match="vol_lookback_days"):
+            RiskConfig(vol_lookback_days=1)
+
+    def test_rejects_small_corr_lookback(self) -> None:
+        from midas.models import RiskConfig
+
+        with pytest.raises(ValueError, match="corr_lookback_days"):
+            RiskConfig(corr_lookback_days=1)
+
+    def test_rejects_negative_vol_floor(self) -> None:
+        from midas.models import RiskConfig
+
+        with pytest.raises(ValueError, match="vol_floor"):
+            RiskConfig(vol_floor=-0.01)
+
+    def test_accepts_zero_vol_floor(self) -> None:
+        from midas.models import RiskConfig
+
+        RiskConfig(vol_floor=0.0)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,56 @@
+"""Tests for the risk-discipline module."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
+
+from midas.risk import realized_vol
+
+
+class TestRealizedVol:
+    def test_constant_series_returns_zero(self):
+        history = ph(np.full(100, 100.0))
+        vol = realized_vol(history, window=30)
+        assert vol == 0.0
+
+    def test_known_series_matches_hand_computed(self):
+        # Daily returns: exactly +1% and -1% alternating over 30 bars (29 returns).
+        # Each daily return is ±0.01 (computed from ratio p_i / p_{i-1}).
+        prices = [100.0]
+        for i in range(1, 31):
+            prices.append(prices[-1] * (1.01 if i % 2 == 1 else 1 / 1.01))
+        history = ph(np.asarray(prices))
+
+        vol = realized_vol(history, window=30)
+        # daily std of ±0.01 (equal-sized up/down moves) ~= 0.01; annualized * sqrt(252)
+        assert vol is not None
+        assert math.isclose(vol, 0.01 * math.sqrt(252), rel_tol=2e-2)
+
+    def test_insufficient_history_returns_none(self):
+        history = ph(np.full(10, 100.0))
+        assert realized_vol(history, window=30) is None
+
+    def test_annualize_false_returns_daily_vol(self):
+        prices = [100.0]
+        for i in range(1, 31):
+            prices.append(prices[-1] * (1.01 if i % 2 == 1 else 1 / 1.01))
+        history = ph(np.asarray(prices))
+        daily = realized_vol(history, window=30, annualize=False)
+        annual = realized_vol(history, window=30, annualize=True)
+        assert daily is not None and annual is not None
+        assert math.isclose(annual / daily, math.sqrt(252), rel_tol=1e-6)
+
+    def test_nan_in_window_returns_none(self):
+        prices = np.full(60, 100.0)
+        prices[-5] = float("nan")
+        history = ph(prices)
+        # Window includes the NaN → insufficient clean history.
+        assert realized_vol(history, window=30) is None
+
+    def test_exact_window_size_is_sufficient(self):
+        # Window == len(history) should succeed (not fail with off-by-one).
+        history = ph(np.full(30, 100.0))
+        assert realized_vol(history, window=30) == 0.0

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -8,7 +8,13 @@ import numpy as np
 import pandas as pd
 from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
 
-from midas.risk import apply_instrument_diversification_multiplier, apply_vol_targeting, covariance_matrix, realized_vol
+from midas.risk import (
+    apply_instrument_diversification_multiplier,
+    apply_vol_targeting,
+    covariance_matrix,
+    predict_portfolio_vol,
+    realized_vol,
+)
 
 
 class TestRealizedVol:
@@ -268,3 +274,35 @@ class TestApplyVolTargeting:
         # portfolio-wide multiplier so the downscaling remains coherent.
         assert math.isclose(out["A"], 0.5, rel_tol=1e-9)
         assert math.isclose(out["B"], 0.15, rel_tol=1e-9)
+
+
+class TestPredictPortfolioVol:
+    def test_two_asset_uncorrelated_equal_weight(self):
+        # var_a = var_b = 0.04 (20% vol), w = (0.5, 0.5), uncorrelated.
+        # portfolio_var = 0.25 * 0.04 + 0.25 * 0.04 = 0.02 → vol ≈ sqrt(0.02) ≈ 0.1414
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.diag([0.04, 0.04]))
+        vol = predict_portfolio_vol({"A": 0.5, "B": 0.5}, cov)
+        assert math.isclose(vol, math.sqrt(0.02), rel_tol=1e-9)
+
+    def test_zero_weights_return_zero(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        assert predict_portfolio_vol({"A": 0.0}, cov) == 0.0
+
+    def test_empty_weights_return_zero(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        assert predict_portfolio_vol({}, cov) == 0.0
+
+    def test_weights_outside_cov_index_ignored(self):
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        # Only A contributes; B is ignored.
+        vol = predict_portfolio_vol({"A": 1.0, "B": 5.0}, cov)
+        assert math.isclose(vol, 0.20, rel_tol=1e-9)
+
+    def test_degenerate_cov_returns_zero(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, -np.eye(2))  # non-PSD, forces quad <= 0
+        assert predict_portfolio_vol({"A": 1.0, "B": 1.0}, cov) == 0.0

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -7,7 +7,7 @@ import math
 import numpy as np
 from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
 
-from midas.risk import realized_vol
+from midas.risk import covariance_matrix, realized_vol
 
 
 class TestRealizedVol:
@@ -54,3 +54,101 @@ class TestRealizedVol:
         # Window == len(history) should succeed (not fail with off-by-one).
         history = ph(np.full(30, 100.0))
         assert realized_vol(history, window=30) == 0.0
+
+
+def _prices_from_returns(daily_returns: np.ndarray, base: float = 100.0) -> np.ndarray:
+    """Build a close array from daily returns."""
+    out = np.empty(len(daily_returns) + 1)
+    out[0] = base
+    for i, ret in enumerate(daily_returns):
+        out[i + 1] = out[i] * (1.0 + ret)
+    return out
+
+
+class TestCovarianceMatrix:
+    def test_uncorrelated_series_give_diagonal_correlation(self):
+        rng = np.random.default_rng(42)
+        # 260 bars each — enough for 252-day corr window + slack.
+        rets_a = rng.normal(0.0, 0.01, 260)
+        rets_b = rng.normal(0.0, 0.02, 260)
+        hist_a = ph(_prices_from_returns(rets_a))
+        hist_b = ph(_prices_from_returns(rets_b))
+
+        cov = covariance_matrix(
+            {"A": hist_a, "B": hist_b},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+
+        assert cov is not None
+        # Diagonals should be ~ (realized vol ** 2)
+        # Off-diagonal correlation should be near zero.
+        corr_ab = cov.loc["A", "B"] / math.sqrt(cov.loc["A", "A"] * cov.loc["B", "B"])
+        assert abs(corr_ab) < 0.2  # shrinkage may pull slightly toward 0 or away
+
+    def test_perfectly_correlated_series_give_unit_correlation(self):
+        rng = np.random.default_rng(7)
+        base_rets = rng.normal(0.0, 0.01, 260)
+        # B is identical to A — scaled vol by 2x to make the math nontrivial.
+        hist_a = ph(_prices_from_returns(base_rets))
+        hist_b = ph(_prices_from_returns(base_rets * 2.0))
+
+        cov = covariance_matrix(
+            {"A": hist_a, "B": hist_b},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+
+        assert cov is not None
+        corr_ab = cov.loc["A", "B"] / math.sqrt(cov.loc["A", "A"] * cov.loc["B", "B"])
+        # LedoitWolf shrinks correlation toward the mean off-diagonal, which
+        # for a 2-asset system with one off-diagonal = 1.0 still stays near 1.
+        assert corr_ab > 0.9
+
+    def test_vol_floor_clamps_low_vol_ticker(self):
+        rng = np.random.default_rng(3)
+        rets_normal = rng.normal(0.0, 0.01, 260)
+        rets_tiny = rng.normal(0.0, 0.0001, 260)  # well below floor
+        hist_normal = ph(_prices_from_returns(rets_normal))
+        hist_tiny = ph(_prices_from_returns(rets_tiny))
+
+        cov = covariance_matrix(
+            {"N": hist_normal, "T": hist_tiny},
+            vol_window=60,
+            corr_window=252,
+            vol_floor=0.05,  # 5% annualized
+        )
+
+        assert cov is not None
+        vol_t = math.sqrt(cov.loc["T", "T"])
+        # Vol floor is annualized 5% → variance ≈ 0.0025 on the diagonal.
+        assert vol_t >= 0.05 - 1e-9
+
+    def test_insufficient_history_returns_none(self):
+        short = ph(np.full(50, 100.0))  # < corr_window of 252
+        cov = covariance_matrix(
+            {"A": short, "B": short},
+            vol_window=30,
+            corr_window=252,
+            vol_floor=0.001,
+        )
+        assert cov is None
+
+    def test_output_is_psd(self):
+        rng = np.random.default_rng(99)
+        hists = {name: ph(_prices_from_returns(rng.normal(0, 0.01, 260))) for name in ("A", "B", "C", "D")}
+        cov = covariance_matrix(hists, vol_window=60, corr_window=252, vol_floor=0.001)
+        assert cov is not None
+        eigenvalues = np.linalg.eigvalsh(cov.values)
+        assert (eigenvalues >= -1e-9).all()
+
+    def test_index_and_columns_match_ticker_order(self):
+        rng = np.random.default_rng(1)
+        hists = {name: ph(_prices_from_returns(rng.normal(0, 0.01, 260))) for name in ("Z", "A", "M")}
+        cov = covariance_matrix(hists, vol_window=60, corr_window=252, vol_floor=0.001)
+        assert cov is not None
+        # Deterministic order for downstream matmul correctness.
+        assert list(cov.index) == ["A", "M", "Z"]
+        assert list(cov.columns) == ["A", "M", "Z"]

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
 
-from midas.risk import apply_instrument_diversification_multiplier, covariance_matrix, realized_vol
+from midas.risk import apply_instrument_diversification_multiplier, apply_vol_targeting, covariance_matrix, realized_vol
 
 
 class TestRealizedVol:
@@ -213,3 +213,58 @@ class TestApplyInstrumentDiversificationMultiplier:
         # for a 1-asset "portfolio" is trivially 1.0.
         assert math.isclose(out["A"], 0.3, rel_tol=1e-9)
         assert math.isclose(out["B"], 0.3, rel_tol=1e-9)
+
+
+def _cov_frame(tickers: list[str], matrix: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame(matrix, index=tickers, columns=tickers)
+
+
+class TestApplyVolTargeting:
+    def test_below_target_returns_unchanged(self):
+        # diag(cov) = 0.01 (10% ann vol), w = 0.5,0.5 uncorrelated → portfolio vol ≈ 7.07%
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.diag([0.01, 0.01]))
+        weights = {"A": 0.5, "B": 0.5}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_exactly_at_target_returns_unchanged(self):
+        # Single asset, vol ≈ 20%; weight = 1 → portfolio vol = 20%.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.04]]))
+        weights = {"A": 1.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert math.isclose(out["A"], 1.0, rel_tol=1e-9)
+
+    def test_double_target_halves_weights(self):
+        # Single asset, vol = 40% (variance 0.16), target = 20% → scale by 0.5.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.16]]))
+        weights = {"A": 1.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert math.isclose(out["A"], 0.5, rel_tol=1e-9)
+
+    def test_zero_weights_returns_zero(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.eye(2))
+        weights = {"A": 0.0, "B": 0.0}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_degenerate_cov_returns_unchanged(self):
+        tickers = ["A", "B"]
+        cov = _cov_frame(tickers, np.zeros((2, 2)))
+        weights = {"A": 0.5, "B": 0.5}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        assert out == weights
+
+    def test_weights_missing_from_cov_pass_through_unscaled(self):
+        # "B" isn't in cov. "A" dominates the vol calculation.
+        tickers = ["A"]
+        cov = _cov_frame(tickers, np.array([[0.16]]))  # 40% vol
+        weights = {"A": 1.0, "B": 0.3}
+        out = apply_vol_targeting(weights, cov, target_annualized_vol=0.20)
+        # A scales by 0.5; B is uncovered → passes through scaled by the same
+        # portfolio-wide multiplier so the downscaling remains coherent.
+        assert math.isclose(out["A"], 0.5, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.15, rel_tol=1e-9)

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import pandas as pd
 from conftest import ph, ph_ohlc  # noqa: F401 — ph_ohlc reserved for future tests
 
-from midas.risk import covariance_matrix, realized_vol
+from midas.risk import apply_instrument_diversification_multiplier, covariance_matrix, realized_vol
 
 
 class TestRealizedVol:
@@ -152,3 +153,63 @@ class TestCovarianceMatrix:
         # Deterministic order for downstream matmul correctness.
         assert list(cov.index) == ["A", "M", "Z"]
         assert list(cov.columns) == ["A", "M", "Z"]
+
+
+def _corr_frame(tickers: list[str], matrix: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame(matrix, index=tickers, columns=tickers)
+
+
+class TestApplyInstrumentDiversificationMultiplier:
+    def test_uncorrelated_equal_weights_give_idm_approx_sqrt_n(self):
+        tickers = ["A", "B", "C", "D"]
+        weights = {t: 0.25 for t in tickers}
+        corr = _corr_frame(tickers, np.eye(4))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=5.0)
+        # IDM = 1/sqrt(0.25 * 4 * 0.25) = 1/sqrt(0.25) = 2.0 = sqrt(4).
+        total = sum(out.values())
+        assert math.isclose(total, sum(weights.values()) * 2.0, rel_tol=1e-9)
+
+    def test_perfect_correlation_gives_idm_one(self):
+        tickers = ["A", "B"]
+        weights = {"A": 0.4, "B": 0.4}
+        corr = _corr_frame(tickers, np.ones((2, 2)))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=5.0)
+        assert math.isclose(out["A"], 0.4, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.4, rel_tol=1e-9)
+
+    def test_cap_binds_when_raw_idm_exceeds(self):
+        tickers = ["A", "B", "C", "D", "E", "F", "G", "H", "I"]
+        weights = dict.fromkeys(tickers, 1.0 / 9.0)
+        corr = _corr_frame(tickers, np.eye(9))
+        # raw IDM = sqrt(9) = 3.0; cap at 2.0 → multiplier = 2.0 / 3.0 of raw, so scale = 2.0.
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.0)
+        total = sum(out.values())
+        assert math.isclose(total, sum(weights.values()) * 2.0, rel_tol=1e-9)
+
+    def test_empty_weights_returns_empty(self):
+        corr = _corr_frame(["A"], np.eye(1))
+        assert apply_instrument_diversification_multiplier({}, corr, cap=2.5) == {}
+
+    def test_single_ticker_weights_unchanged(self):
+        weights = {"A": 0.5}
+        corr = _corr_frame(["A"], np.eye(1))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        assert out == {"A": 0.5}
+
+    def test_zero_weights_returns_unchanged(self):
+        tickers = ["A", "B"]
+        weights = dict.fromkeys(tickers, 0.0)
+        corr = _corr_frame(tickers, np.eye(2))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        assert out == weights
+
+    def test_weights_referencing_missing_ticker_are_ignored(self):
+        # "A" is in weights but absent from the correlation matrix — treat as
+        # uncorrelated (contributes to sum but not to the diversification math).
+        weights = {"A": 0.3, "B": 0.3}
+        corr = _corr_frame(["B"], np.eye(1))
+        out = apply_instrument_diversification_multiplier(weights, corr, cap=2.5)
+        # A passes through with multiplier 1.0; B scales by its own IDM which
+        # for a 1-asset "portfolio" is trivially 1.0.
+        assert math.isclose(out["A"], 0.3, rel_tol=1e-9)
+        assert math.isclose(out["B"], 0.3, rel_tol=1e-9)

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -403,6 +412,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "scikit-learn" },
     { name = "yfinance" },
 ]
 
@@ -424,6 +434,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
+    { name = "scikit-learn", specifier = ">=1.5" },
     { name = "yfinance", specifier = ">=0.2" },
 ]
 
@@ -809,6 +820,63 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -850,6 +918,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/95/32107c4d13be077a9cae61e9ae49966a35dc4bf442a8852dd871db31f62e/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f", size = 2147209, upload-time = "2026-03-02T15:52:54.274Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d7/1e073da7a4bc645eb83c76067284a0374e643bc4be57f14cc6414656f92c/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933", size = 2182198, upload-time = "2026-03-02T15:52:55.606Z" },
     { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Implements Carver-style risk discipline as a policy layer on top of the existing allocator. Adds a new `risk:` YAML block, threads `RiskConfig` through the allocator, and introduces phases 1.5a / 3.5 / 3.6 / 3.7 to scale weights by realized vol, instrument diversification multiplier (IDM), and a portfolio vol target.

- **New `midas.risk` module** — pure functions: `realized_vol`, `covariance_matrix` (LedoitWolf-shrunk correlation composed with realized vols), `apply_instrument_diversification_multiplier`, `predict_portfolio_vol`, `apply_vol_targeting`.
- **Allocator phases** — 1 → 1.5a (per-ticker vol score offset, applied only when `weighting == "inverse_vol"`) → 2 (softmax) → 3 (cap + redistribute) → 3.5 (IDM) → 3.6 (re-cap) → 3.7 (portfolio vol target).
- **Config** — `RiskConfig` dataclass with frozen defaults and `__post_init__` validation; `load_strategies` parses a top-level `risk:` block.
- **scikit-learn** — new dep for `LedoitWolf` correlation shrinkage.
- **Tests** — 277 passing. New suites: direct risk-module unit tests, per-ticker vol scaling, IDM, vol targeting, risk-off regression, warmup progression, and an end-to-end backtest change-detector.

Phase 3.6 derives its budget from the current sum of active targets (not the pre-IDM `budget_for_active`) so IDM's scaled-up gross exposure is preserved when caps bind — without that, `sum(targets)` could exceed `N * max_position_pct` and silently violate `min_cash_pct`.

## Follow-ups (not in this PR)
- Strengthen the e2e change-detector with numeric lock-in (currently compares against a baseline config rather than pinning absolute target values).
- Add a full-pipeline `inverse_vol` backtest integration test — current coverage is allocator-unit only.
- Upper-bound `scikit-learn` in `pyproject.toml` — `LedoitWolf` is stable but the dep is currently unpinned.

## Test plan
- [x] `uv run pytest` — 277 passing
- [x] `uv run ruff check . && uv run ruff format .` — clean
- [x] `uv run mypy src` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)