### PR TITLE
Live per-lot tracking: persist positions, HWM, peak equity, cash across runs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,9 +200,17 @@ After optimizing and backtesting, live mode puts the strategy to work on real-ti
 
 The live engine polls real-time prices on a configurable interval (default 60 seconds) and emits order alerts for manual execution. On each tick, it fetches the last 120 days of price history, runs the full allocation and exit-rule pipeline, and compares the resulting order set to the previous tick. If nothing changed, it stays quiet. If new orders appear or existing ones change, it emits an alert with the ticker, price, reason, source strategy, and suggested share count.
 
-The live engine is fully stateless -- it reads current holdings from the portfolio config each tick and re-derives everything from scratch. Exit rules see the `cost_basis` from the portfolio YAML and a high-water mark derived as `max(cost_basis, current_price)`. This is a synthetic HWM, not a tracked peak: it equals `current_price` whenever the position is in profit and `cost_basis` otherwise. As a consequence, **`TrailingStop` is effectively inert in live mode** — its drawdown-from-HWM check collapses to 0 when in profit and fails the in-profit gate when underwater. `LiveEngine` logs a warning at startup if `TrailingStop` is configured; remove it from live configs, or rely on `StopLoss` / `ProfitTaking` until per-lot HWM persistence is implemented. The live engine does not execute trades; it's designed for operators who execute manually through their broker.
+The live engine carries persistent runtime state across ticks and runs via a YAML sidecar (see [Live State Persistence](#live-state-persistence) below). Exit rules see a share-weighted cost basis from the live lot list and a per-ticker high-water mark tracked as the running peak of price observed since seed. This matches backtest semantics: `TrailingStop` fires on real drawdown from a tracked peak, the CPPI overlay scales budget against tracked peak equity, and FIFO sell consumption preserves short-term/long-term holding-period classification. The live engine does not execute trades; it's designed for operators who execute manually through their broker, and it assumes every emitted alert is filled at the alert price when it updates state.
 
 See [CLI Reference](cli.md#live) for all live options.
+
+### Live State Persistence
+
+The live engine persists runtime state to a YAML sidecar (`<portfolio>.state.yaml` by default, alongside `portfolio.yaml`, or the path under the optional top-level `state_file:` field in `portfolio.yaml`). The schema is owned by `src/midas/live_state.py` and documented in [the design spec](specs/2026-05-07-live-per-lot-tracking-design.md).
+
+After first seed, `portfolio.yaml` is read-only seed config. The state file owns positions (per-lot), available cash, per-ticker high-water marks, peak equity, and the cash-infusion `next_date`. Edits to `portfolio.yaml`'s aggregate `shares`, `cost_basis`, or `available_cash` after seed have no effect; the engine warns on drift but trusts the state file.
+
+The engine writes the state file atomically (tempfile + `os.replace`) at the end of every tick, on the assumption that emitted alerts are filled at the alert price. Operators who need to reflect slippage or manual overrides can hand-edit the state file — it is plain YAML.
 
 ## Lot Tracking
 

--- a/docs/plans/2026-05-07-live-per-lot-tracking.md
+++ b/docs/plans/2026-05-07-live-per-lot-tracking.md
@@ -1,0 +1,1691 @@
+# Live Per-Lot Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist per-lot positions, per-ticker HWM, peak equity, and available cash across `midas live` runs so the live engine matches backtest behavior. Today live mode synthesizes one lot per ticker and re-derives HWM each tick, structurally disabling `TrailingStop`, weighted-avg cost basis after multiple buys, ST/LT classification, and CPPI overlay.
+
+**Architecture:** New `src/midas/live_state.py` module owns a `LiveState` dataclass and YAML serialization. `LiveEngine` loads or seeds at startup, mutates the in-memory `LiveState` as it generates orders (alerts == assumed fills) and updates HWM / peak / infusion, then atomic-writes back at the end of each tick. The FIFO sell-consumption logic that lives in `backtest.py` today is extracted into shared helpers in `live_state.py`; backtest imports from the new module with no behavior change.
+
+**Tech Stack:** Python 3.14, dataclasses, PyYAML, pytest. No new deps.
+
+**Spec:** `docs/specs/2026-05-07-live-per-lot-tracking-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+- `src/midas/live_state.py` — `LiveState` dataclass, `load_or_seed`, `save_atomic`, `apply_buy`, `apply_sell`, plus the extracted FIFO primitives (`aggregate_cost_basis`, `consume_lots_fifo`).
+- `tests/test_live_state.py` — unit tests for serialization, seeding, drift detection, FIFO helpers.
+- `tests/test_live_engine.py` — integration tests for `LiveEngine` driving a `LiveState` across multiple synthetic ticks.
+- `tests/test_live_backtest_parity.py` — bar-for-bar parity between backtest and live on a deterministic price series.
+
+**Modified:**
+- `src/midas/models.py` — add `state_file: Path | None = None` to `PortfolioConfig`.
+- `src/midas/config.py` — parse optional top-level `state_file:` key.
+- `src/midas/backtest.py` — replace `_aggregate_cost_basis` and the inline FIFO loop in `_execute` with imports from `live_state.py`. No behavior change.
+- `src/midas/live.py` — constructor takes `state_path`, loads/seeds; `_tick` reads HWM and weighted-avg basis from `self._state`; emits `apply_buy` / `apply_sell` per alert; `save_atomic` per tick. Drop `TrailingStop` and `drawdown_penalty` inert-warnings.
+- `src/midas/cli.py` — `live` command resolves `state_path` and passes to `LiveEngine`.
+
+---
+
+## Task 1: `LiveState` dataclass + YAML round-trip
+
+**Files:**
+- Create: `src/midas/live_state.py`
+- Test: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_live_state.py
+"""Unit tests for live state persistence."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from midas.live_state import LiveState, load_state, save_atomic
+from midas.models import PositionLot
+
+
+def test_save_load_round_trip(tmp_path: Path) -> None:
+    state = LiveState(
+        available_cash=4823.50,
+        cash_infusion_next_date=date(2026, 5, 15),
+        high_water_marks={"PLTR": 24.18, "NVDA": 142.5},
+        peak_equity=18420.0,
+        lots={
+            "PLTR": [
+                PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0),
+                PositionLot(shares=50.0, purchase_date=date(2026, 4, 12), cost_basis=22.5),
+            ],
+            "NVDA": [PositionLot(shares=100.0, purchase_date=None, cost_basis=49.76)],
+        },
+    )
+    path = tmp_path / "portfolio.state.yaml"
+    save_atomic(state, path)
+    loaded = load_state(path)
+    assert loaded == state
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_live_state.py::test_save_load_round_trip -v
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'midas.live_state'`.
+
+- [ ] **Step 3: Implement `LiveState`, `save_atomic`, `load_state`**
+
+```python
+# src/midas/live_state.py
+"""Persistent runtime state for the live engine.
+
+After first seed, this state file is the runtime source of truth for
+positions, available cash, per-ticker HWM, peak equity, and the cash-
+infusion ``next_date``. The portfolio YAML continues to own everything
+else (tickers, strategies, allocation constraints, infusion amount/
+frequency, restrictions); see docs/specs/2026-05-07-live-per-lot-
+tracking-design.md.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from midas.models import PositionLot
+
+SCHEMA_VERSION = 1
+
+
+class StateFileError(ValueError):
+    """Raised on schema version mismatch, parse failure, or invalid state."""
+
+
+@dataclass
+class LiveState:
+    """Mutable runtime state persisted between live ticks."""
+
+    available_cash: float
+    cash_infusion_next_date: date | None
+    high_water_marks: dict[str, float] = field(default_factory=dict)
+    peak_equity: float | None = None
+    lots: dict[str, list[PositionLot]] = field(default_factory=dict)
+
+
+def save_atomic(state: LiveState, path: Path) -> None:
+    """Serialize *state* to *path* atomically (tempfile + os.replace)."""
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "last_updated": datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat(),
+        "available_cash": state.available_cash,
+        "cash_infusion": (
+            {"next_date": state.cash_infusion_next_date}
+            if state.cash_infusion_next_date is not None
+            else None
+        ),
+        "high_water_marks": dict(state.high_water_marks),
+        "peak_equity": state.peak_equity,
+        "lots": {
+            ticker: [
+                {
+                    "shares": lot.shares,
+                    "purchase_date": lot.purchase_date,
+                    "cost_basis": lot.cost_basis,
+                }
+                for lot in lots
+            ]
+            for ticker, lots in state.lots.items()
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False)
+        os.replace(tmp_name, path)
+    except Exception:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
+
+
+def load_state(path: Path) -> LiveState:
+    """Load state from *path*. Raises ``StateFileError`` on invalid input."""
+    try:
+        with open(path) as handle:
+            raw = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        msg = f"failed to parse state file at {path}: {exc}"
+        raise StateFileError(msg) from exc
+    if not isinstance(raw, dict):
+        msg = f"state file at {path} is not a YAML mapping"
+        raise StateFileError(msg)
+    version = raw.get("schema_version")
+    if version != SCHEMA_VERSION:
+        msg = f"unsupported state version {version!r} in {path}; expected {SCHEMA_VERSION}"
+        raise StateFileError(msg)
+
+    infusion = raw.get("cash_infusion")
+    next_date: date | None = None
+    if infusion is not None:
+        next_date = infusion.get("next_date")
+        if isinstance(next_date, str):
+            next_date = date.fromisoformat(next_date)
+
+    lots: dict[str, list[PositionLot]] = {}
+    for ticker, entries in (raw.get("lots") or {}).items():
+        lots[ticker] = [
+            PositionLot(
+                shares=float(entry["shares"]),
+                purchase_date=entry.get("purchase_date"),
+                cost_basis=float(entry["cost_basis"]),
+            )
+            for entry in entries
+        ]
+
+    return LiveState(
+        available_cash=float(raw["available_cash"]),
+        cash_infusion_next_date=next_date,
+        high_water_marks={k: float(v) for k, v in (raw.get("high_water_marks") or {}).items()},
+        peak_equity=raw.get("peak_equity"),
+        lots=lots,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+uv run pytest tests/test_live_state.py::test_save_load_round_trip -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add tests for schema-version mismatch, parse failure, atomic-write safety**
+
+```python
+# tests/test_live_state.py — append
+import pytest
+
+from midas.live_state import StateFileError
+
+
+def test_load_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "state.yaml"
+    path.write_text("schema_version: 99\navailable_cash: 0\n")
+    with pytest.raises(StateFileError, match="unsupported state version"):
+        load_state(path)
+
+
+def test_load_rejects_unparseable_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "state.yaml"
+    path.write_text(":\n - this isn't\n  valid yaml: ::\n")
+    with pytest.raises(StateFileError):
+        load_state(path)
+
+
+def test_save_atomic_leaves_canonical_intact_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = LiveState(available_cash=100.0, cash_infusion_next_date=None)
+    path = tmp_path / "state.yaml"
+    save_atomic(state, path)
+    canonical_before = path.read_text()
+
+    def boom(*args: object, **kwargs: object) -> None:
+        msg = "simulated rename failure"
+        raise OSError(msg)
+
+    monkeypatch.setattr("os.replace", boom)
+    with pytest.raises(OSError, match="simulated rename failure"):
+        save_atomic(LiveState(available_cash=999.99, cash_infusion_next_date=None), path)
+    assert path.read_text() == canonical_before
+```
+
+- [ ] **Step 6: Run all live_state tests**
+
+```
+uv run pytest tests/test_live_state.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Lint/format/type check**
+
+```
+uv run ruff check src/midas/live_state.py tests/test_live_state.py
+uv run ruff format src/midas/live_state.py tests/test_live_state.py
+uv run mypy src/midas/live_state.py
+```
+
+Expected: all clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/midas/live_state.py tests/test_live_state.py
+git commit -m "Add LiveState dataclass with atomic YAML round-trip (#36)"
+```
+
+---
+
+## Task 2: Seed `LiveState` from `PortfolioConfig` on first run
+
+**Files:**
+- Modify: `src/midas/live_state.py`
+- Modify: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_live_state.py — append
+from midas.live_state import load_or_seed
+from midas.models import CashInfusion, Holding, PortfolioConfig
+
+
+def test_load_or_seed_creates_state_from_portfolio(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[
+            Holding(ticker="AAPL", shares=100.0, cost_basis=150.0),
+            Holding(ticker="NVDA", shares=50.0, cost_basis=49.76),
+        ],
+        available_cash=5000.0,
+        cash_infusion=CashInfusion(amount=1500.0, next_date=date(2026, 5, 15), frequency="biweekly"),
+    )
+    path = tmp_path / "portfolio.state.yaml"
+    assert not path.exists()
+
+    state = load_or_seed(portfolio, path)
+
+    assert path.exists()  # seed wrote the file
+    assert state.available_cash == 5000.0
+    assert state.cash_infusion_next_date == date(2026, 5, 15)
+    assert state.peak_equity is None
+    assert state.high_water_marks == {}
+    assert state.lots == {
+        "AAPL": [PositionLot(shares=100.0, purchase_date=None, cost_basis=150.0)],
+        "NVDA": [PositionLot(shares=50.0, purchase_date=None, cost_basis=49.76)],
+    }
+
+
+def test_load_or_seed_skips_holdings_with_zero_shares(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[
+            Holding(ticker="AAPL", shares=100.0, cost_basis=150.0),
+            Holding(ticker="MSFT", shares=0.0, cost_basis=None),
+        ],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    state = load_or_seed(portfolio, path)
+    assert "AAPL" in state.lots
+    assert "MSFT" not in state.lots
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_live_state.py::test_load_or_seed_creates_state_from_portfolio tests/test_live_state.py::test_load_or_seed_skips_holdings_with_zero_shares -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'load_or_seed'`.
+
+- [ ] **Step 3: Implement `load_or_seed`'s seed branch**
+
+```python
+# src/midas/live_state.py — append
+import logging
+
+from midas.models import PortfolioConfig
+
+logger = logging.getLogger(__name__)
+
+
+def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
+    """Load state from *state_path*, or seed it from *portfolio* if missing.
+
+    The seed branch creates one ``PositionLot`` per ticker with ``shares > 0``,
+    using the YAML's ``cost_basis`` and ``purchase_date=None`` (we don't know
+    when the operator originally bought; affects ST/LT classification — they
+    can hand-edit later if precision matters).
+    """
+    if state_path.exists():
+        return load_state(state_path)
+
+    lots: dict[str, list[PositionLot]] = {}
+    for holding in portfolio.holdings:
+        if holding.shares <= 0:
+            continue
+        lots[holding.ticker] = [
+            PositionLot(
+                shares=holding.shares,
+                purchase_date=None,
+                cost_basis=holding.cost_basis if holding.cost_basis is not None else 0.0,
+            )
+        ]
+
+    state = LiveState(
+        available_cash=portfolio.available_cash,
+        cash_infusion_next_date=portfolio.cash_infusion.next_date if portfolio.cash_infusion else None,
+        high_water_marks={},
+        peak_equity=None,
+        lots=lots,
+    )
+    save_atomic(state, state_path)
+    logger.info("Seeded state at %s from portfolio config", state_path)
+    return state
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_live_state.py::test_load_or_seed_creates_state_from_portfolio tests/test_live_state.py::test_load_or_seed_skips_holdings_with_zero_shares -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live_state.py tests/test_live_state.py
+git commit -m "Seed LiveState from PortfolioConfig on first run (#36)"
+```
+
+---
+
+## Task 3: Drift detection on subsequent loads
+
+**Files:**
+- Modify: `src/midas/live_state.py`
+- Modify: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_live_state.py — append
+def test_load_or_seed_warns_on_share_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)  # first call seeds
+
+    portfolio_drifted = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=200.0, cost_basis=150.0)],  # state still has 100
+        available_cash=1000.0,
+    )
+    with caplog.at_level("WARNING"):
+        state = load_or_seed(portfolio_drifted, path)
+    assert state.lots["AAPL"][0].shares == 100.0  # state file wins
+    assert any("AAPL" in record.message and "200" in record.message for record in caplog.records)
+
+
+def test_load_or_seed_warns_on_cash_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_drifted = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=9999.99,
+    )
+    with caplog.at_level("WARNING"):
+        state = load_or_seed(portfolio_drifted, path)
+    assert state.available_cash == 1000.0  # state file wins
+    assert any("available_cash" in record.message for record in caplog.records)
+
+
+def test_load_or_seed_raises_when_held_ticker_removed_from_portfolio(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_without = PortfolioConfig(
+        holdings=[],  # AAPL removed from portfolio while still held in state
+        available_cash=1000.0,
+    )
+    with pytest.raises(StateFileError, match="AAPL.*100"):
+        load_or_seed(portfolio_without, path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_live_state.py -k "drift or removed" -v
+```
+
+Expected: FAIL — drift detection not yet implemented.
+
+- [ ] **Step 3: Add drift detection to `load_or_seed`**
+
+```python
+# src/midas/live_state.py — modify load_or_seed to add the load branch
+def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
+    """Load state from *state_path*, or seed it from *portfolio* if missing.
+
+    On subsequent loads, warns if the YAML aggregates disagree with state
+    (the state file wins). Refuses to start if the portfolio no longer lists
+    a ticker for which lots are still held — that's almost certainly a config
+    mistake.
+    """
+    if not state_path.exists():
+        # ... existing seed code unchanged ...
+        return state
+
+    state = load_state(state_path)
+    _check_for_drift(state, portfolio)
+    return state
+
+
+def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
+    """Warn on aggregate drift; raise if a held ticker has no Holding."""
+    yaml_tickers = {holding.ticker for holding in portfolio.holdings}
+    for ticker, lots in state.lots.items():
+        held = sum(lot.shares for lot in lots)
+        if held <= 0:
+            continue
+        if ticker not in yaml_tickers:
+            msg = (
+                f"ticker {ticker} is held in state ({held} shares) but not "
+                f"listed in portfolio.yaml; refusing to start. Either restore "
+                f"the holding entry or close out the position in state."
+            )
+            raise StateFileError(msg)
+        holding = portfolio.get_holding(ticker)
+        assert holding is not None  # guarded by yaml_tickers membership
+        if holding.shares != held:
+            logger.warning(
+                "share drift: portfolio.yaml has %s=%s but state has %s; trusting state",
+                ticker,
+                holding.shares,
+                held,
+            )
+    if portfolio.available_cash != state.available_cash:
+        logger.warning(
+            "available_cash drift: portfolio.yaml has %s but state has %s; trusting state",
+            portfolio.available_cash,
+            state.available_cash,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_live_state.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live_state.py tests/test_live_state.py
+git commit -m "Detect aggregate drift between portfolio.yaml and state (#36)"
+```
+
+---
+
+## Task 4: Extract FIFO helpers from `backtest.py` into `live_state.py`
+
+**Files:**
+- Modify: `src/midas/backtest.py`
+- Modify: `src/midas/live_state.py`
+- Test: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing test for the extracted primitives**
+
+```python
+# tests/test_live_state.py — append
+from midas.live_state import aggregate_cost_basis, consume_lots_fifo
+
+
+def test_aggregate_cost_basis_share_weighted() -> None:
+    lots = [
+        PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0),
+        PositionLot(shares=50.0, purchase_date=date(2026, 4, 12), cost_basis=22.0),
+    ]
+    # (100 * 10 + 50 * 22) / 150 = 14.0
+    assert aggregate_cost_basis(lots) == pytest.approx(14.0)
+
+
+def test_aggregate_cost_basis_empty_returns_zero() -> None:
+    assert aggregate_cost_basis([]) == 0.0
+
+
+def test_consume_lots_fifo_st_only() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=100.0, purchase_date=date(2026, 4, 1), cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=40.0, day=today)
+    assert breakdown.st_shares == 40.0
+    assert breakdown.st_basis == pytest.approx(10.0)
+    assert breakdown.lt_shares == 0.0
+    assert lots[0].shares == 60.0  # mutated in place
+
+
+def test_consume_lots_fifo_straddles_st_lt_boundary() -> None:
+    today = date(2026, 5, 7)
+    # First lot is >365 days old (LT); second is recent (ST).
+    lots = [
+        PositionLot(shares=30.0, purchase_date=date(2025, 4, 1), cost_basis=10.0),
+        PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),
+    ]
+    breakdown = consume_lots_fifo(lots, shares=40.0, day=today)
+    assert breakdown.lt_shares == 30.0
+    assert breakdown.lt_basis == pytest.approx(10.0)
+    assert breakdown.st_shares == 10.0
+    assert breakdown.st_basis == pytest.approx(20.0)
+    assert lots == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+
+
+def test_consume_lots_fifo_unknown_purchase_date_is_short_term() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=50.0, day=today)
+    assert breakdown.st_shares == 50.0
+    assert breakdown.lt_shares == 0.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_live_state.py -k "aggregate_cost_basis or consume_lots_fifo" -v
+```
+
+Expected: FAIL — symbols not yet exported.
+
+- [ ] **Step 3: Add the primitives to `live_state.py`**
+
+```python
+# src/midas/live_state.py — append
+from collections.abc import Sequence
+
+
+@dataclass(frozen=True)
+class SellBreakdown:
+    """Result of consuming lots FIFO for a sell.
+
+    Each pair (shares, share-weighted basis) is reported separately for the
+    short-term (held <365 days, or unknown purchase date) and long-term
+    (held >=365 days) buckets. Either bucket can be zero.
+    """
+
+    st_shares: float
+    st_basis: float
+    lt_shares: float
+    lt_basis: float
+
+
+def aggregate_cost_basis(lots: Sequence[PositionLot]) -> float:
+    """Share-weighted average cost basis across all open lots, or 0.0 if empty."""
+    total_shares = sum(lot.shares for lot in lots)
+    if total_shares <= 0:
+        return 0.0
+    return sum(lot.shares * lot.cost_basis for lot in lots) / total_shares
+
+
+def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> SellBreakdown:
+    """Consume *shares* from *lots* in FIFO order, mutating in place.
+
+    Lots whose ``purchase_date`` is at least 365 days before *day* contribute
+    to the long-term bucket; everything else (including ``purchase_date=None``)
+    goes to the short-term bucket. Each bucket reports a share-weighted
+    cost basis over the consumed slices.
+    """
+    if shares <= 0 or not lots:
+        return SellBreakdown(0.0, 0.0, 0.0, 0.0)
+
+    st_shares = 0.0
+    st_weighted = 0.0
+    lt_shares = 0.0
+    lt_weighted = 0.0
+    remaining = shares
+    while remaining > 0 and lots:
+        lot = lots[0]
+        take = min(lot.shares, remaining)
+        is_long_term = lot.purchase_date is not None and (day - lot.purchase_date).days >= 365
+        if is_long_term:
+            lt_shares += take
+            lt_weighted += take * lot.cost_basis
+        else:
+            st_shares += take
+            st_weighted += take * lot.cost_basis
+
+        if lot.shares <= remaining:
+            remaining -= lot.shares
+            lots.pop(0)
+        else:
+            lots[0] = PositionLot(
+                shares=lot.shares - remaining,
+                purchase_date=lot.purchase_date,
+                cost_basis=lot.cost_basis,
+            )
+            remaining = 0
+
+    st_basis = st_weighted / st_shares if st_shares > 0 else 0.0
+    lt_basis = lt_weighted / lt_shares if lt_shares > 0 else 0.0
+    return SellBreakdown(st_shares=st_shares, st_basis=st_basis, lt_shares=lt_shares, lt_basis=lt_basis)
+```
+
+- [ ] **Step 4: Run new tests to verify they pass**
+
+```
+uv run pytest tests/test_live_state.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Replace backtest's inline FIFO logic with imports**
+
+Locate and replace the static methods in `src/midas/backtest.py`:
+
+- Delete `_aggregate_cost_basis` (lines 884-890) and replace its single call site at line 743 with `aggregate_cost_basis(state.lots.get(ticker, []))`.
+- Delete `_fifo_consumed_basis` (lines 892-912). Its only call site is in `_update_buy_attribution` — keep using it there but route through `consume_lots_fifo` if appropriate, or leave the helper inlined as a backtest-internal computation (it does not mutate lots and is used for attribution only, so leave it as a static method on the backtest engine).
+- Replace the inline lot-consumption while-loop in `_execute` (lines 957-982) with:
+
+```python
+breakdown = consume_lots_fifo(lots, order.shares, day)
+```
+
+Then derive the existing `st_shares`, `st_weighted_basis`, `lt_shares`, `lt_weighted_basis` from `breakdown` (multiply basis back out by shares to keep the rest of `_execute` unchanged):
+
+```python
+st_shares = breakdown.st_shares
+st_weighted_basis = breakdown.st_basis * breakdown.st_shares
+lt_shares = breakdown.lt_shares
+lt_weighted_basis = breakdown.lt_basis * breakdown.lt_shares
+```
+
+Add the import at the top of `backtest.py`:
+
+```python
+from midas.live_state import aggregate_cost_basis, consume_lots_fifo
+```
+
+- [ ] **Step 6: Run the full backtest suite to verify no regressions**
+
+```
+uv run pytest tests/test_backtest.py tests/test_lookahead_regression.py tests/test_integration.py -v
+```
+
+Expected: all PASS — the refactor is mechanical, behavior unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/midas/live_state.py src/midas/backtest.py tests/test_live_state.py
+git commit -m "Extract FIFO helpers from backtest into live_state (#36)"
+```
+
+---
+
+## Task 5: `apply_buy` and `apply_sell`
+
+**Files:**
+- Modify: `src/midas/live_state.py`
+- Modify: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_live_state.py — append
+from midas.live_state import apply_buy, apply_sell
+
+
+def test_apply_buy_appends_lot_and_decrements_cash() -> None:
+    state = LiveState(available_cash=1000.0, cash_infusion_next_date=None)
+    apply_buy(state, "AAPL", shares=10.0, price=150.0, day=date(2026, 5, 7))
+    assert state.available_cash == pytest.approx(1000.0 - 10.0 * 150.0)
+    assert state.lots["AAPL"] == [
+        PositionLot(shares=10.0, purchase_date=date(2026, 5, 7), cost_basis=150.0)
+    ]
+
+
+def test_apply_buy_appends_to_existing_lots() -> None:
+    state = LiveState(
+        available_cash=1000.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=5.0, purchase_date=date(2026, 4, 1), cost_basis=140.0)]},
+    )
+    apply_buy(state, "AAPL", shares=10.0, price=150.0, day=date(2026, 5, 7))
+    assert len(state.lots["AAPL"]) == 2
+    assert state.available_cash == pytest.approx(1000.0 - 10.0 * 150.0)
+
+
+def test_apply_sell_consumes_fifo_and_increments_cash() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={
+            "AAPL": [
+                PositionLot(shares=30.0, purchase_date=date(2025, 4, 1), cost_basis=10.0),  # LT
+                PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),  # ST
+            ]
+        },
+    )
+    st_pnl, lt_pnl = apply_sell(state, "AAPL", shares=40.0, price=25.0, day=date(2026, 5, 7))
+    assert state.available_cash == pytest.approx(40.0 * 25.0)
+    assert state.lots["AAPL"] == [
+        PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)
+    ]
+    assert lt_pnl == pytest.approx(30.0 * (25.0 - 10.0))
+    assert st_pnl == pytest.approx(10.0 * (25.0 - 20.0))
+
+
+def test_apply_sell_drops_empty_ticker_entry() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]},
+    )
+    apply_sell(state, "AAPL", shares=10.0, price=20.0, day=date(2026, 5, 7))
+    assert "AAPL" not in state.lots  # cleared
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_live_state.py -k "apply_buy or apply_sell" -v
+```
+
+Expected: FAIL — symbols not exported.
+
+- [ ] **Step 3: Implement `apply_buy` and `apply_sell`**
+
+```python
+# src/midas/live_state.py — append
+def apply_buy(state: LiveState, ticker: str, shares: float, price: float, day: date) -> None:
+    """Append a new lot for *ticker* and decrement cash by ``shares * price``.
+
+    Mutates *state* in place. Use after the live engine has emitted a buy
+    alert and the operator is assumed to have filled at *price*.
+    """
+    state.lots.setdefault(ticker, []).append(
+        PositionLot(shares=shares, purchase_date=day, cost_basis=price)
+    )
+    state.available_cash -= shares * price
+
+
+def apply_sell(
+    state: LiveState, ticker: str, shares: float, price: float, day: date
+) -> tuple[float, float]:
+    """Consume *shares* of *ticker* FIFO and increment cash by ``shares * price``.
+
+    Mutates *state* in place. Returns ``(st_realized_pnl, lt_realized_pnl)``
+    matching backtest's ST/LT classification (lots with purchase_date >=365
+    days before *day* count as long-term; everything else, including
+    ``purchase_date=None``, counts as short-term).
+    """
+    lots = state.lots.get(ticker, [])
+    breakdown = consume_lots_fifo(lots, shares, day)
+    state.available_cash += shares * price
+    if not lots:
+        state.lots.pop(ticker, None)
+    st_pnl = breakdown.st_shares * (price - breakdown.st_basis) if breakdown.st_shares > 0 else 0.0
+    lt_pnl = breakdown.lt_shares * (price - breakdown.lt_basis) if breakdown.lt_shares > 0 else 0.0
+    return st_pnl, lt_pnl
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_live_state.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live_state.py tests/test_live_state.py
+git commit -m "Add apply_buy and apply_sell mutators on LiveState (#36)"
+```
+
+---
+
+## Task 6: Add `state_file` field to `PortfolioConfig` + config parsing
+
+**Files:**
+- Modify: `src/midas/models.py`
+- Modify: `src/midas/config.py`
+- Modify: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config.py — append at end of TestLoadPortfolio (or its equivalent)
+def test_load_portfolio_parses_state_file_field(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        "state_file: ./run/portfolio.state.yaml\n"
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 100\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+    portfolio = load_portfolio(yaml_path)
+    assert portfolio.state_file == Path("./run/portfolio.state.yaml")
+
+
+def test_load_portfolio_state_file_field_optional(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 100\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+    portfolio = load_portfolio(yaml_path)
+    assert portfolio.state_file is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_config.py -k "state_file" -v
+```
+
+Expected: FAIL with `AttributeError: 'PortfolioConfig' object has no attribute 'state_file'`.
+
+- [ ] **Step 3: Add the field to `PortfolioConfig`**
+
+```python
+# src/midas/models.py — modify
+from pathlib import Path
+
+@dataclass
+class PortfolioConfig:
+    holdings: list[Holding]
+    available_cash: float
+    cash_infusion: CashInfusion | None = None
+    trading_restrictions: TradingRestrictions | None = None
+    state_file: Path | None = None
+
+    def __post_init__(self) -> None:
+        self._by_ticker = {holding.ticker: holding for holding in self.holdings}
+
+    def get_holding(self, ticker: str) -> Holding | None:
+        return self._by_ticker.get(ticker)
+```
+
+- [ ] **Step 4: Parse the field in `load_portfolio`**
+
+```python
+# src/midas/config.py — modify load_portfolio body, add after existing parsing:
+state_file_raw = raw.get("state_file")
+state_file = Path(state_file_raw) if state_file_raw is not None else None
+
+portfolio = PortfolioConfig(
+    holdings=holdings,
+    available_cash=float(raw["available_cash"]),
+    cash_infusion=infusion,
+    trading_restrictions=restrictions,
+    state_file=state_file,
+)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_config.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/midas/models.py src/midas/config.py tests/test_config.py
+git commit -m "Add state_file field to PortfolioConfig (#36)"
+```
+
+---
+
+## Task 7: Wire `LiveEngine` to `LiveState` (load/seed at construction)
+
+**Files:**
+- Modify: `src/midas/live.py`
+- Test: `tests/test_live_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_live_engine.py — new file
+"""Integration tests for LiveEngine driving LiveState across ticks."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from midas.allocator import Allocator
+from midas.live import LiveEngine
+from midas.live_state import load_state
+from midas.models import (
+    AllocationConstraints,
+    CashInfusion,
+    Holding,
+    PortfolioConfig,
+    StrategyConfig,
+)
+from midas.order_sizer import OrderSizer
+
+
+def _make_provider(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
+    """Build a fake DataProvider returning an OHLCV frame for each ticker."""
+    provider = MagicMock()
+
+    def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
+        closes = prices[ticker]
+        return pd.DataFrame(
+            {
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "volume": [1000.0] * len(closes),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
+        )
+
+    provider.get_history.side_effect = get_history
+    return provider
+
+
+@pytest.fixture
+def basic_portfolio() -> PortfolioConfig:
+    return PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+
+
+def test_live_engine_seeds_state_on_first_construction(basic_portfolio: PortfolioConfig, tmp_path: Path) -> None:
+    state_path = tmp_path / "portfolio.state.yaml"
+    assert not state_path.exists()
+
+    allocator = Allocator(strategies=[], constraints=AllocationConstraints())
+    sizer = OrderSizer()
+    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+
+    LiveEngine(
+        portfolio=basic_portfolio,
+        allocator=allocator,
+        order_sizer=sizer,
+        provider=provider,
+        state_path=state_path,
+    )
+
+    assert state_path.exists()
+    state = load_state(state_path)
+    assert state.available_cash == 1000.0
+    assert "AAPL" in state.lots
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_live_engine.py::test_live_engine_seeds_state_on_first_construction -v
+```
+
+Expected: FAIL — `LiveEngine` doesn't accept `state_path` yet.
+
+- [ ] **Step 3: Modify `LiveEngine.__init__` to load/seed state**
+
+```python
+# src/midas/live.py — modify imports
+from pathlib import Path
+
+from midas.live_state import LiveState, apply_buy, apply_sell, load_or_seed, save_atomic, aggregate_cost_basis
+
+# src/midas/live.py — modify __init__ signature and body
+class LiveEngine:
+    def __init__(
+        self,
+        portfolio: PortfolioConfig,
+        allocator: Allocator,
+        order_sizer: OrderSizer,
+        provider: DataProvider,
+        state_path: Path,
+        exit_rules: list[ExitRule] | None = None,
+        constraints: AllocationConstraints | None = None,
+        poll_interval: int = 60,
+        dry_run: bool = False,
+        history_days: int | None = None,
+    ) -> None:
+        self._portfolio = portfolio
+        self._allocator = allocator
+        self._order_sizer = order_sizer
+        self._exit_rules = exit_rules or []
+        self._constraints = constraints or AllocationConstraints()
+        self._provider = provider
+        self._poll_interval = poll_interval
+        self._dry_run = dry_run
+        self._state_path = state_path
+        self._state: LiveState = load_or_seed(portfolio, state_path)
+        # ... existing history_days, _last_order_keys, restriction_tracker setup ...
+```
+
+Also: **delete** the two warning blocks at `live.py:65-93` — both `TrailingStop` and CPPI conditions are now resolved.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+uv run pytest tests/test_live_engine.py::test_live_engine_seeds_state_on_first_construction -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live.py tests/test_live_engine.py
+git commit -m "LiveEngine loads or seeds LiveState at construction (#36)"
+```
+
+---
+
+## Task 8: Use persisted HWM and weighted-avg basis in `_tick`
+
+**Files:**
+- Modify: `src/midas/live.py`
+- Modify: `tests/test_live_engine.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_live_engine.py — append
+from midas.strategies.trailing_stop import TrailingStop
+
+
+def test_persisted_hwm_lets_trailing_stop_fire_on_drawdown(tmp_path: Path) -> None:
+    """Two ticks: tick 1 records peak at 200, tick 2 at 150 → 25% drawdown
+    fires TrailingStop with trail_pct=0.10."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    allocator = Allocator(strategies=[], constraints=AllocationConstraints())
+    sizer = OrderSizer()
+    trailing = TrailingStop(trail_pct=0.10)
+
+    # Tick 1: price at 200 (above cost basis → HWM advances).
+    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=allocator,
+        order_sizer=sizer,
+        provider=provider,
+        state_path=state_path,
+        exit_rules=[trailing],
+    )
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    assert state.high_water_marks["AAPL"] == 200.0
+
+    # Tick 2: price at 150 → 25% drawdown from HWM, exceeds 10% threshold.
+    # Same engine instance with state already loaded; provider returns 150 now.
+    provider2 = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 8)])
+    engine._provider = provider2
+    engine._tick(["AAPL"])
+
+    # The exit rule should have clamped the target to 0; sell order should
+    # have been emitted; state should reflect the assumed sell.
+    state2 = load_state(state_path)
+    assert state2.lots.get("AAPL", []) == []  # sold out
+    assert state2.available_cash > 0  # sell proceeds added
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_live_engine.py::test_persisted_hwm_lets_trailing_stop_fire_on_drawdown -v
+```
+
+Expected: FAIL — HWM not yet read from state.
+
+- [ ] **Step 3: Read HWM and weighted-avg basis from `self._state` in `_tick`**
+
+In `src/midas/live.py`, modify the exit-rule loop in `_tick` to:
+- Update `self._state.high_water_marks[ticker]` from the current price *before* the exit-rule loop.
+- Use `aggregate_cost_basis(self._state.lots.get(ticker, []))` instead of `holding.cost_basis`.
+- Use `self._state.high_water_marks[ticker]` instead of `max(cost_basis, current_prices[ticker])`.
+
+```python
+# src/midas/live.py — replace the exit-rule cost_basis/hwm derivation
+# (lines around 184-198 in the original)
+for rule in self._exit_rules:
+    for ticker in active_tickers:
+        if positions.get(ticker, 0.0) <= 0:
+            continue
+        proposed = clamped_targets.get(ticker, 0.0)
+        if proposed <= 0:
+            continue
+        cost_basis = aggregate_cost_basis(self._state.lots.get(ticker, []))
+        hwm = self._state.high_water_marks.get(ticker, current_prices[ticker])
+        clamped = rule.clamp_target(ticker, proposed, price_history[ticker], cost_basis, hwm)
+        # ... rest unchanged ...
+```
+
+Also update `positions` to be derived from state lots, not from `holding.shares`:
+
+```python
+positions = {
+    ticker: sum(lot.shares for lot in self._state.lots.get(ticker, [])) for ticker in active_tickers
+}
+```
+
+And update HWM at the top of `_tick` (before the exit loop):
+
+```python
+# After current_prices is built, before the exit-rule loop:
+for ticker in active_tickers:
+    close = current_prices[ticker]
+    self._state.high_water_marks[ticker] = max(
+        self._state.high_water_marks.get(ticker, close), close
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes** (will need Task 10's apply_sell wiring; for now, assert just up through HWM update)
+
+Pause and split: this test asserts behavior that depends on Tasks 8 + 10. Reduce the assertion scope to just HWM persistence for now:
+
+```python
+# Replace the post-tick-2 assertions with:
+state2 = load_state(state_path)
+assert state2.high_water_marks["AAPL"] == 200.0  # HWM did not regress on lower price
+```
+
+The full sell-execution assertion lives in Task 10.
+
+```
+uv run pytest tests/test_live_engine.py::test_persisted_hwm_lets_trailing_stop_fire_on_drawdown -v
+```
+
+Expected: PASS (HWM behavior verified; sell-execution check is deferred).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live.py tests/test_live_engine.py
+git commit -m "LiveEngine reads HWM and weighted-avg basis from LiveState (#36)"
+```
+
+---
+
+## Task 9: Per-tick mutations — apply assumed fills, advance peak, advance infusion, save
+
+**Files:**
+- Modify: `src/midas/live.py`
+- Modify: `tests/test_live_engine.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_live_engine.py — append
+def test_buy_alert_appends_lot_and_decrements_state_cash(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=0.0, cost_basis=None)],
+        available_cash=2000.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    # Use a strategy stub that returns a strong buy signal for AAPL.
+    # ... build allocator that produces a target weight for AAPL ...
+    # (See "Test Helpers" section for build_strong_buy_engine helper)
+    engine = build_engine_with_buy_signal(portfolio, state_path, ticker="AAPL", price=100.0)
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    # First tick should buy AAPL; lot list now has one entry.
+    assert "AAPL" in state.lots
+    assert state.available_cash < 2000.0
+
+
+def test_peak_equity_advances_and_persists(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(strategies=[], constraints=AllocationConstraints()),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    assert state.peak_equity == pytest.approx(10 * 200.0)
+
+
+def test_cash_infusion_advances_when_due(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=500.0,
+        cash_infusion=CashInfusion(amount=1500.0, next_date=date(2026, 5, 1), frequency="biweekly"),
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])  # past next_date
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(strategies=[], constraints=AllocationConstraints()),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    # Patch date.today() so the engine's "today" is 2026-05-07.
+    # Use a fixture or freezegun if available; otherwise inject via a kwarg.
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    assert state.available_cash == pytest.approx(500.0 + 1500.0)
+    assert state.cash_infusion_next_date == date(2026, 5, 15)  # advanced biweekly
+```
+
+> **Note on `build_engine_with_buy_signal`:** create a minimal helper at the top of `test_live_engine.py` that builds an `Allocator` with a single stub `EntrySignal` returning a fixed score of 1.0 for the given ticker. Reuse the pattern from `tests/test_allocator.py` if a similar fixture exists.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_live_engine.py -v
+```
+
+Expected: FAIL — apply_buy/apply_sell not wired into `_tick`.
+
+- [ ] **Step 3: Wire mutations into `_tick`**
+
+In `src/midas/live.py`, after the alert-emission loop, add:
+
+```python
+# Apply assumed fills to the in-memory state.
+for order in filtered:
+    if order.shares <= 0:
+        continue
+    if order.direction == Direction.BUY:
+        apply_buy(self._state, order.ticker, order.shares, order.price, today)
+    else:
+        apply_sell(self._state, order.ticker, order.shares, order.price, today)
+
+# Update peak equity from the current portfolio value.
+current_equity = self._state.available_cash + sum(
+    sum(lot.shares for lot in self._state.lots.get(ticker, [])) * current_prices[ticker]
+    for ticker in active_tickers
+)
+self._state.peak_equity = max(self._state.peak_equity or 0.0, current_equity)
+
+# Advance cash infusion if due.
+infusion = self._portfolio.cash_infusion
+if (
+    infusion is not None
+    and self._state.cash_infusion_next_date is not None
+    and today >= self._state.cash_infusion_next_date
+):
+    self._state.available_cash += infusion.amount
+    infusion.next_date = self._state.cash_infusion_next_date  # for advance() to work on the right value
+    infusion.advance()
+    self._state.cash_infusion_next_date = infusion.next_date
+
+# Persist state at the end of the tick.
+save_atomic(self._state, self._state_path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_live_engine.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live.py tests/test_live_engine.py
+git commit -m "LiveEngine applies assumed fills and persists state per tick (#36)"
+```
+
+---
+
+## Task 10: CLI wiring — resolve `state_path` in `live` command
+
+**Files:**
+- Modify: `src/midas/cli.py`
+- Test: extend an existing CLI test or add `tests/test_cli_live.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_live.py — new file
+"""End-to-end smoke test for the live CLI command's state-path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from midas.cli import cli
+
+
+def test_live_command_uses_sidecar_state_path_by_default(tmp_path: Path) -> None:
+    portfolio_yaml = tmp_path / "portfolio.yaml"
+    portfolio_yaml.write_text(
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 10\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+
+    captured: dict[str, Path] = {}
+
+    class _StubEngine:
+        def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
+            captured["state_path"] = state_path
+
+        def run(self) -> None:
+            return
+
+    with patch("midas.live.LiveEngine", _StubEngine):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["live", "-p", str(portfolio_yaml), "--dry-run"])
+        assert result.exit_code == 0, result.output
+    assert captured["state_path"] == portfolio_yaml.with_suffix(".state.yaml")
+
+
+def test_live_command_honors_state_file_field(tmp_path: Path) -> None:
+    state_target = tmp_path / "run" / "explicit.state.yaml"
+    portfolio_yaml = tmp_path / "portfolio.yaml"
+    portfolio_yaml.write_text(
+        f"state_file: {state_target}\n"
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 10\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+
+    captured: dict[str, Path] = {}
+
+    class _StubEngine:
+        def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
+            captured["state_path"] = state_path
+
+        def run(self) -> None:
+            return
+
+    with patch("midas.live.LiveEngine", _StubEngine):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["live", "-p", str(portfolio_yaml), "--dry-run"])
+        assert result.exit_code == 0, result.output
+    assert captured["state_path"] == state_target
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+uv run pytest tests/test_cli_live.py -v
+```
+
+Expected: FAIL — `LiveEngine` invocation in `cli.py` does not pass `state_path` yet.
+
+- [ ] **Step 3: Resolve and pass `state_path` in the CLI**
+
+```python
+# src/midas/cli.py — modify the live() command body
+def live(portfolio: str, strategies: str | None, interval: int, dry_run: bool) -> None:
+    """Run live analysis with real-time price polling."""
+    from midas.live import LiveEngine
+
+    portfolio_path = Path(portfolio)
+    port = load_portfolio(portfolio_path)
+    state_path = port.state_file or portfolio_path.with_suffix(".state.yaml")
+    # ... existing strategy/component setup unchanged ...
+
+    engine = LiveEngine(
+        portfolio=port,
+        allocator=allocator,
+        order_sizer=order_sizer,
+        provider=provider,
+        state_path=state_path,
+        exit_rules=exit_rules,
+        constraints=constraints,
+        poll_interval=interval,
+        dry_run=dry_run,
+    )
+    engine.run()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+uv run pytest tests/test_cli_live.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/cli.py tests/test_cli_live.py
+git commit -m "CLI live command resolves state_path from portfolio config (#36)"
+```
+
+---
+
+## Task 11: Backtest parity test — same prices, same state evolution
+
+**Files:**
+- Test: `tests/test_live_backtest_parity.py`
+
+- [ ] **Step 1: Write the parity test**
+
+```python
+# tests/test_live_backtest_parity.py — new file
+"""Bar-for-bar parity between the backtest and live engines.
+
+Feeds a deterministic synthetic price series through both engines and asserts
+that lot lists, HWMs, peak equity, and available cash agree at the end of
+the run. The live engine reads from a fake DataProvider that yields the
+same OHLCV frame the backtest sees.
+
+NOTE: Backtest executes orders at the next bar's open (lag=1), so the live
+harness emits at the previous bar's close to match. This is the only
+intentional offset.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from midas.allocator import Allocator
+from midas.backtest import Backtest
+from midas.live import LiveEngine
+from midas.live_state import load_state
+from midas.models import (
+    AllocationConstraints,
+    Holding,
+    PortfolioConfig,
+    StrategyConfig,
+)
+from midas.order_sizer import OrderSizer
+
+
+@pytest.fixture
+def deterministic_price_series() -> dict[str, pd.DataFrame]:
+    rng = np.random.default_rng(42)
+    n_bars = 60
+    closes = 100.0 * np.exp(np.cumsum(rng.normal(0, 0.01, n_bars)))
+    index = pd.bdate_range(start="2026-01-02", periods=n_bars)
+    return {
+        "AAPL": pd.DataFrame(
+            {
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "volume": [1000.0] * n_bars,
+            },
+            index=index,
+        )
+    }
+
+
+def test_live_and_backtest_agree_on_state_trajectory(
+    deterministic_price_series: dict[str, pd.DataFrame], tmp_path: Path
+) -> None:
+    """Run backtest and live on the same series; state at the end matches."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=90.0)],
+        available_cash=1000.0,
+    )
+
+    # ... build identical Allocator / strategies / OrderSizer for both engines ...
+    # ... run Backtest end-to-end, capture final state.lots / state.cash / state.peak_value ...
+    # ... drive LiveEngine tick-by-tick over the same price series with a fake DataProvider ...
+    # ... at end, load_state(state_path) and compare:
+    #       - lot lists per ticker (shares, purchase_date, cost_basis)
+    #       - high_water_marks
+    #       - peak_equity
+    #       - available_cash
+
+    # Concrete assertion shape:
+    # final_live = load_state(tmp_path / "p.state.yaml")
+    # assert final_live.lots == backtest_final.lots
+    # assert final_live.high_water_marks == backtest_final.high_water_marks
+    # assert final_live.peak_equity == pytest.approx(backtest_final.peak_value)
+    # assert final_live.available_cash == pytest.approx(backtest_final.cash)
+    pytest.skip("parity harness scaffold — concrete strategies/sizer setup TBD in implementation")
+```
+
+- [ ] **Step 2: Implement the harness (replace the `pytest.skip` with a concrete run)**
+
+The harness builds:
+- A `Backtest` driven by `deterministic_price_series` with one `EntrySignal` strategy, no exit rules. Run end-to-end via `Backtest.run` (or whatever the project's entry point is).
+- A `LiveEngine` with a fake `DataProvider` that, on each `_tick` invocation for date `d`, returns the slice of `deterministic_price_series` up through the bar before `d` (matching backtest's lag=1 execution).
+- Iterate over the trading days; for each day, monkey-patch `date.today()` (or pass a `today` argument; if the engine doesn't accept one, add it as part of this task) and call `engine._tick`.
+
+Compare the live state file to the backtest's final `_SimState` field-by-field as documented in Step 1.
+
+- [ ] **Step 3: Run the parity test**
+
+```
+uv run pytest tests/test_live_backtest_parity.py -v
+```
+
+Expected: PASS — the two engines see the same prices and produce the same state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_live_backtest_parity.py
+git commit -m "Add backtest/live parity test for state evolution (#36)"
+```
+
+---
+
+## Task 12: Documentation updates
+
+**Files:**
+- Modify: `docs/architecture.md`
+- Modify: `docs/strategies.md` (the live-mode warning section, if any)
+
+- [ ] **Step 1: Update `docs/architecture.md`**
+
+Add a section describing the new state model:
+
+```markdown
+## Live State Persistence
+
+The live engine persists runtime state to a YAML sidecar (`portfolio.state.yaml`
+by default, or the path under the optional `state_file:` field in `portfolio.yaml`).
+Schema is owned by `src/midas/live_state.py` and documented in
+`docs/specs/2026-05-07-live-per-lot-tracking-design.md`.
+
+After first seed, `portfolio.yaml` is read-only seed config. The state file owns
+positions (per-lot), available cash, per-ticker high-water marks, peak equity,
+and the cash-infusion `next_date`. Edits to `portfolio.yaml`'s aggregate
+`shares`, `cost_basis`, or `available_cash` after seed have no effect; the engine
+warns on drift but trusts the state file.
+
+The engine writes the state file atomically (tempfile + os.replace) at the end
+of every tick, on the assumption that emitted alerts are filled at the alert
+price. Operators who need to reflect slippage or manual overrides can hand-edit
+the state file (it is plain YAML).
+```
+
+- [ ] **Step 2: Update `docs/strategies.md`**
+
+If the doc currently warns that `TrailingStop` does not fire in live mode (it does, per the original issue), remove or update that warning.
+
+- [ ] **Step 3: Run the full test suite as a regression sweep**
+
+```
+uv run pytest -q
+uv run ruff check .
+uv run mypy src
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/architecture.md docs/strategies.md
+git commit -m "Document live state persistence (#36)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Goal (live behaves like backtest re HWM, weighted-avg basis, ST/LT classification, CPPI peak): Tasks 7, 8, 9, 11.
+- State file location & schema: Task 1.
+- Source-of-truth principle (portfolio.yaml seeds, state owns thereafter): Tasks 2, 3, 7.
+- Lifecycle — first run seeds, subsequent runs detect drift: Tasks 2, 3.
+- Per-tick HWM/peak/infusion updates and atomic save: Tasks 8, 9.
+- Crash safety (atomic writes, parse failure, schema mismatch): Task 1.
+- Migration / strict ticker-removed: Task 3.
+- Engine integration (`live_state.py` module, `LiveEngine` rework, FIFO refactor, `config.py`, `cli.py`): Tasks 1, 4, 5, 6, 7, 8, 9, 10.
+- Removal of `TrailingStop` and `drawdown_penalty` warnings: Task 7 (deletion in same change as wiring).
+- Testing — unit, integration, parity: Tasks 1-5 (unit), 7-9 (integration), 11 (parity).
+
+**Placeholder scan:** the parity test in Task 11 has a partial-skeleton implementation (Step 2 says "implement the harness" rather than showing the full code). This is a deliberate scope decision — the harness shape depends on small details of `Backtest.run`'s API that are easier to lock in when the engineer has Tasks 1-10 in hand. Acceptable, but flagging.
+
+**Type consistency:** `apply_sell` returns `tuple[float, float]` (st_pnl, lt_pnl) consistently. `consume_lots_fifo` returns `SellBreakdown`. `LiveState` field names match across all tasks. `state_path` consistently typed as `Path`.
+
+**Engineer-may-be-out-of-order assumption:** every task that depends on a previous task names the symbol(s) it imports from `midas.live_state`, so reading Task 7 in isolation, the engineer can still write the import line correctly.

--- a/docs/specs/2026-05-07-live-per-lot-tracking-design.md
+++ b/docs/specs/2026-05-07-live-per-lot-tracking-design.md
@@ -1,0 +1,220 @@
+# Live Per-Lot Tracking Design
+
+Closes #36.
+
+## Goal
+
+Make the live engine behave like the backtest engine with respect to per-lot accounting and stateful exit rules. Today live mode synthesizes a single one-element `PositionLot` per ticker on every tick, which collapses three things that work correctly in backtest:
+
+1. **Weighted-average cost basis after multiple buys** — the YAML's static `cost_basis` doesn't update when the operator buys more, so exit-rule clamps fire against a stale basis.
+2. **Per-ticker high-water mark** — re-derived as `max(cost_basis, current_price)` on every tick, which makes `TrailingStop`'s drawdown-from-HWM check structurally always-zero or never-fire.
+3. **Short-term vs long-term holding-period classification on sells** — meaningless with one synthetic lot.
+
+Persistence also unblocks the CPPI overlay (`drawdown_penalty`/`drawdown_floor`), which is currently inert in live because the running peak isn't carried across runs.
+
+## Scope
+
+**In:**
+
+1. A single mutable state file (sidecar to `portfolio.yaml`, YAML, atomic writes) that is the runtime source of truth for positions, cash, HWM, and peak equity.
+2. `LiveEngine` loads or seeds the state file at startup, mutates an in-memory representation as it generates orders (alerts == assumed fills) and updates HWM / peak / infusion, writes back at the end of each tick.
+3. Drift detection on subsequent loads (warn if `portfolio.yaml` aggregates disagree with state).
+4. Removal of the `TrailingStop`-disabled and `drawdown_penalty`-inert warnings — both conditions are now resolved.
+
+**Out (deferred to follow-up issues):**
+
+- **Per-lot HWM and lot-aware exit clamping** (#36 follow-up). Backtest doesn't have per-lot HWM today either; per-ticker HWM is enough to match. Lot-aware clamping is an `ExitRule` API change, not a persistence change.
+- **`record-fill` CLI** for slippage / manual override. This iteration assumes every emitted alert is filled at the alert price; operators who need slippage handling can hand-edit the state file as an escape valve. Real fill recording is its own UX surface.
+- **`RestrictionTracker` round-trip-days persistence**. The 30-day no-buy-after-sell window currently resets on `midas live` restart. Adjacent state but a separate concern; keep the tracker in-memory for v1.
+- **Tax-shaped P&L reporting** (tracked separately under #66).
+
+## Source-of-Truth Principle
+
+After first seed, `portfolio.yaml` is read-only seed config and the state file owns all mutable runtime state. Edits to the YAML's `shares`, `cost_basis`, `available_cash`, or `cash_infusion.next_date` after seed have no effect on live behavior; the engine warns on first load if it detects drift but trusts the state file.
+
+The YAML keeps owning everything that isn't mutable runtime state: tickers, strategies, allocation constraints, restrictions, infusion *amount* and *frequency* (only `next_date` moves to state).
+
+## State File
+
+**Location:** sidecar to `portfolio.yaml` by default. `<portfolio>.yaml` → `<portfolio>.state.yaml` next to it. An optional `state_file:` top-level field in `portfolio.yaml` overrides the path (use case: read-only `portfolio.yaml` checked into git, mutable state in a writable runtime dir).
+
+**Format:** YAML, atomic writes (temp file + `os.replace`). One canonical file per portfolio, continuously updated; no append-only history, no rotating backups.
+
+**Schema:**
+
+```yaml
+schema_version: 1
+last_updated: 2026-05-07T15:23:00Z
+
+available_cash: 4823.50
+
+cash_infusion:
+  next_date: 2026-05-15
+  # amount + frequency stay in portfolio.yaml (immutable policy);
+  # next_date moves here because advance() mutates it.
+
+high_water_marks:
+  PLTR: 24.18
+  NVDA: 142.50
+
+peak_equity: 18420.00     # for CPPI overlay; current_drawdown = 1 - equity/peak
+
+lots:
+  PLTR:
+    - shares: 100
+      purchase_date: null      # seeded; operator can hand-edit
+      cost_basis: 10.00
+    - shares: 50
+      purchase_date: 2026-04-12
+      cost_basis: 22.50
+  NVDA:
+    - shares: 100
+      purchase_date: null
+      cost_basis: 49.76
+```
+
+**Schema versioning:** `schema_version: 1` is reserved for forward compatibility. Any other value refuses to load with a clear "unsupported state version" error. No migration code in v1.
+
+**Hand-edits:** allowed but unusual. Expected use cases are correcting a seed lot's `purchase_date` for accurate ST/LT classification, or adjusting cash to reflect external transfers the engine doesn't know about. Not a primary workflow.
+
+## Lifecycle
+
+### First run (state file does not exist)
+
+1. Resolve state path: `portfolio.yaml`'s `state_file:` field if set, else sidecar.
+2. Seed from `portfolio.yaml`:
+   - One `PositionLot(shares=Holding.shares, cost_basis=Holding.cost_basis, purchase_date=None)` per ticker with `shares > 0`.
+   - `available_cash` from YAML.
+   - `cash_infusion.next_date` from YAML.
+   - Empty `high_water_marks` dict.
+   - `peak_equity = None` (filled on first tick).
+3. Atomic-write the state file.
+4. Log one info line: `"Seeded state at <path> from <portfolio.yaml>"`.
+5. Continue the tick loop normally.
+
+### Subsequent runs
+
+1. Load state file.
+2. Ignore `Holding.shares`, `Holding.cost_basis`, `available_cash`, and `cash_infusion.next_date` from `portfolio.yaml`.
+3. Drift check:
+   - For each ticker in state, sum `lots[ticker].shares` and compare to `Holding.shares`. If different, warn naming both values.
+   - Compare state `available_cash` to YAML's. If different, warn.
+   - Don't refuse to run; trust the state file. Warning is the signal.
+
+### Per tick
+
+1. **Update HWM:** `hwm[ticker] = max(hwm.get(ticker, 0.0), close)` for each held ticker.
+2. **Update peak equity:** `peak_equity = max(peak_equity or 0.0, current_equity)` where `current_equity = available_cash + Σ shares * close`.
+3. **Allocator + exit rules + sizer** run as today, but:
+   - `cost_basis` for `clamp_target` is the weighted-avg over the in-memory lot list (matches backtest's `_aggregate_cost_basis`).
+   - `high_water_mark` for `clamp_target` is the persisted per-ticker HWM (not the synthesized `max(cost_basis, current_price)`).
+4. **Apply assumed fills** to the in-memory state for each emitted alert:
+   - `apply_buy(state, ticker, shares, price, today)` appends a `PositionLot(shares, today, price)` and decrements cash by `shares * price`.
+   - `apply_sell(state, ticker, shares, price)` consumes lots FIFO, increments cash by `shares * price`, returns `(st_realized_pnl, lt_realized_pnl)` matching backtest's classification.
+5. **Advance cash infusion:** if `today >= cash_infusion.next_date`, add `amount` to cash and call `advance()` (matches backtest behavior).
+6. **Atomic write:** serialize to temp file, `os.replace` over the canonical path. Update `last_updated`.
+
+The write happens every tick. HWM and peak almost always advance on a non-flat day, so skipping writes when "nothing changed" would rarely apply and isn't worth the complexity. Optimizing further is a v1.1 concern if I/O becomes a bottleneck.
+
+## Crash Safety
+
+- **Mid-write crash:** atomic write (`tempfile + os.replace`) guarantees the canonical file is either the old version or the new version, never partial.
+- **Mid-tick crash after alert emission, before write:** the next tick re-reads the previous state. The alert was emitted but not recorded — same divergence the operator sees if they ignore an alert. Acceptable for the "assume immediate execution" model.
+- **State file corruption / parse failure:** refuse to start with a clear error pointing at the file. Don't auto-recover or re-seed; that would silently overwrite real positions.
+- **Schema version mismatch:** refuse to load.
+
+## Migration & Edge Cases
+
+**Tickers added to `portfolio.yaml` after seed.** `Holding` exists with `shares=0` (or non-zero, doesn't matter — state ignores it) and no entry in `state.lots`. Engine treats it as a fresh ticker; allocator can buy into it; first buy creates the lot list for that ticker.
+
+**Tickers removed from `portfolio.yaml` after seed but still held in state.** Refuse to start with a clear error naming the ticker and the share count in state. Removing a ticker while still holding shares is almost certainly a config mistake; failing loudly prevents silent forks of state.
+
+**`state_file:` field present in YAML but the named file doesn't exist.** Treat as first run; seed there.
+
+**Two `midas live` processes against the same state file.** Out of scope. The engine is not designed for concurrent execution. (Future hardening could use `flock` or a lockfile, but not in v1.)
+
+## Engine Integration
+
+### New module: `src/midas/live_state.py` (~150 lines)
+
+```python
+@dataclass
+class LiveState:
+    available_cash: float
+    cash_infusion_next_date: date | None
+    high_water_marks: dict[str, float]
+    peak_equity: float | None
+    lots: dict[str, list[PositionLot]]
+
+def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState: ...
+def save_atomic(state: LiveState, path: Path) -> None: ...
+def apply_buy(state: LiveState, ticker: str, shares: float, price: float, day: date) -> None: ...
+def apply_sell(
+    state: LiveState, ticker: str, shares: float, price: float, day: date
+) -> tuple[float, float]:
+    """Consume lots FIFO; returns (st_realized_pnl, lt_realized_pnl)."""
+```
+
+`apply_buy` / `apply_sell` reuse the FIFO logic that lives in `backtest.py:893-1004` today. Extract that logic into shared helpers in `live_state.py`; `backtest.py` imports from the new module. The refactor is mechanical — no behavior change for backtest.
+
+### `LiveEngine` (`src/midas/live.py`)
+
+- Constructor takes a `state_path: Path`. Loads or seeds at construction.
+- The CPPI and `TrailingStop` warnings (`live.py:73-93`) are removed — both conditions are now resolved.
+- `_tick` reads HWM / weighted-avg cost basis from `self._state` instead of synthesizing them.
+- After alerts are emitted, `apply_buy` / `apply_sell` mutate `self._state`, then `save_atomic` flushes.
+- The duplicate-suppression set `_last_order_keys` stays in-memory: re-emitting on restart is correct so the operator doesn't miss a still-relevant signal.
+
+### `config.py`
+
+- `load_portfolio` learns to parse an optional `state_file:` top-level field. No change to the `portfolio:` block schema.
+
+### `cli.py`
+
+- The `live` command resolves `state_path = port.state_file or portfolio_path.with_suffix('.state.yaml')` and passes it to `LiveEngine`.
+
+## Testing
+
+### Unit (`tests/test_live_state.py`)
+
+- `load_or_seed` creates a state file from `portfolio.yaml` when none exists; seed lots have `purchase_date=None`.
+- `load_or_seed` reads an existing state file and ignores aggregate drift in `Holding.shares`, with a warning.
+- `apply_buy` appends a lot, decrements cash by `shares * price`.
+- `apply_sell` consumes FIFO, returns ST/LT P&L split matching backtest's classification (boundary at 365 days).
+- `save_atomic` produces a parseable file; partial-write failure (mocked) leaves the canonical file intact.
+- `schema_version` mismatch refuses to load.
+- Strict mode: ticker removed from `portfolio.yaml` while lots remain → load raises with a clear error.
+
+### Integration (`tests/test_live_engine.py`)
+
+- HWM persists across two synthetic ticks: tick 1 records peak, tick 2 with lower price → `TrailingStop` fires.
+- Two assumed buys at different prices produce a correct weighted-avg cost basis on the next tick's clamp.
+- Sell consumes lots FIFO; the next tick's allocator sees reduced shares.
+- Cash decrements/increments correctly across a buy + sell sequence.
+- `peak_equity` advances on a winning tick; on a subsequent losing tick that produces a non-zero `current_drawdown`, the CPPI exposure scale falls below 1.0 (matching the formula in `risk.apply_drawdown_overlay`).
+
+### Backtest parity (`tests/test_live_backtest_parity.py`)
+
+A deterministic synthetic price series fed through both the backtest engine and a `LiveEngine` driven by a fake `DataProvider`. Assert lot lists, HWMs, peak equity, available cash, and emitted-order shapes match bar-for-bar (modulo backtest's `lag=1` execution offset, which the test harness replicates by emitting on the previous bar's close).
+
+### No regressions
+
+The refactor of FIFO helpers from `backtest.py` into `live_state.py` is mechanical — backtest imports from the new module, behavior unchanged. All existing tests pass.
+
+## YAML Interface
+
+```yaml
+# portfolio.yaml — unchanged except for the optional state_file field
+state_file: ./run/portfolio.state.yaml   # optional; default is sidecar
+
+portfolio:
+  - ticker: PLTR
+    shares: 100
+    cost_basis: 10
+  # ...
+
+available_cash: 5000.00
+# (cash_infusion, trading_restrictions unchanged)
+```
+
+The `state_file:` field is optional and the `portfolio:` block schema does not change. Existing portfolios continue to work; first `midas live` invocation seeds the state file alongside the portfolio.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -69,7 +69,7 @@ risk:
 
 The optimizer **does not** search risk knobs — risk is policy, easy to overfit, and changing it is a deliberate user act. To experiment, edit the YAML and rerun. For A/B comparisons keep two strategies files in version control.
 
-CPPI (`drawdown_penalty` / `drawdown_floor`) is currently inert in `live` mode — peak persistence requires a state file that is tracked for v2. Live runs log a warning at startup if CPPI is configured.
+CPPI (`drawdown_penalty` / `drawdown_floor`) is supported in `live` mode — peak equity persists across runs through the live state sidecar (see [Architecture: Live State Persistence](architecture.md#live-state-persistence)).
 
 See [Architecture: Risk-aware allocator phases](architecture.md#phase-4a-cppi-drawdown-overlay-optional) for the phase-by-phase behavior.
 

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -949,9 +949,9 @@ class BacktestEngine:
 
         breakdown = consume_lots_fifo(lots, order.shares, day)
         st_shares = breakdown.st_shares
-        st_weighted_basis = breakdown.st_basis * breakdown.st_shares
+        st_weighted_basis = breakdown.st_weighted
         lt_shares = breakdown.lt_shares
-        lt_weighted_basis = breakdown.lt_basis * breakdown.lt_shares
+        lt_weighted_basis = breakdown.lt_weighted
 
         new_position = state.positions.get(ticker, 0) - order.shares
         # ``size_sells`` caps at held shares, so reaching _execute with a

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from midas.allocator import AllocationResult, Allocator, AllocatorRiskTelemetry
 from midas.data.price_history import PriceHistory
+from midas.live_state import aggregate_cost_basis, consume_lots_fifo
 from midas.metrics import (
     compute_annualized_return,
     compute_cagr,
@@ -740,7 +741,7 @@ class BacktestEngine:
                 proposed = clamped_targets.get(ticker, 0.0)
                 if proposed <= 0:
                     continue
-                cost_basis = self._aggregate_cost_basis(state.lots.get(ticker, []))
+                cost_basis = aggregate_cost_basis(state.lots.get(ticker, []))
                 hwm = state.high_water_marks.get(ticker, 0.0)
                 clamped = rule.clamp_target(
                     ticker,
@@ -882,14 +883,6 @@ class BacktestEngine:
             state.cash -= order.estimated_value
 
     @staticmethod
-    def _aggregate_cost_basis(lots: list[PositionLot]) -> float:
-        """Share-weighted average cost basis across all open lots."""
-        total_shares = sum(lot.shares for lot in lots)
-        if total_shares <= 0:
-            return 0.0
-        return sum(lot.shares * lot.cost_basis for lot in lots) / total_shares
-
-    @staticmethod
     def _fifo_consumed_basis(lots: list[PositionLot], shares: float) -> float:
         """Share-weighted cost basis of the first *shares* shares in FIFO order.
 
@@ -954,32 +947,11 @@ class BacktestEngine:
         if not lots:
             return []
 
-        st_shares = 0.0
-        st_weighted_basis = 0.0
-        lt_shares = 0.0
-        lt_weighted_basis = 0.0
-
-        remaining = order.shares
-        while remaining > 0 and lots:
-            lot = lots[0]
-            take = min(lot.shares, remaining)
-            if lot.purchase_date is not None and (day - lot.purchase_date).days >= 365:
-                lt_shares += take
-                lt_weighted_basis += take * lot.cost_basis
-            else:
-                st_shares += take
-                st_weighted_basis += take * lot.cost_basis
-
-            if lot.shares <= remaining:
-                remaining -= lot.shares
-                lots.pop(0)
-            else:
-                lots[0] = PositionLot(
-                    shares=lot.shares - remaining,
-                    purchase_date=lot.purchase_date,
-                    cost_basis=lot.cost_basis,
-                )
-                remaining = 0
+        breakdown = consume_lots_fifo(lots, order.shares, day)
+        st_shares = breakdown.st_shares
+        st_weighted_basis = breakdown.st_basis * breakdown.st_shares
+        lt_shares = breakdown.lt_shares
+        lt_weighted_basis = breakdown.lt_basis * breakdown.lt_shares
 
         new_position = state.positions.get(ticker, 0) - order.shares
         # ``size_sells`` caps at held shares, so reaching _execute with a

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -238,7 +238,7 @@ def live(
         risk_config=risk_config,
     )
 
-    engine = LiveEngine(
+    with LiveEngine(
         portfolio=port,
         allocator=allocator,
         order_sizer=order_sizer,
@@ -248,8 +248,8 @@ def live(
         constraints=constraints,
         poll_interval=interval,
         dry_run=dry_run,
-    )
-    engine.run()
+    ) as engine:
+        engine.run()
 
 
 @cli.command()

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -236,7 +236,8 @@ def live(
         risk_config=risk_config,
     )
 
-    engine = LiveEngine(
+    # TODO(task-10): pass state_path resolved from portfolio.state_file or default.
+    engine = LiveEngine(  # type: ignore[call-arg]
         portfolio=port,
         allocator=allocator,
         order_sizer=order_sizer,

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -222,7 +222,9 @@ def live(
     """Run live analysis with real-time price polling."""
     from midas.live import LiveEngine
 
-    port = load_portfolio(Path(portfolio))
+    portfolio_path = Path(portfolio)
+    port = load_portfolio(portfolio_path)
+    state_path = port.state_file if port.state_file is not None else portfolio_path.with_suffix(".state.yaml")
     strat_configs, constraints, risk_config = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
     )
@@ -236,12 +238,12 @@ def live(
         risk_config=risk_config,
     )
 
-    # TODO(task-10): pass state_path resolved from portfolio.state_file or default.
-    engine = LiveEngine(  # type: ignore[call-arg]
+    engine = LiveEngine(
         portfolio=port,
         allocator=allocator,
         order_sizer=order_sizer,
         provider=provider,
+        state_path=state_path,
         exit_rules=exit_rules,
         constraints=constraints,
         poll_interval=interval,

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -66,11 +66,15 @@ def load_portfolio(path: Path) -> PortfolioConfig:
             round_trip_days=int(tr.get("round_trip_days", 0)),
         )
 
+    state_file_raw = raw.get("state_file")
+    state_file = Path(state_file_raw) if state_file_raw is not None else None
+
     portfolio = PortfolioConfig(
         holdings=holdings,
         available_cash=float(raw["available_cash"]),
         cash_infusion=infusion,
         trading_restrictions=restrictions,
+        state_file=state_file,
     )
 
     return portfolio

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -126,6 +126,21 @@ class LiveEngine:
             close = current_prices[ticker]
             self._state.high_water_marks[ticker] = max(self._state.high_water_marks.get(ticker, close), close)
 
+        # Advance cash infusion if due — credit BEFORE allocator/sizer decisions
+        # so the new cash is available for today's allocations (matches backtest's
+        # _run_day, which credits the infusion at the start of the day).
+        infusion = self._portfolio.cash_infusion
+        if (
+            infusion is not None
+            and self._state.cash_infusion_next_date is not None
+            and today >= self._state.cash_infusion_next_date
+        ):
+            self._state.available_cash += infusion.amount
+            # CashInfusion.advance() mutates next_date in place; align it with state, advance, copy back.
+            infusion.next_date = self._state.cash_infusion_next_date
+            infusion.advance()
+            self._state.cash_infusion_next_date = infusion.next_date
+
         # Current positions + weights (weights feed Option A: neutral=hold).
         # Positions are derived from state lots, not the YAML.
         positions = {ticker: sum(lot.shares for lot in self._state.lots.get(ticker, [])) for ticker in active_tickers}
@@ -226,19 +241,6 @@ class LiveEngine:
             positions_after[ticker] * current_prices[ticker] for ticker in active_tickers
         )
         self._state.peak_equity = max(self._state.peak_equity or 0.0, current_equity)
-
-        # Advance cash infusion if due.
-        infusion = self._portfolio.cash_infusion
-        if (
-            infusion is not None
-            and self._state.cash_infusion_next_date is not None
-            and today >= self._state.cash_infusion_next_date
-        ):
-            self._state.available_cash += infusion.amount
-            # CashInfusion.advance() mutates next_date in place; align it with state, advance, copy back.
-            infusion.next_date = self._state.cash_infusion_next_date
-            infusion.advance()
-            self._state.cash_infusion_next_date = infusion.next_date
 
         # Persist state at the end of the tick (HWM/peak/infusion always advance,
         # even on no-change ticks where alert printing is suppressed below).

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import logging
 import time
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 
 import pandas as pd
 
 from midas.allocator import AllocationResult, Allocator
 from midas.data.price_history import PriceHistory
 from midas.data.provider import DataProvider
+from midas.live_state import LiveState, load_or_seed
 from midas.models import (
     AllocationConstraints,
     Direction,
@@ -20,7 +22,6 @@ from midas.order_sizer import OrderSizer
 from midas.output import print_alert, print_status
 from midas.restrictions import RestrictionTracker
 from midas.strategies.base import ExitRule, max_warmup, warmup_bars_to_calendar_days
-from midas.strategies.trailing_stop import TrailingStop
 
 logger = logging.getLogger(__name__)
 
@@ -32,12 +33,15 @@ class LiveEngine:
         allocator: Allocator,
         order_sizer: OrderSizer,
         provider: DataProvider,
+        state_path: Path,
         exit_rules: list[ExitRule] | None = None,
         constraints: AllocationConstraints | None = None,
         poll_interval: int = 60,
         dry_run: bool = False,
         history_days: int | None = None,
     ) -> None:
+        self._state_path = state_path
+        self._state: LiveState = load_or_seed(portfolio, state_path)
         self._portfolio = portfolio
         self._allocator = allocator
         self._order_sizer = order_sizer
@@ -60,36 +64,6 @@ class LiveEngine:
         if portfolio.trading_restrictions:
             self._restriction_tracker = RestrictionTracker(
                 portfolio.trading_restrictions,
-            )
-
-        # Live mode does not persist per-lot state across runs, so the
-        # high-water mark passed to exit rules is derived as
-        # ``max(cost_basis, current_price)`` (see ``_tick``). Under that
-        # derivation, TrailingStop's drawdown-from-HWM check always
-        # collapses: it's 0 when in profit (current == hwm) and the
-        # in-profit gate fails when underwater. The rule never fires.
-        # Warn loudly so optimized strategies that rely on TrailingStop
-        # aren't silently neutered at deployment.
-        if any(isinstance(rule, TrailingStop) for rule in self._exit_rules):
-            logger.warning(
-                "TrailingStop is configured but live mode does not track a "
-                "real high-water mark — it will NOT fire. Optimized backtest "
-                "behavior will diverge from live. Remove TrailingStop from "
-                "your live config or wait for per-lot HWM persistence."
-            )
-
-        # CPPI overlay also depends on a persistent peak across runs. Live
-        # mode is stateless across ticks (re-derives from YAML each cycle),
-        # so the CPPI overlay is inert in live v1. Warn at startup so
-        # operators know backtests with drawdown_penalty configured will
-        # diverge from live behavior during drawdown periods.
-        risk_config = getattr(self._allocator, "risk_config", None)
-        if risk_config is not None and risk_config.drawdown_penalty is not None:
-            logger.warning(
-                "drawdown_penalty is configured but live mode does not yet "
-                "track a persistent peak across runs — the CPPI overlay is "
-                "inert in live and behavior will diverge from backtest. "
-                "Peak persistence is tracked for v2."
             )
 
     def run(self) -> None:

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import errno
+import fcntl
 import logging
+import os
 import time
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -41,6 +44,28 @@ class LiveEngine:
         history_days: int | None = None,
     ) -> None:
         self._state_path = state_path
+        # Take an exclusive non-blocking advisory lock on a sidecar lockfile
+        # before touching the state. Two ``midas live`` processes against the
+        # same state file would otherwise both load, both compute, both write
+        # — ``os.replace`` picks a winner and the loser's fills are lost
+        # silently. This converts that silent corruption into a loud error.
+        # The lock is held for the lifetime of the process; flock releases on
+        # fd close, which Python handles automatically at interpreter exit.
+        self._lock_path = state_path.with_suffix(state_path.suffix + ".lock")
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_fd: int | None = os.open(str(self._lock_path), os.O_WRONLY | os.O_CREAT, 0o644)
+        try:
+            fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            os.close(self._lock_fd)
+            self._lock_fd = None
+            if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                msg = (
+                    f"another midas live process appears to hold the state lock at {self._lock_path}; "
+                    f"refusing to start. If you're sure no other process is running, remove the lock file."
+                )
+                raise RuntimeError(msg) from exc
+            raise
         self._state: LiveState = load_or_seed(portfolio, state_path)
         self._portfolio = portfolio
         self._allocator = allocator
@@ -65,6 +90,30 @@ class LiveEngine:
             self._restriction_tracker = RestrictionTracker(
                 portfolio.trading_restrictions,
             )
+
+    def close(self) -> None:
+        """Release the state lockfile.
+
+        In production the engine lives for the lifetime of the process and
+        the lock is released implicitly at interpreter exit when the file
+        descriptor is closed. Tests that construct multiple ``LiveEngine``s
+        against the same state file (e.g. the backtest/live parity suite)
+        must call this between instances or the second construction will
+        race the first's GC and fail with ``RuntimeError`` on the
+        ``LOCK_EX | LOCK_NB`` acquire. Idempotent.
+        """
+        if self._lock_fd is not None:
+            try:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._lock_fd)
+                self._lock_fd = None
+
+    def __enter__(self) -> LiveEngine:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
 
     def run(self) -> None:
         tickers = [holding.ticker for holding in self._portfolio.holdings]
@@ -122,7 +171,14 @@ class LiveEngine:
         active_tickers = [ticker for ticker in tickers if ticker in price_data]
 
         # Advance per-ticker HWM in state to the latest close (never regress).
+        # Only held tickers count: HWM on a not-yet-bought ticker would seed
+        # ``TrailingStop`` against a pre-purchase peak on the very first held
+        # day, silently more conservative than backtest, which only tracks
+        # HWM on positions with shares > 0.
+        held_tickers = {ticker for ticker, lots in self._state.lots.items() if sum(lot.shares for lot in lots) > 0}
         for ticker in active_tickers:
+            if ticker not in held_tickers:
+                continue
             close = current_prices[ticker]
             self._state.high_water_marks[ticker] = max(self._state.high_water_marks.get(ticker, close), close)
 
@@ -157,10 +213,17 @@ class LiveEngine:
             }
 
         # Phase 1: Allocator scores entry signals and blends to target weights.
+        # ``current_drawdown`` feeds the optional CPPI overlay (Phase 4a).
+        # ``peak_equity`` is now persistent across runs via the state
+        # sidecar — without this argument the overlay would always be a
+        # no-op in live (its raison d'être for this PR).
+        peak = self._state.peak_equity
+        current_drawdown = (peak - total_value) / peak if peak is not None and peak > 0 and total_value < peak else 0.0
         allocation = self._allocator.allocate(
             active_tickers,
             price_history,
             current_weights=current_weights,
+            current_drawdown=current_drawdown,
         )
 
         # Phase 2: Exit rules clamp proposed targets downward (LEAN pattern).

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import fcntl
 import logging
 import os
 import time
@@ -11,6 +10,11 @@ from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 import pandas as pd
+
+try:
+    import fcntl
+except ImportError:  # Windows
+    fcntl = None  # type: ignore[assignment]
 
 from midas.allocator import AllocationResult, Allocator
 from midas.data.price_history import PriceHistory
@@ -43,6 +47,12 @@ class LiveEngine:
         dry_run: bool = False,
         history_days: int | None = None,
     ) -> None:
+        if fcntl is None:
+            msg = (
+                "LiveEngine requires fcntl-based file locking, which is unavailable "
+                "on this platform (Windows). The live engine is currently POSIX-only."
+            )
+            raise RuntimeError(msg)
         self._state_path = state_path
         # Take an exclusive non-blocking advisory lock on a sidecar lockfile
         # before touching the state. Two ``midas live`` processes against the

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -12,7 +12,7 @@ import pandas as pd
 from midas.allocator import AllocationResult, Allocator
 from midas.data.price_history import PriceHistory
 from midas.data.provider import DataProvider
-from midas.live_state import LiveState, load_or_seed
+from midas.live_state import LiveState, aggregate_cost_basis, load_or_seed
 from midas.models import (
     AllocationConstraints,
     Direction,
@@ -121,15 +121,18 @@ class LiveEngine:
 
         active_tickers = [ticker for ticker in tickers if ticker in price_data]
 
-        # Current positions + weights (weights feed Option A: neutral=hold).
-        positions = {}
+        # Advance per-ticker HWM in state to the latest close (never regress).
         for ticker in active_tickers:
-            held = self._portfolio.get_holding(ticker)
-            positions[ticker] = held.shares if held else 0.0
+            close = current_prices[ticker]
+            self._state.high_water_marks[ticker] = max(self._state.high_water_marks.get(ticker, close), close)
+
+        # Current positions + weights (weights feed Option A: neutral=hold).
+        # Positions are derived from state lots, not the YAML.
+        positions = {ticker: sum(lot.shares for lot in self._state.lots.get(ticker, [])) for ticker in active_tickers}
 
         # Pass None (not {}) when the denominator is zero so the allocator
         # falls back to its equal-weight baseline.
-        total_value = self._portfolio.available_cash + sum(
+        total_value = self._state.available_cash + sum(
             positions[ticker] * current_prices[ticker] for ticker in active_tickers
         )
         current_weights: dict[str, float] | None = None
@@ -155,21 +158,8 @@ class LiveEngine:
                 proposed = clamped_targets.get(ticker, 0.0)
                 if proposed <= 0:
                     continue
-                holding = self._portfolio.get_holding(ticker)
-                if holding is None:
-                    continue
-                if holding.cost_basis is None:
-                    logger.warning(
-                        "%s: no cost_basis in portfolio config — using current "
-                        "price as fallback. Stop-loss and profit-taking exits "
-                        "are effectively disabled for this ticker until a real "
-                        "basis is recorded.",
-                        ticker,
-                    )
-                    cost_basis = current_prices[ticker]
-                else:
-                    cost_basis = holding.cost_basis
-                hwm = max(cost_basis, current_prices[ticker])
+                cost_basis = aggregate_cost_basis(self._state.lots.get(ticker, []))
+                hwm = self._state.high_water_marks.get(ticker, current_prices[ticker])
                 clamped = rule.clamp_target(ticker, proposed, price_history[ticker], cost_basis, hwm)
                 if clamped < proposed:
                     clamped_targets[ticker] = clamped
@@ -194,7 +184,7 @@ class LiveEngine:
                 if not self._restriction_tracker.is_blocked(order.ticker, order.direction, today)
             ]
         sell_proceeds = sum(order.estimated_value for order in exit_orders)
-        post_sell_cash = self._portfolio.available_cash + sell_proceeds
+        post_sell_cash = self._state.available_cash + sell_proceeds
 
         clamped_allocation = AllocationResult(
             targets=clamped_targets,
@@ -226,7 +216,7 @@ class LiveEngine:
         self._last_order_keys = current_keys
 
         now = datetime.now(tz=UTC)
-        remaining_cash = self._portfolio.available_cash
+        remaining_cash = self._state.available_cash
         for order in filtered:
             if order.shares <= 0:
                 continue

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -321,6 +321,8 @@ class LiveEngine:
                 apply_buy(self._state, order.ticker, order.shares, order.price, today)
             else:
                 apply_sell(self._state, order.ticker, order.shares, order.price, today)
+            if self._restriction_tracker is not None:
+                self._restriction_tracker.record_trade(order.ticker, order.direction, today)
 
         # Update peak equity from the current portfolio value (post-fills).
         positions_after = {

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -224,6 +224,11 @@ class LiveEngine:
 
         filtered = exit_orders + buy_orders
 
+        # Capture the pre-fill cash baseline for the alert-emission loop below.
+        # apply_buy/apply_sell mutate state.available_cash, so seeding the
+        # running subtotal from state after fills would double-count.
+        pre_fill_cash = self._state.available_cash
+
         # Apply assumed fills to the in-memory state.
         for order in filtered:
             if order.shares <= 0:
@@ -253,7 +258,7 @@ class LiveEngine:
         self._last_order_keys = current_keys
 
         now = datetime.now(tz=UTC)
-        remaining_cash = self._state.available_cash
+        remaining_cash = pre_fill_cash
         for order in filtered:
             if order.shares <= 0:
                 continue

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -66,30 +66,41 @@ class LiveEngine:
                 )
                 raise RuntimeError(msg) from exc
             raise
-        self._state: LiveState = load_or_seed(portfolio, state_path)
-        self._portfolio = portfolio
-        self._allocator = allocator
-        self._order_sizer = order_sizer
-        self._exit_rules = exit_rules or []
-        self._constraints = constraints or AllocationConstraints()
-        self._provider = provider
-        self._poll_interval = poll_interval
-        self._dry_run = dry_run
-        # Derive the history window from the largest warmup required across
-        # configured strategies (plus slack for weekends/holidays). An explicit
-        # ``history_days`` override is still honored for tests.
-        if history_days is not None:
-            self._history_days = history_days
-        else:
-            warmup_bars = max_warmup([*allocator.strategies, *self._exit_rules])
-            self._history_days = warmup_bars_to_calendar_days(warmup_bars)
-        # Track (ticker, direction, shares) from last tick to suppress duplicate alerts
-        self._last_order_keys: set[tuple[str, Direction, float]] = set()
-        self._restriction_tracker: RestrictionTracker | None = None
-        if portfolio.trading_restrictions:
-            self._restriction_tracker = RestrictionTracker(
-                portfolio.trading_restrictions,
-            )
+
+        # Once the lock is held, any failure during the rest of __init__ must
+        # release it; otherwise a supervisor (or REPL) that catches the
+        # exception and retries would see a misleading "another midas live
+        # process" RuntimeError on the second attempt within the same process.
+        # ``BaseException`` is intentional — keyboard interrupts during
+        # ``load_or_seed`` should also release the lock.
+        try:
+            self._state: LiveState = load_or_seed(portfolio, state_path)
+            self._portfolio = portfolio
+            self._allocator = allocator
+            self._order_sizer = order_sizer
+            self._exit_rules = exit_rules or []
+            self._constraints = constraints or AllocationConstraints()
+            self._provider = provider
+            self._poll_interval = poll_interval
+            self._dry_run = dry_run
+            # Derive the history window from the largest warmup required across
+            # configured strategies (plus slack for weekends/holidays). An explicit
+            # ``history_days`` override is still honored for tests.
+            if history_days is not None:
+                self._history_days = history_days
+            else:
+                warmup_bars = max_warmup([*allocator.strategies, *self._exit_rules])
+                self._history_days = warmup_bars_to_calendar_days(warmup_bars)
+            # Track (ticker, direction, shares) from last tick to suppress duplicate alerts
+            self._last_order_keys: set[tuple[str, Direction, float]] = set()
+            self._restriction_tracker: RestrictionTracker | None = None
+            if portfolio.trading_restrictions:
+                self._restriction_tracker = RestrictionTracker(
+                    portfolio.trading_restrictions,
+                )
+        except BaseException:
+            self.close()
+            raise
 
     def close(self) -> None:
         """Release the state lockfile.

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -12,7 +12,7 @@ import pandas as pd
 from midas.allocator import AllocationResult, Allocator
 from midas.data.price_history import PriceHistory
 from midas.data.provider import DataProvider
-from midas.live_state import LiveState, aggregate_cost_basis, load_or_seed
+from midas.live_state import LiveState, aggregate_cost_basis, apply_buy, apply_sell, load_or_seed, save_atomic
 from midas.models import (
     AllocationConstraints,
     Direction,
@@ -208,6 +208,41 @@ class LiveEngine:
             ]
 
         filtered = exit_orders + buy_orders
+
+        # Apply assumed fills to the in-memory state.
+        for order in filtered:
+            if order.shares <= 0:
+                continue
+            if order.direction == Direction.BUY:
+                apply_buy(self._state, order.ticker, order.shares, order.price, today)
+            else:
+                apply_sell(self._state, order.ticker, order.shares, order.price, today)
+
+        # Update peak equity from the current portfolio value (post-fills).
+        positions_after = {
+            ticker: sum(lot.shares for lot in self._state.lots.get(ticker, [])) for ticker in active_tickers
+        }
+        current_equity = self._state.available_cash + sum(
+            positions_after[ticker] * current_prices[ticker] for ticker in active_tickers
+        )
+        self._state.peak_equity = max(self._state.peak_equity or 0.0, current_equity)
+
+        # Advance cash infusion if due.
+        infusion = self._portfolio.cash_infusion
+        if (
+            infusion is not None
+            and self._state.cash_infusion_next_date is not None
+            and today >= self._state.cash_infusion_next_date
+        ):
+            self._state.available_cash += infusion.amount
+            # CashInfusion.advance() mutates next_date in place; align it with state, advance, copy back.
+            infusion.next_date = self._state.cash_infusion_next_date
+            infusion.advance()
+            self._state.cash_infusion_next_date = infusion.next_date
+
+        # Persist state at the end of the tick (HWM/peak/infusion always advance,
+        # even on no-change ticks where alert printing is suppressed below).
+        save_atomic(self._state, self._state_path)
 
         # Emit alerts only when the order set changes
         current_keys = {(order.ticker, order.direction, order.shares) for order in filtered if order.shares > 0}

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -10,6 +10,7 @@ tracking-design.md.
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -19,7 +20,9 @@ from typing import Any
 
 import yaml
 
-from midas.models import PositionLot
+from midas.models import PortfolioConfig, PositionLot
+
+logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
 
@@ -65,7 +68,7 @@ def save_atomic(state: LiveState, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
     try:
-        with os.fdopen(fd, "w") as handle:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
             yaml.safe_dump(payload, handle, sort_keys=False)
         os.replace(tmp_name, path)
     except Exception:
@@ -77,7 +80,7 @@ def save_atomic(state: LiveState, path: Path) -> None:
 def load_state(path: Path) -> LiveState:
     """Load state from *path*. Raises ``StateFileError`` on invalid input."""
     try:
-        with open(path) as handle:
+        with open(path, encoding="utf-8") as handle:
             raw = yaml.safe_load(handle)
     except yaml.YAMLError as exc:
         msg = f"failed to parse state file at {path}: {exc}"
@@ -93,6 +96,9 @@ def load_state(path: Path) -> LiveState:
     infusion = raw.get("cash_infusion")
     next_date: date | None = None
     if infusion is not None:
+        if not isinstance(infusion, dict):
+            msg = f"cash_infusion in {path} must be a mapping, got {type(infusion).__name__}"
+            raise StateFileError(msg)
         next_date = infusion.get("next_date")
         if isinstance(next_date, str):
             next_date = date.fromisoformat(next_date)
@@ -115,3 +121,45 @@ def load_state(path: Path) -> LiveState:
         peak_equity=raw.get("peak_equity"),
         lots=lots,
     )
+
+
+def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
+    """Load state from *state_path*, or seed it from *portfolio* if missing.
+
+    The seed branch creates one ``PositionLot`` per ticker with ``shares > 0``,
+    using the YAML's ``cost_basis`` and ``purchase_date=None`` (we don't know
+    when the operator originally bought; affects ST/LT classification — they
+    can hand-edit later if precision matters).
+
+    Args:
+        portfolio: Portfolio configuration to seed from when no state exists.
+        state_path: Filesystem path of the persisted state YAML.
+
+    Returns:
+        The loaded or freshly-seeded ``LiveState``.
+    """
+    if state_path.exists():
+        return load_state(state_path)
+
+    lots: dict[str, list[PositionLot]] = {}
+    for holding in portfolio.holdings:
+        if holding.shares <= 0:
+            continue
+        lots[holding.ticker] = [
+            PositionLot(
+                shares=holding.shares,
+                purchase_date=None,
+                cost_basis=holding.cost_basis if holding.cost_basis is not None else 0.0,
+            )
+        ]
+
+    state = LiveState(
+        available_cash=portfolio.available_cash,
+        cash_infusion_next_date=portfolio.cash_infusion.next_date if portfolio.cash_infusion else None,
+        high_water_marks={},
+        peak_equity=None,
+        lots=lots,
+    )
+    save_atomic(state, state_path)
+    logger.info("Seeded state at %s from portfolio config", state_path)
+    return state

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -161,11 +161,19 @@ def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
             )
         ]
 
+    # Seed peak_equity to starting equity so CPPI/drawdown calcs match backtest,
+    # which seeds state.peak_value = state.starting_value at _initialize_state.
+    # The YAML's cost_basis is the operator's basis — for live, that IS the
+    # starting equity baseline. Defensive ``> 0`` keeps zero/negative as None.
+    seed_equity = portfolio.available_cash + sum(
+        holding.shares * (holding.cost_basis or 0.0) for holding in portfolio.holdings if holding.shares > 0
+    )
+
     state = LiveState(
         available_cash=portfolio.available_cash,
         cash_infusion_next_date=portfolio.cash_infusion.next_date if portfolio.cash_infusion else None,
         high_water_marks={},
-        peak_equity=None,
+        peak_equity=seed_equity if seed_equity > 0 else None,
         lots=lots,
     )
     save_atomic(state, state_path)

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -208,15 +208,20 @@ def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
 class SellBreakdown:
     """Result of consuming lots FIFO for a sell.
 
-    Each pair (shares, share-weighted basis) is reported separately for the
-    short-term (held <365 days, or unknown purchase date) and long-term
-    (held >=365 days) buckets. Either bucket can be zero.
+    Reports shares and share-weighted cost basis separately for the short-term
+    (held <365 days, or unknown purchase date) and long-term (held >=365 days)
+    buckets. Either bucket may be zero. The ``*_weighted`` fields hold the raw
+    ``sum(take * cost_basis)`` accumulator, useful for callers that need bit-
+    identical reconstructions of total basis (since ``basis * shares`` is only
+    algebraically — not bit-identically — equal in IEEE-754).
     """
 
     st_shares: float
     st_basis: float
+    st_weighted: float
     lt_shares: float
     lt_basis: float
+    lt_weighted: float
 
 
 def aggregate_cost_basis(lots: Sequence[PositionLot]) -> float:
@@ -236,7 +241,14 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
     cost basis over the consumed slices.
     """
     if shares <= 0 or not lots:
-        return SellBreakdown(0.0, 0.0, 0.0, 0.0)
+        return SellBreakdown(
+            st_shares=0.0,
+            st_basis=0.0,
+            st_weighted=0.0,
+            lt_shares=0.0,
+            lt_basis=0.0,
+            lt_weighted=0.0,
+        )
 
     st_shares = 0.0
     st_weighted = 0.0
@@ -267,4 +279,11 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
 
     st_basis = st_weighted / st_shares if st_shares > 0 else 0.0
     lt_basis = lt_weighted / lt_shares if lt_shares > 0 else 0.0
-    return SellBreakdown(st_shares=st_shares, st_basis=st_basis, lt_shares=lt_shares, lt_basis=lt_basis)
+    return SellBreakdown(
+        st_shares=st_shares,
+        st_basis=st_basis,
+        st_weighted=st_weighted,
+        lt_shares=lt_shares,
+        lt_basis=lt_basis,
+        lt_weighted=lt_weighted,
+    )

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -287,3 +287,31 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
         lt_basis=lt_basis,
         lt_weighted=lt_weighted,
     )
+
+
+def apply_buy(state: LiveState, ticker: str, shares: float, price: float, day: date) -> None:
+    """Append a new lot for *ticker* and decrement cash by ``shares * price``.
+
+    Mutates *state* in place. Use after the live engine has emitted a buy
+    alert and the operator is assumed to have filled at *price*.
+    """
+    state.lots.setdefault(ticker, []).append(PositionLot(shares=shares, purchase_date=day, cost_basis=price))
+    state.available_cash -= shares * price
+
+
+def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: date) -> tuple[float, float]:
+    """Consume *shares* of *ticker* FIFO and increment cash by ``shares * price``.
+
+    Mutates *state* in place. Returns ``(st_realized_pnl, lt_realized_pnl)``
+    matching backtest's ST/LT classification (lots with purchase_date >=365
+    days before *day* count as long-term; everything else, including
+    ``purchase_date=None``, counts as short-term).
+    """
+    lots = state.lots.get(ticker, [])
+    breakdown = consume_lots_fifo(lots, shares, day)
+    state.available_cash += shares * price
+    if not lots:
+        state.lots.pop(ticker, None)
+    st_pnl = breakdown.st_shares * (price - breakdown.st_basis) if breakdown.st_shares > 0 else 0.0
+    lt_pnl = breakdown.lt_shares * (price - breakdown.lt_basis) if breakdown.lt_shares > 0 else 0.0
+    return st_pnl, lt_pnl

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -27,6 +27,12 @@ from midas.models import PortfolioConfig, PositionLot
 logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
+# When bumping SCHEMA_VERSION, add a migration path in ``load_state`` so
+# v1 files don't fail with ``StateFileError`` on first load after upgrade.
+# The simplest pattern: read the version, dispatch to a per-version
+# upgrader that returns the v(N) payload dict, then build ``LiveState``
+# from that. See the design spec at
+# ``docs/specs/2026-05-07-live-per-lot-tracking-design.md`` for context.
 
 
 class StateFileError(ValueError):
@@ -72,11 +78,28 @@ def save_atomic(state: LiveState, path: Path) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             yaml.safe_dump(payload, handle, sort_keys=False)
+            # fsync the tempfile so the data is on disk before the rename.
+            # Without this, ``os.replace`` is atomic w.r.t. the dirent but the
+            # data blocks may still be in page cache; a power-loss event can
+            # leave the canonical path pointing at unflushed bytes.
+            handle.flush()
+            os.fsync(handle.fileno())
         os.replace(tmp_name, path)
     except Exception:
         if os.path.exists(tmp_name):
             os.unlink(tmp_name)
         raise
+    # fsync the parent directory so the rename's dirent is durable. Best-
+    # effort: APFS / Windows treat this as a no-op or raise, which is fine —
+    # we still get the data fsync above.
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
 
 
 def load_state(path: Path) -> LiveState:
@@ -205,6 +228,20 @@ def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
                 holding.shares,
                 held,
             )
+        # Cost-basis drift surfaces hand-edits to portfolio.yaml that the
+        # operator likely intended to take effect. State wins (this is the
+        # documented policy — runtime fills are authoritative), so this is a
+        # warn-not-raise. The 1% relative tolerance ignores accumulated
+        # weighted-average drift after many fills against an unchanged YAML.
+        yaml_basis = holding.cost_basis if holding.cost_basis is not None else 0.0
+        state_basis = aggregate_cost_basis(lots)
+        if yaml_basis > 0 and state_basis > 0 and not math.isclose(yaml_basis, state_basis, rel_tol=0.01):
+            logger.warning(
+                "cost_basis drift: portfolio.yaml has %s=$%.4f but state weighted-avg is $%.4f; trusting state",
+                ticker,
+                yaml_basis,
+                state_basis,
+            )
     # Tolerate IEEE-754 round-trip noise that accumulates over many ticks; only
     # warn on drift that exceeds half a cent.
     if not math.isclose(portfolio.available_cash, state.available_cash, abs_tol=0.005):
@@ -328,6 +365,11 @@ def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: 
     state.available_cash += shares * price
     if not lots:
         state.lots.pop(ticker, None)
+        # Full exit also clears the per-ticker HWM so a future re-entry starts
+        # fresh against the new entry price, not a stale months-old peak.
+        # Mirrors backtest's ``state.high_water_marks.pop(ticker, None)`` on
+        # ``new_position == 0``.
+        state.high_water_marks.pop(ticker, None)
     st_pnl = breakdown.st_shares * price - breakdown.st_weighted
     lt_pnl = breakdown.lt_shares * price - breakdown.lt_weighted
     return st_pnl, lt_pnl

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -1,0 +1,117 @@
+"""Persistent runtime state for the live engine.
+
+After first seed, this state file is the runtime source of truth for
+positions, available cash, per-ticker HWM, peak equity, and the cash-
+infusion ``next_date``. The portfolio YAML continues to own everything
+else (tickers, strategies, allocation constraints, infusion amount/
+frequency, restrictions); see docs/specs/2026-05-07-live-per-lot-
+tracking-design.md.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from midas.models import PositionLot
+
+SCHEMA_VERSION = 1
+
+
+class StateFileError(ValueError):
+    """Raised on schema version mismatch, parse failure, or invalid state."""
+
+
+@dataclass
+class LiveState:
+    """Mutable runtime state persisted between live ticks."""
+
+    available_cash: float
+    cash_infusion_next_date: date | None
+    high_water_marks: dict[str, float] = field(default_factory=dict)
+    peak_equity: float | None = None
+    lots: dict[str, list[PositionLot]] = field(default_factory=dict)
+
+
+def save_atomic(state: LiveState, path: Path) -> None:
+    """Serialize *state* to *path* atomically (tempfile + os.replace)."""
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "last_updated": datetime.now(tz=UTC).replace(microsecond=0).isoformat(),
+        "available_cash": state.available_cash,
+        "cash_infusion": (
+            {"next_date": state.cash_infusion_next_date} if state.cash_infusion_next_date is not None else None
+        ),
+        "high_water_marks": dict(state.high_water_marks),
+        "peak_equity": state.peak_equity,
+        "lots": {
+            ticker: [
+                {
+                    "shares": lot.shares,
+                    "purchase_date": lot.purchase_date,
+                    "cost_basis": lot.cost_basis,
+                }
+                for lot in lots
+            ]
+            for ticker, lots in state.lots.items()
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False)
+        os.replace(tmp_name, path)
+    except Exception:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
+
+
+def load_state(path: Path) -> LiveState:
+    """Load state from *path*. Raises ``StateFileError`` on invalid input."""
+    try:
+        with open(path) as handle:
+            raw = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        msg = f"failed to parse state file at {path}: {exc}"
+        raise StateFileError(msg) from exc
+    if not isinstance(raw, dict):
+        msg = f"state file at {path} is not a YAML mapping"
+        raise StateFileError(msg)
+    version = raw.get("schema_version")
+    if version != SCHEMA_VERSION:
+        msg = f"unsupported state version {version!r} in {path}; expected {SCHEMA_VERSION}"
+        raise StateFileError(msg)
+
+    infusion = raw.get("cash_infusion")
+    next_date: date | None = None
+    if infusion is not None:
+        next_date = infusion.get("next_date")
+        if isinstance(next_date, str):
+            next_date = date.fromisoformat(next_date)
+
+    lots: dict[str, list[PositionLot]] = {}
+    for ticker, entries in (raw.get("lots") or {}).items():
+        lots[ticker] = [
+            PositionLot(
+                shares=float(entry["shares"]),
+                purchase_date=entry.get("purchase_date"),
+                cost_basis=float(entry["cost_basis"]),
+            )
+            for entry in entries
+        ]
+
+    return LiveState(
+        available_cash=float(raw["available_cash"]),
+        cash_infusion_next_date=next_date,
+        high_water_marks={k: float(v) for k, v in (raw.get("high_water_marks") or {}).items()},
+        peak_equity=raw.get("peak_equity"),
+        lots=lots,
+    )

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -312,6 +312,6 @@ def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: 
     state.available_cash += shares * price
     if not lots:
         state.lots.pop(ticker, None)
-    st_pnl = breakdown.st_shares * (price - breakdown.st_basis) if breakdown.st_shares > 0 else 0.0
-    lt_pnl = breakdown.lt_shares * (price - breakdown.lt_basis) if breakdown.lt_shares > 0 else 0.0
+    st_pnl = breakdown.st_shares * price - breakdown.st_weighted
+    lt_pnl = breakdown.lt_shares * price - breakdown.lt_weighted
     return st_pnl, lt_pnl

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -11,6 +11,7 @@ tracking-design.md.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import tempfile
 from collections.abc import Sequence
@@ -204,7 +205,9 @@ def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
                 holding.shares,
                 held,
             )
-    if portfolio.available_cash != state.available_cash:
+    # Tolerate IEEE-754 round-trip noise that accumulates over many ticks; only
+    # warn on drift that exceeds half a cent.
+    if not math.isclose(portfolio.available_cash, state.available_cash, abs_tol=0.005):
         logger.warning(
             "available_cash drift: portfolio.yaml has %s but state has %s; trusting state",
             portfolio.available_cash,
@@ -317,6 +320,11 @@ def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: 
     """
     lots = state.lots.get(ticker, [])
     breakdown = consume_lots_fifo(lots, shares, day)
+    total_consumed = breakdown.st_shares + breakdown.lt_shares
+    # Mirrors backtest's ``assert new_position >= 0`` invariant: oversells must
+    # be clamped upstream by ``OrderSizer.size_sells``. ``math.isclose`` tolerates
+    # IEEE-754 drift while still catching genuine bugs.
+    assert math.isclose(total_consumed, shares), f"oversell on {ticker}: requested {shares}, consumed {total_consumed}"
     state.available_cash += shares * price
     if not lots:
         state.lots.pop(ticker, None)

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -201,3 +202,69 @@ def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
             portfolio.available_cash,
             state.available_cash,
         )
+
+
+@dataclass(frozen=True)
+class SellBreakdown:
+    """Result of consuming lots FIFO for a sell.
+
+    Each pair (shares, share-weighted basis) is reported separately for the
+    short-term (held <365 days, or unknown purchase date) and long-term
+    (held >=365 days) buckets. Either bucket can be zero.
+    """
+
+    st_shares: float
+    st_basis: float
+    lt_shares: float
+    lt_basis: float
+
+
+def aggregate_cost_basis(lots: Sequence[PositionLot]) -> float:
+    """Share-weighted average cost basis across all open lots, or 0.0 if empty."""
+    total_shares = sum(lot.shares for lot in lots)
+    if total_shares <= 0:
+        return 0.0
+    return sum(lot.shares * lot.cost_basis for lot in lots) / total_shares
+
+
+def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> SellBreakdown:
+    """Consume *shares* from *lots* in FIFO order, mutating in place.
+
+    Lots whose ``purchase_date`` is at least 365 days before *day* contribute
+    to the long-term bucket; everything else (including ``purchase_date=None``)
+    goes to the short-term bucket. Each bucket reports a share-weighted
+    cost basis over the consumed slices.
+    """
+    if shares <= 0 or not lots:
+        return SellBreakdown(0.0, 0.0, 0.0, 0.0)
+
+    st_shares = 0.0
+    st_weighted = 0.0
+    lt_shares = 0.0
+    lt_weighted = 0.0
+    remaining = shares
+    while remaining > 0 and lots:
+        lot = lots[0]
+        take = min(lot.shares, remaining)
+        is_long_term = lot.purchase_date is not None and (day - lot.purchase_date).days >= 365
+        if is_long_term:
+            lt_shares += take
+            lt_weighted += take * lot.cost_basis
+        else:
+            st_shares += take
+            st_weighted += take * lot.cost_basis
+
+        if lot.shares <= remaining:
+            remaining -= lot.shares
+            lots.pop(0)
+        else:
+            lots[0] = PositionLot(
+                shares=lot.shares - remaining,
+                purchase_date=lot.purchase_date,
+                cost_basis=lot.cost_basis,
+            )
+            remaining = 0
+
+    st_basis = st_weighted / st_shares if st_shares > 0 else 0.0
+    lt_basis = lt_weighted / lt_shares if lt_shares > 0 else 0.0
+    return SellBreakdown(st_shares=st_shares, st_basis=st_basis, lt_shares=lt_shares, lt_basis=lt_basis)

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -131,6 +131,11 @@ def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
     when the operator originally bought; affects ST/LT classification — they
     can hand-edit later if precision matters).
 
+    On subsequent loads, warns if the YAML aggregates disagree with state
+    (the state file wins). Refuses to start if the portfolio no longer lists
+    a ticker for which lots are still held — that's almost certainly a config
+    mistake.
+
     Args:
         portfolio: Portfolio configuration to seed from when no state exists.
         state_path: Filesystem path of the persisted state YAML.
@@ -139,7 +144,9 @@ def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
         The loaded or freshly-seeded ``LiveState``.
     """
     if state_path.exists():
-        return load_state(state_path)
+        state = load_state(state_path)
+        _check_for_drift(state, portfolio)
+        return state
 
     lots: dict[str, list[PositionLot]] = {}
     for holding in portfolio.holdings:
@@ -163,3 +170,34 @@ def load_or_seed(portfolio: PortfolioConfig, state_path: Path) -> LiveState:
     save_atomic(state, state_path)
     logger.info("Seeded state at %s from portfolio config", state_path)
     return state
+
+
+def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
+    """Warn on aggregate drift; raise if a held ticker has no Holding."""
+    yaml_tickers = {holding.ticker for holding in portfolio.holdings}
+    for ticker, lots in state.lots.items():
+        held = sum(lot.shares for lot in lots)
+        if held <= 0:
+            continue
+        if ticker not in yaml_tickers:
+            msg = (
+                f"ticker {ticker} is held in state ({held} shares) but not "
+                f"listed in portfolio.yaml; refusing to start. Either restore "
+                f"the holding entry or close out the position in state."
+            )
+            raise StateFileError(msg)
+        holding = portfolio.get_holding(ticker)
+        assert holding is not None  # guarded by yaml_tickers membership
+        if holding.shares != held:
+            logger.warning(
+                "share drift: portfolio.yaml has %s=%s but state has %s; trusting state",
+                ticker,
+                holding.shares,
+                held,
+            )
+    if portfolio.available_cash != state.available_cash:
+        logger.warning(
+            "available_cash drift: portfolio.yaml has %s but state has %s; trusting state",
+            portfolio.available_cash,
+            state.available_cash,
+        )

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -221,7 +221,9 @@ def _check_for_drift(state: LiveState, portfolio: PortfolioConfig) -> None:
             raise StateFileError(msg)
         holding = portfolio.get_holding(ticker)
         assert holding is not None  # guarded by yaml_tickers membership
-        if holding.shares != held:
+        # Tolerate IEEE-754 round-trip noise from accumulated fractional fills;
+        # only warn on share counts that differ by more than 1e-6.
+        if not math.isclose(holding.shares, held, abs_tol=1e-6):
             logger.warning(
                 "share drift: portfolio.yaml has %s=%s but state has %s; trusting state",
                 ticker,

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -35,6 +35,19 @@ SCHEMA_VERSION = 1
 # ``docs/specs/2026-05-07-live-per-lot-tracking-design.md`` for context.
 
 
+class _NoAliasSafeDumper(yaml.SafeDumper):
+    """SafeDumper that emits inline values instead of anchors and aliases.
+
+    PyYAML auto-generates ``&id001`` / ``*id001`` for repeated Python
+    objects (e.g. multiple lots sharing the same ``date`` instance). Valid
+    YAML but unfriendly for humans hand-editing the state file. This
+    dumper writes each occurrence inline.
+    """
+
+
+_NoAliasSafeDumper.ignore_aliases = lambda self, data: True  # type: ignore[method-assign]
+
+
 class StateFileError(ValueError):
     """Raised on schema version mismatch, parse failure, or invalid state."""
 
@@ -77,7 +90,7 @@ def save_atomic(state: LiveState, path: Path) -> None:
     fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            yaml.safe_dump(payload, handle, sort_keys=False)
+            yaml.dump(payload, handle, Dumper=_NoAliasSafeDumper, sort_keys=False)
             # fsync the tempfile so the data is on disk before the rename.
             # Without this, ``os.replace`` is atomic w.r.t. the dirent but the
             # data blocks may still be in page cache; a power-loss event can

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from enum import Enum
+from pathlib import Path
 
 DEFAULT_MIN_CASH_PCT = 0.05
 DEFAULT_MIN_BUY_DELTA = 0.02
@@ -72,6 +73,7 @@ class PortfolioConfig:
     available_cash: float
     cash_infusion: CashInfusion | None = None
     trading_restrictions: TradingRestrictions | None = None
+    state_file: Path | None = None
 
     def __post_init__(self) -> None:
         self._by_ticker = {holding.ticker: holding for holding in self.holdings}

--- a/tests/test_cli_live.py
+++ b/tests/test_cli_live.py
@@ -1,0 +1,60 @@
+"""End-to-end smoke test for the live CLI command's state-path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from midas.cli import cli
+
+
+def test_live_command_uses_sidecar_state_path_by_default(tmp_path: Path) -> None:
+    portfolio_yaml = tmp_path / "portfolio.yaml"
+    portfolio_yaml.write_text(
+        "portfolio:\n  - ticker: AAPL\n    shares: 10\n    cost_basis: 150\navailable_cash: 1000\n"
+    )
+
+    captured: dict[str, Path] = {}
+
+    class _StubEngine:
+        def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
+            captured["state_path"] = state_path
+
+        def run(self) -> None:
+            return
+
+    with patch("midas.live.LiveEngine", _StubEngine):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["live", "-p", str(portfolio_yaml), "--dry-run"])
+        assert result.exit_code == 0, result.output
+    assert captured["state_path"] == portfolio_yaml.with_suffix(".state.yaml")
+
+
+def test_live_command_honors_state_file_field(tmp_path: Path) -> None:
+    state_target = tmp_path / "run" / "explicit.state.yaml"
+    portfolio_yaml = tmp_path / "portfolio.yaml"
+    portfolio_yaml.write_text(
+        f"state_file: {state_target}\n"
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 10\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+
+    captured: dict[str, Path] = {}
+
+    class _StubEngine:
+        def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
+            captured["state_path"] = state_path
+
+        def run(self) -> None:
+            return
+
+    with patch("midas.live.LiveEngine", _StubEngine):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["live", "-p", str(portfolio_yaml), "--dry-run"])
+        assert result.exit_code == 0, result.output
+    assert captured["state_path"] == state_target

--- a/tests/test_cli_live.py
+++ b/tests/test_cli_live.py
@@ -22,6 +22,12 @@ def test_live_command_uses_sidecar_state_path_by_default(tmp_path: Path) -> None
         def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
             captured["state_path"] = state_path
 
+        def __enter__(self) -> _StubEngine:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
         def run(self) -> None:
             return
 
@@ -49,6 +55,12 @@ def test_live_command_honors_state_file_field(tmp_path: Path) -> None:
     class _StubEngine:
         def __init__(self, *args: object, state_path: Path, **kwargs: object) -> None:
             captured["state_path"] = state_path
+
+        def __enter__(self) -> _StubEngine:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            return None
 
         def run(self) -> None:
             return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,27 @@ def test_load_portfolio_minimal(tmp_path: Path) -> None:
     assert port.available_cash == 1000.0
 
 
+def test_load_portfolio_parses_state_file_field(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text(
+        "state_file: ./run/portfolio.state.yaml\n"
+        "portfolio:\n"
+        "  - ticker: AAPL\n"
+        "    shares: 100\n"
+        "    cost_basis: 150\n"
+        "available_cash: 1000\n"
+    )
+    portfolio = load_portfolio(yaml_path)
+    assert portfolio.state_file == Path("./run/portfolio.state.yaml")
+
+
+def test_load_portfolio_state_file_field_optional(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "portfolio.yaml"
+    yaml_path.write_text("portfolio:\n  - ticker: AAPL\n    shares: 100\n    cost_basis: 150\navailable_cash: 1000\n")
+    portfolio = load_portfolio(yaml_path)
+    assert portfolio.state_file is None
+
+
 def test_load_strategies(strategy_yaml: Path) -> None:
     configs, constraints, _risk = load_strategies(strategy_yaml)
     assert len(configs) == 3

--- a/tests/test_live_backtest_parity.py
+++ b/tests/test_live_backtest_parity.py
@@ -6,7 +6,10 @@ peak equity, and available cash agree at the end of the run.
 
 The simplest version uses no strategies and no exit rules — both engines
 just track time, prices, and the seed position. This isolates the state-
-evolution mechanics from any strategy-driven order flow.
+evolution mechanics from any strategy-driven order flow. Note that with
+no order flow, lot-consumption parity (FIFO/LIFO accounting under sells)
+is not exercised end-to-end here — that requires the strategy-driven
+follow-up.
 
 Notes on alignment:
 
@@ -197,9 +200,13 @@ def test_no_action_state_evolution_matches_backtest(
     for current_day in prices.index:
         provider = _make_provider_for_window(prices, ticker, current_day)
 
-        # Bind ``current_day`` as a class attribute so a static ``today()`` returns
-        # the loop's current value (closing over the loop variable would trip
-        # ruff's B023 and also be functionally incorrect for late-bound lookups).
+        # Stub ``date.today()`` to return the current loop bar so live's
+        # ``_tick`` sees the same "today" the backtest's day-T decision is
+        # comparing against. We use a class attribute (not a closure over
+        # ``current_day``) to satisfy ruff's B023 check on loop-variable
+        # capture. The stub is intentionally narrow: it overrides only
+        # ``today()``, not the ``date`` constructor — ``_tick`` doesn't
+        # call other ``date`` factories.
         class FakeDate:
             value: date = current_day
 
@@ -222,14 +229,57 @@ def test_no_action_state_evolution_matches_backtest(
     final_live = load_state(state_path)
 
     # ---- Compare ---------------------------------------------------------
-    bt_lots = bt_state.lots[ticker]
-    live_lots = final_live.lots[ticker]
-    assert len(bt_lots) == len(live_lots)
-    for bt_lot, live_lot in zip(bt_lots, live_lots, strict=True):
-        assert bt_lot.shares == pytest.approx(live_lot.shares)
-        assert bt_lot.cost_basis == pytest.approx(live_lot.cost_basis)
-        assert bt_lot.purchase_date == live_lot.purchase_date
+    # Build comparable summaries from each engine's final state so any
+    # divergence is reported with the field, the ticker, and both values.
+    bt_summary = {
+        "lots": {
+            tk: [(lot.shares, lot.purchase_date, lot.cost_basis) for lot in lots] for tk, lots in bt_state.lots.items()
+        },
+        "hwm": dict(bt_state.high_water_marks),
+        "peak": bt_state.peak_value,
+        "cash": bt_state.cash,
+    }
+    live_summary = {
+        "lots": {
+            tk: [(lot.shares, lot.purchase_date, lot.cost_basis) for lot in lots]
+            for tk, lots in final_live.lots.items()
+        },
+        "hwm": dict(final_live.high_water_marks),
+        "peak": final_live.peak_equity,
+        "cash": final_live.available_cash,
+    }
 
-    assert bt_state.high_water_marks[ticker] == pytest.approx(final_live.high_water_marks[ticker])
-    assert bt_state.peak_value == pytest.approx(final_live.peak_equity)
-    assert bt_state.cash == pytest.approx(final_live.available_cash)
+    assert bt_summary["lots"].keys() == live_summary["lots"].keys(), (
+        f"lot tickers diverge: backtest={set(bt_summary['lots'])}, live={set(live_summary['lots'])}"
+    )
+    for tk in bt_summary["lots"]:
+        bt_lots = bt_summary["lots"][tk]
+        live_lots = live_summary["lots"][tk]
+        assert len(bt_lots) == len(live_lots), (
+            f"{tk}: lot count diverges: backtest={len(bt_lots)}, live={len(live_lots)}"
+        )
+        for idx, (bt_lot, live_lot) in enumerate(zip(bt_lots, live_lots, strict=True)):
+            assert bt_lot[0] == pytest.approx(live_lot[0]), (
+                f"{tk} lot {idx}: shares diverge: backtest={bt_lot[0]}, live={live_lot[0]}"
+            )
+            assert bt_lot[1] == live_lot[1], (
+                f"{tk} lot {idx}: purchase_date diverges: backtest={bt_lot[1]}, live={live_lot[1]}"
+            )
+            assert bt_lot[2] == pytest.approx(live_lot[2]), (
+                f"{tk} lot {idx}: cost_basis diverges: backtest={bt_lot[2]}, live={live_lot[2]}"
+            )
+
+    assert bt_summary["hwm"].keys() == live_summary["hwm"].keys(), (
+        f"HWM tickers diverge: backtest={set(bt_summary['hwm'])}, live={set(live_summary['hwm'])}"
+    )
+    for tk, bt_hwm in bt_summary["hwm"].items():
+        assert bt_hwm == pytest.approx(live_summary["hwm"][tk]), (
+            f"{tk}: HWM diverges: backtest={bt_hwm}, live={live_summary['hwm'][tk]}"
+        )
+
+    assert bt_summary["peak"] == pytest.approx(live_summary["peak"]), (
+        f"peak diverges: backtest.peak_value={bt_summary['peak']}, live.peak_equity={live_summary['peak']}"
+    )
+    assert bt_summary["cash"] == pytest.approx(live_summary["cash"]), (
+        f"cash diverges: backtest.cash={bt_summary['cash']}, live.available_cash={live_summary['cash']}"
+    )

--- a/tests/test_live_backtest_parity.py
+++ b/tests/test_live_backtest_parity.py
@@ -48,6 +48,7 @@ from midas.models import (
 )
 from midas.order_sizer import OrderSizer
 from midas.results import BacktestResult
+from midas.strategies.stop_loss import StopLoss
 
 
 def _build_price_frame(start: date, n_bars: int, seed: int = 42) -> pd.DataFrame:
@@ -224,7 +225,13 @@ def test_no_action_state_evolution_matches_backtest(
             state_path=state_path,
             history_days=n_bars * 2,
         )
-        live_engine._tick([ticker])
+        try:
+            live_engine._tick([ticker])
+        finally:
+            # Release the state lockfile so the next loop iteration's engine
+            # can reacquire it. In production a single engine lives for the
+            # whole process; this teardown is test-only.
+            live_engine.close()
 
     final_live = load_state(state_path)
 
@@ -282,4 +289,131 @@ def test_no_action_state_evolution_matches_backtest(
     )
     assert bt_summary["cash"] == pytest.approx(live_summary["cash"]), (
         f"cash diverges: backtest.cash={bt_summary['cash']}, live.available_cash={live_summary['cash']}"
+    )
+
+
+def _build_drop_price_frame(start: date, n_bars: int, drop_at: int, drop_pct: float) -> pd.DataFrame:
+    """Flat-then-drop OHLCV frame: ``drop_pct`` decline at bar ``drop_at``.
+
+    Deterministic — no randomness — so the test asserts exact equivalence
+    rather than tolerance windows.
+    """
+    closes = np.full(n_bars, 100.0)
+    closes[drop_at:] = 100.0 * (1.0 - drop_pct)
+    dates: list[date] = []
+    current = start
+    while len(dates) < n_bars:
+        if current.weekday() < 5:
+            dates.append(current)
+        current += timedelta(days=1)
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": np.full(n_bars, 1_000_000.0),
+        },
+        index=dates,
+    )
+
+
+def test_stoploss_sell_state_evolution_matches_backtest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both engines execute the same StopLoss sell and end with matching state.
+
+    Drives a price drop large enough to trigger ``StopLoss(loss_threshold=0.10)``
+    on a held position. Asserts the resulting lot list (empty after full exit),
+    cash (credited with sale proceeds), HWM (cleared on full exit), and peak
+    equity all match between backtest and live. The earlier no-action parity
+    test only exercises HWM/peak ratchets; this one exercises the order
+    sizer, FIFO consumption, and the on-exit cleanup invariants — the actual
+    plumbing that makes the two engines comparable in real use.
+    """
+    ticker = "AAPL"
+    shares = 10.0
+    cash = 0.0
+    n_bars = 20
+    drop_at = 5
+    start = date(2026, 1, 5)
+    prices = _build_drop_price_frame(start, n_bars, drop_at, drop_pct=0.20)
+    seed_day = prices.index[0]
+    seed_close = float(prices["close"].iloc[0])
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker=ticker, shares=shares, cost_basis=seed_close)],
+        available_cash=cash,
+    )
+    constraints = AllocationConstraints()
+
+    # ---- Backtest --------------------------------------------------------
+    bt_engine = _CapturingBacktestEngine(
+        allocator=Allocator(entries=[], constraints=constraints, n_tickers=1),
+        order_sizer=OrderSizer(),
+        exit_rules=[StopLoss(loss_threshold=0.10)],
+        constraints=constraints,
+        enable_split=False,
+        execution_mode="close",  # Avoid next-day fill lag for cleaner parity.
+    )
+    bt_engine.run(portfolio, {ticker: prices}, prices.index[0], prices.index[-1])
+    bt_state = bt_engine.captured_state
+    assert bt_state is not None
+    assert bt_state.positions.get(ticker, 0) == 0, "backtest should fully exit on StopLoss"
+
+    # ---- Live ------------------------------------------------------------
+    state_path = tmp_path / "state.yaml"
+    _seed_state_to_match_backtest(
+        state_path=state_path,
+        ticker=ticker,
+        shares=shares,
+        seed_close=seed_close,
+        seed_day=seed_day,
+        cash=cash,
+    )
+
+    for current_day in prices.index:
+        provider = _make_provider_for_window(prices, ticker, current_day)
+
+        class FakeDate:
+            value: date = current_day
+
+            @staticmethod
+            def today() -> date:
+                return FakeDate.value
+
+        monkeypatch.setattr("midas.live.date", FakeDate)
+
+        live_engine = LiveEngine(
+            portfolio=portfolio,
+            allocator=Allocator(entries=[], constraints=constraints, n_tickers=1),
+            order_sizer=OrderSizer(),
+            provider=provider,
+            state_path=state_path,
+            exit_rules=[StopLoss(loss_threshold=0.10)],
+            constraints=constraints,
+            history_days=n_bars * 2,
+        )
+        try:
+            live_engine._tick([ticker])
+        finally:
+            live_engine.close()
+
+    final_live = load_state(state_path)
+
+    # ---- Compare ---------------------------------------------------------
+    assert ticker not in final_live.lots, "live should empty lots after full exit"
+    # HWM clear-on-exit invariant: backtest pops state.high_water_marks on
+    # full exit at backtest.py:_execute. Live now does the same in
+    # apply_sell — this asserts the symmetry.
+    assert ticker not in final_live.high_water_marks, (
+        "live should clear HWM on full exit (regression for the C2 leak the reviewer flagged)"
+    )
+    assert bt_state.cash == pytest.approx(final_live.available_cash), (
+        f"cash diverges after StopLoss sell: backtest={bt_state.cash}, live={final_live.available_cash}"
+    )
+    # Peak must match — both engines saw the same equity trajectory.
+    assert bt_state.peak_value == pytest.approx(final_live.peak_equity), (
+        f"peak diverges: backtest.peak_value={bt_state.peak_value}, live.peak_equity={final_live.peak_equity}"
     )

--- a/tests/test_live_backtest_parity.py
+++ b/tests/test_live_backtest_parity.py
@@ -1,0 +1,235 @@
+"""Bar-for-bar parity between the backtest and live engines.
+
+Drives a deterministic synthetic price series through both the backtest and
+the live engine (with a fake DataProvider). Asserts that lot lists, HWMs,
+peak equity, and available cash agree at the end of the run.
+
+The simplest version uses no strategies and no exit rules — both engines
+just track time, prices, and the seed position. This isolates the state-
+evolution mechanics from any strategy-driven order flow.
+
+Notes on alignment:
+
+- The backtest's ``_init_positions`` reseeds each holding's cost basis to
+  the day-0 close (so exit rules don't fire on pre-backtest gains). The
+  live engine's ``load_or_seed`` uses the YAML cost basis. We pre-seed
+  the live state YAML on disk to match the backtest's seed exactly,
+  isolating state-evolution mechanics from seeding policy.
+- The backtest uses ``execution_mode="next_open"`` (lag=1) by default,
+  but with no strategies and no exit rules there are no decisions and
+  no fills, so the lag is a no-op and both engines reduce to the same
+  "track HWM/peak across closes" loop.
+- ``date.today()`` is monkeypatched per tick so the live engine sees the
+  same calendar day as the backtest's current bar.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from midas.allocator import Allocator
+from midas.backtest import BacktestEngine, _SimState
+from midas.live import LiveEngine
+from midas.live_state import LiveState, load_state, save_atomic
+from midas.models import (
+    AllocationConstraints,
+    Holding,
+    PortfolioConfig,
+    PositionLot,
+)
+from midas.order_sizer import OrderSizer
+from midas.results import BacktestResult
+
+
+def _build_price_frame(start: date, n_bars: int, seed: int = 42) -> pd.DataFrame:
+    """Deterministic synthetic OHLCV frame indexed by business days."""
+    rng = np.random.default_rng(seed)
+    closes = 100.0 * np.exp(np.cumsum(rng.normal(0.0, 0.01, n_bars)))
+    dates: list[date] = []
+    current = start
+    while len(dates) < n_bars:
+        if current.weekday() < 5:
+            dates.append(current)
+        current += timedelta(days=1)
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": np.full(n_bars, 1_000_000.0),
+        },
+        index=dates,
+    )
+
+
+class _CapturingBacktestEngine(BacktestEngine):
+    """Subclass that stashes the final ``_SimState`` for test inspection.
+
+    ``BacktestEngine.run`` builds state internally and only returns a
+    ``BacktestResult`` summary. We need the raw lot list, HWMs, peak,
+    and cash to compare against ``LiveState`` — capture them via
+    ``_build_result``, the last hook the engine calls before returning.
+    """
+
+    captured_state: _SimState | None = None
+
+    def _build_result(
+        self,
+        state: _SimState,
+        portfolio: PortfolioConfig,
+        price_data: dict[str, pd.DataFrame],
+        trading_days: list[date],
+        split_date: date | None,
+    ) -> BacktestResult:
+        self.captured_state = state
+        return super()._build_result(state, portfolio, price_data, trading_days, split_date)
+
+
+def _make_provider_for_window(
+    prices: pd.DataFrame,
+    ticker: str,
+    upto: date,
+) -> MagicMock:
+    """Build a fake provider returning *prices* sliced to ``index <= upto``."""
+    provider = MagicMock()
+
+    def get_history(ticker_arg: str, start: date, end: date) -> pd.DataFrame:
+        if ticker_arg != ticker:
+            msg = f"unexpected ticker {ticker_arg!r}"
+            raise KeyError(msg)
+        return prices[prices.index <= upto]
+
+    provider.get_history.side_effect = get_history
+    return provider
+
+
+def _seed_state_to_match_backtest(
+    state_path: Path,
+    ticker: str,
+    shares: float,
+    seed_close: float,
+    seed_day: date,
+    cash: float,
+) -> None:
+    """Pre-seed the live state YAML to mirror backtest's ``_init_positions``.
+
+    Backtest reseeds the seed lot's cost basis to the day-0 close and uses
+    ``trading_days[0]`` as ``purchase_date``; live's default ``load_or_seed``
+    uses the YAML basis with ``purchase_date=None``. We write the matching
+    seed straight to disk so the engine loads it on construction.
+    """
+    seeded = LiveState(
+        available_cash=cash,
+        cash_infusion_next_date=None,
+        high_water_marks={ticker: seed_close},
+        peak_equity=cash + shares * seed_close,
+        lots={
+            ticker: [
+                PositionLot(shares=shares, purchase_date=seed_day, cost_basis=seed_close),
+            ]
+        },
+    )
+    save_atomic(seeded, state_path)
+
+
+def test_no_action_state_evolution_matches_backtest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no strategies and no exit rules, both engines should converge on
+    the same final state for a held position over a fixed price series.
+
+    The backtest's ``_init_positions`` rewrites the seed lot's cost basis to
+    the day-0 close and stamps ``purchase_date=trading_days[0]``. We pre-seed
+    the live state file with that same lot so any divergence is purely from
+    state evolution (HWM, peak, cash), not from differing seeding policy.
+    """
+    ticker = "AAPL"
+    shares = 10.0
+    cash = 0.0
+    n_bars = 30
+    start = date(2026, 1, 5)
+    prices = _build_price_frame(start, n_bars)
+    seed_day = prices.index[0]
+    seed_close = float(prices["close"].iloc[0])
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker=ticker, shares=shares, cost_basis=seed_close)],
+        available_cash=cash,
+    )
+
+    # ---- Backtest --------------------------------------------------------
+    bt_allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+    bt_engine = _CapturingBacktestEngine(
+        allocator=bt_allocator,
+        order_sizer=OrderSizer(),
+        exit_rules=[],
+        constraints=AllocationConstraints(),
+        enable_split=False,
+    )
+    bt_engine.run(portfolio, {ticker: prices}, prices.index[0], prices.index[-1])
+    bt_state = bt_engine.captured_state
+    assert bt_state is not None
+
+    # ---- Live ------------------------------------------------------------
+    state_path = tmp_path / "state.yaml"
+    _seed_state_to_match_backtest(
+        state_path=state_path,
+        ticker=ticker,
+        shares=shares,
+        seed_close=seed_close,
+        seed_day=seed_day,
+        cash=cash,
+    )
+
+    # The live engine constructs its provider once at __init__, but the
+    # provider's slice depends on each tick's date — we rebuild the engine
+    # per tick with a provider whose ``get_history`` returns prices through
+    # the current day. (Construction is cheap and idempotent because the
+    # state file persists across invocations.)
+    for current_day in prices.index:
+        provider = _make_provider_for_window(prices, ticker, current_day)
+
+        # Bind ``current_day`` as a class attribute so a static ``today()`` returns
+        # the loop's current value (closing over the loop variable would trip
+        # ruff's B023 and also be functionally incorrect for late-bound lookups).
+        class FakeDate:
+            value: date = current_day
+
+            @staticmethod
+            def today() -> date:
+                return FakeDate.value
+
+        monkeypatch.setattr("midas.live.date", FakeDate)
+
+        live_engine = LiveEngine(
+            portfolio=portfolio,
+            allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+            order_sizer=OrderSizer(),
+            provider=provider,
+            state_path=state_path,
+            history_days=n_bars * 2,
+        )
+        live_engine._tick([ticker])
+
+    final_live = load_state(state_path)
+
+    # ---- Compare ---------------------------------------------------------
+    bt_lots = bt_state.lots[ticker]
+    live_lots = final_live.lots[ticker]
+    assert len(bt_lots) == len(live_lots)
+    for bt_lot, live_lot in zip(bt_lots, live_lots, strict=True):
+        assert bt_lot.shares == pytest.approx(live_lot.shares)
+        assert bt_lot.cost_basis == pytest.approx(live_lot.cost_basis)
+        assert bt_lot.purchase_date == live_lot.purchase_date
+
+    assert bt_state.high_water_marks[ticker] == pytest.approx(final_live.high_water_marks[ticker])
+    assert bt_state.peak_value == pytest.approx(final_live.peak_equity)
+    assert bt_state.cash == pytest.approx(final_live.available_cash)

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -14,6 +14,7 @@ from midas.live import LiveEngine
 from midas.live_state import LiveState, aggregate_cost_basis, load_state, save_atomic
 from midas.models import (
     AllocationConstraints,
+    CashInfusion,
     Holding,
     PortfolioConfig,
     PositionLot,
@@ -132,3 +133,77 @@ def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path) -> None:
     # And after a tick, HWM should advance to 150.0 (the close).
     engine._tick(["AAPL"])
     assert engine._state.high_water_marks["AAPL"] == 150.0
+
+
+def test_peak_equity_advances_and_persists(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    assert state.peak_equity == pytest.approx(10 * 200.0)
+
+
+def test_state_is_persisted_to_disk_each_tick(tmp_path: Path) -> None:
+    """Even on a no-op tick (no orders), HWM and peak advance get saved."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    on_disk = load_state(state_path)
+    assert on_disk.high_water_marks["AAPL"] == 150.0
+    assert on_disk.peak_equity == pytest.approx(10 * 150.0)
+
+
+def test_cash_infusion_advances_when_due(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If today >= cash_infusion.next_date, cash increases by amount and
+    next_date advances."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=500.0,
+        cash_infusion=CashInfusion(amount=1500.0, next_date=date(2026, 5, 1), frequency="biweekly"),
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Patch date.today() to 2026-05-07 (past next_date 2026-05-01).
+    class _FakeDate:
+        @staticmethod
+        def today() -> date:
+            return date(2026, 5, 7)
+
+    monkeypatch.setattr("midas.live.date", _FakeDate)
+    engine._tick(["AAPL"])
+
+    state = load_state(state_path)
+    assert state.available_cash == pytest.approx(500.0 + 1500.0)
+    assert state.cash_infusion_next_date == date(2026, 5, 15)  # +14 days for biweekly

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -1,0 +1,71 @@
+"""Integration tests for LiveEngine driving LiveState across ticks."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from midas.allocator import Allocator
+from midas.live import LiveEngine
+from midas.live_state import load_state
+from midas.models import (
+    AllocationConstraints,
+    Holding,
+    PortfolioConfig,
+)
+from midas.order_sizer import OrderSizer
+
+
+def _make_provider(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
+    """Build a fake DataProvider returning an OHLCV frame for each ticker."""
+    provider = MagicMock()
+
+    def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
+        closes = prices[ticker]
+        return pd.DataFrame(
+            {
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "volume": [1000.0] * len(closes),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
+        )
+
+    provider.get_history.side_effect = get_history
+    return provider
+
+
+@pytest.fixture
+def basic_portfolio() -> PortfolioConfig:
+    return PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+
+
+def test_live_engine_seeds_state_on_first_construction(basic_portfolio: PortfolioConfig, tmp_path: Path) -> None:
+    state_path = tmp_path / "portfolio.state.yaml"
+    assert not state_path.exists()
+
+    allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+    sizer = OrderSizer()
+    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+
+    LiveEngine(
+        portfolio=basic_portfolio,
+        allocator=allocator,
+        order_sizer=sizer,
+        provider=provider,
+        state_path=state_path,
+    )
+
+    assert state_path.exists()
+    state = load_state(state_path)
+    assert state.available_cash == 1000.0
+    assert "AAPL" in state.lots

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -317,6 +317,67 @@ def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path) -> None:
     assert captured_kwargs["current_drawdown"] == pytest.approx(0.6)
 
 
+def test_peak_equity_survives_engine_restart_and_drives_drawdown(tmp_path: Path) -> None:
+    """Tick A advances peak via the engine's own logic, then a fresh engine
+    constructed from the same state path reads peak from disk and the next
+    tick's current_drawdown reflects the persisted value.
+
+    Without persistence, the second engine would re-seed peak from the YAML's
+    seed_equity and compute drawdown=0.0 on the same total_value that was a
+    real drawdown vs the persisted peak. Same dead-code-shape as the original
+    C1 finding (peak_equity wired but never restored across processes).
+    """
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+
+    # Tick A: price at 200 → equity at $2000, peak ratchets to $2000.
+    provider_a = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    engine_a = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider_a,
+        state_path=state_path,
+    )
+    engine_a._tick(["AAPL"])
+    persisted_peak = engine_a._state.peak_equity
+    engine_a.close()
+
+    # On disk the peak should now be $2000 (state was written by tick A).
+    on_disk = load_state(state_path)
+    assert on_disk.peak_equity == pytest.approx(2000.0)
+    assert persisted_peak == pytest.approx(2000.0)
+
+    # Tick B: fresh engine, lower price → current_drawdown reflects the persisted peak.
+    captured: dict[str, float] = {}
+    allocator_b = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+    original_allocate = allocator_b.allocate
+
+    def capturing_allocate(*args: object, current_drawdown: float = 0.0, **kwargs: object) -> object:
+        captured["current_drawdown"] = current_drawdown
+        return original_allocate(*args, current_drawdown=current_drawdown, **kwargs)  # type: ignore[arg-type]
+
+    allocator_b.allocate = capturing_allocate  # type: ignore[method-assign]
+
+    provider_b = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 8)])
+    engine_b = LiveEngine(
+        portfolio=portfolio,
+        allocator=allocator_b,
+        order_sizer=OrderSizer(),
+        provider=provider_b,
+        state_path=state_path,
+    )
+    engine_b._tick(["AAPL"])
+    engine_b.close()
+
+    # total_value on tick B = 0 cash + 10 * 80 = $800. peak (persisted) = $2000.
+    # current_drawdown = (2000 - 800) / 2000 = 0.6
+    assert captured["current_drawdown"] == pytest.approx(0.6)
+
+
 def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path) -> None:
     """HWM must only ratchet for tickers we actually hold. Otherwise a ticker
     that ran up before the strategy first bought it would seed ``TrailingStop``

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -266,3 +266,129 @@ def test_alert_cash_display_does_not_double_count(tmp_path: Path, monkeypatch: p
     # to $800.
     assert captured == [pytest.approx(900.0)]
     assert engine._state.available_cash == pytest.approx(900.0)
+
+
+def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path) -> None:
+    """``_tick`` must compute ``(peak_equity - total_value) / peak_equity`` from
+    persisted state and pass it as ``current_drawdown`` to the allocator. Without
+    this, the CPPI overlay is inert in live regardless of how far below peak the
+    portfolio sits — the headline scope-1 fix this PR claims to deliver. (Earlier
+    iterations let it default to 0.0, leaving CPPI a no-op even when peak_equity
+    persistence was present.)
+    """
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    # Pre-seed state with peak_equity=$2000 so the current $800 portfolio is
+    # 60% below peak — non-trivial drawdown that should flow through.
+    seeded = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        peak_equity=2000.0,
+        lots={"AAPL": [PositionLot(shares=10.0, purchase_date=None, cost_basis=100.0)]},
+    )
+    save_atomic(seeded, state_path)
+
+    provider = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
+    captured_kwargs: dict[str, object] = {}
+    allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+
+    original_allocate = allocator.allocate
+
+    def capturing_allocate(*args: object, **kwargs: object) -> object:
+        captured_kwargs.update(kwargs)
+        return original_allocate(*args, **kwargs)  # type: ignore[arg-type]
+
+    allocator.allocate = capturing_allocate  # type: ignore[method-assign]
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=allocator,
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    # total_value = $0 cash + 10 shares * $80 = $800. peak = $2000.
+    # current_drawdown = (2000 - 800) / 2000 = 0.6
+    assert captured_kwargs["current_drawdown"] == pytest.approx(0.6)
+
+
+def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path) -> None:
+    """HWM must only ratchet for tickers we actually hold. Otherwise a ticker
+    that ran up before the strategy first bought it would seed ``TrailingStop``
+    against a pre-purchase peak — silently more conservative than backtest,
+    which only tracks HWM on positions with shares > 0.
+    """
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=0.0, cost_basis=None)],
+        available_cash=10000.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    seeded = LiveState(
+        available_cash=10000.0,
+        cash_infusion_next_date=None,
+        # No lots → not held. AAPL is on the watchlist but has zero shares.
+        lots={},
+    )
+    save_atomic(seeded, state_path)
+
+    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    assert "AAPL" not in engine._state.high_water_marks, (
+        "HWM should not be set for an unheld ticker; otherwise TrailingStop seeds against pre-purchase peaks"
+    )
+
+
+def test_lockfile_prevents_concurrent_engines(tmp_path: Path) -> None:
+    """Two ``LiveEngine``s against the same state file would otherwise both
+    load, both compute, both write — ``os.replace`` would pick a winner and
+    silently drop the loser's fills. The advisory lock turns this into a clear
+    "another midas live is already running" error.
+    """
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+
+    first = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="another midas live process"):
+            LiveEngine(
+                portfolio=portfolio,
+                allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+                order_sizer=OrderSizer(),
+                provider=provider,
+                state_path=state_path,
+            )
+    finally:
+        first.close()
+
+    # After close(), a fresh engine should acquire the lock cleanly.
+    second = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    second.close()

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -11,11 +11,12 @@ import pytest
 
 from midas.allocator import Allocator
 from midas.live import LiveEngine
-from midas.live_state import load_state
+from midas.live_state import LiveState, aggregate_cost_basis, load_state, save_atomic
 from midas.models import (
     AllocationConstraints,
     Holding,
     PortfolioConfig,
+    PositionLot,
 )
 from midas.order_sizer import OrderSizer
 
@@ -69,3 +70,65 @@ def test_live_engine_seeds_state_on_first_construction(basic_portfolio: Portfoli
     state = load_state(state_path)
     assert state.available_cash == 1000.0
     assert "AAPL" in state.lots
+
+
+def test_tick_advances_in_memory_hwm(tmp_path: Path) -> None:
+    """First tick should advance per-ticker HWM in self._state to the latest close."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+    sizer = OrderSizer()
+    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=allocator,
+        order_sizer=sizer,
+        provider=provider,
+        state_path=state_path,
+    )
+    engine._tick(["AAPL"])
+
+    assert engine._state.high_water_marks["AAPL"] == 200.0
+
+
+def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path) -> None:
+    """If the operator has two lots at different prices, the exit-rule loop
+    should see the share-weighted average basis, not the YAML's static value."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=20.0, cost_basis=999.0)],  # YAML lies
+        available_cash=0.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    # Pre-populate state with two real lots so the engine sees the right basis.
+    seeded = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={
+            "AAPL": [
+                PositionLot(shares=10.0, purchase_date=None, cost_basis=100.0),
+                PositionLot(shares=10.0, purchase_date=None, cost_basis=200.0),
+            ]
+        },
+    )
+    save_atomic(seeded, state_path)
+
+    allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
+    sizer = OrderSizer()
+    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=allocator,
+        order_sizer=sizer,
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Verify positions/basis as the engine would compute them inside _tick.
+    assert aggregate_cost_basis(engine._state.lots["AAPL"]) == 150.0
+    # And after a tick, HWM should advance to 150.0 (the close).
+    engine._tick(["AAPL"])
+    assert engine._state.high_water_marks["AAPL"] == 150.0

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -11,7 +11,7 @@ import pytest
 
 from midas.allocator import Allocator
 from midas.live import LiveEngine
-from midas.live_state import LiveState, aggregate_cost_basis, load_state, save_atomic
+from midas.live_state import LiveState, StateFileError, aggregate_cost_basis, load_state, save_atomic
 from midas.models import (
     AllocationConstraints,
     CashInfusion,
@@ -392,3 +392,71 @@ def test_lockfile_prevents_concurrent_engines(tmp_path: Path) -> None:
         state_path=state_path,
     )
     second.close()
+
+
+def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path) -> None:
+    """If load_or_seed raises after the lock is acquired (e.g., corrupt state file),
+    the lock fd must be released. Otherwise a retry in the same process hits a
+    bogus 'another midas live process' RuntimeError.
+    """
+    # Pre-write a corrupt state file so load_or_seed raises StateFileError.
+    state_path = tmp_path / "state.yaml"
+    state_path.write_text("schema_version: 99\navailable_cash: 0\n")  # unsupported
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+
+    # First attempt: load_or_seed raises on the unsupported schema_version.
+    with pytest.raises(StateFileError):
+        LiveEngine(
+            portfolio=portfolio,
+            allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+            order_sizer=OrderSizer(),
+            provider=provider,
+            state_path=state_path,
+        )
+
+    # Fix the state file and retry — should succeed without "another midas live"
+    # RuntimeError because the lock was released on the first failure.
+    state_path.write_text("schema_version: 1\navailable_cash: 0.0\n")
+    second = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+    second.close()
+
+
+def test_drawdown_overlay_produces_smaller_exposure_under_real_drawdown() -> None:
+    """End-to-end check that current_drawdown actually affects exposure scaling.
+
+    The Task 9 fix wires current_drawdown from state.peak_equity through to
+    Allocator.allocate. Paired with ``test_tick_passes_current_drawdown_to_allocator``
+    (which pins the kwarg arriving), this test pins the downstream formula —
+    ``apply_drawdown_overlay`` reduces exposure when drawdown is non-zero, with
+    the expected formula and clamping. Together they establish the chain works
+    end-to-end: kwarg arrives + overlay produces expected scale = behavior is
+    correct (and not silently dead code).
+    """
+    from midas.risk import apply_drawdown_overlay
+
+    # No drawdown: exposure scale stays at 1.0.
+    no_dd = apply_drawdown_overlay(current_drawdown=0.0, penalty=2.0, floor=0.5)
+    assert no_dd == 1.0
+
+    # 20% drawdown with penalty=2.0: exposure = max(1 - 2*0.2, 0.5) = 0.6.
+    moderate = apply_drawdown_overlay(current_drawdown=0.2, penalty=2.0, floor=0.5)
+    assert moderate == pytest.approx(0.6)
+
+    # 60% drawdown (matches the live-engine kwarg-arrival test): raw =
+    # 1 - 1.2 = -0.2, clamped to floor 0.5.
+    deep = apply_drawdown_overlay(current_drawdown=0.6, penalty=2.0, floor=0.5)
+    assert deep == pytest.approx(0.5)
+
+    # Confirm the chain: deeper drawdown produces smaller-or-equal exposure.
+    assert deep <= moderate <= no_dd

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -15,7 +15,10 @@ from midas.live_state import LiveState, aggregate_cost_basis, load_state, save_a
 from midas.models import (
     AllocationConstraints,
     CashInfusion,
+    Direction,
     Holding,
+    Order,
+    OrderContext,
     PortfolioConfig,
     PositionLot,
 )
@@ -207,3 +210,59 @@ def test_cash_infusion_advances_when_due(tmp_path: Path, monkeypatch: pytest.Mon
     state = load_state(state_path)
     assert state.available_cash == pytest.approx(500.0 + 1500.0)
     assert state.cash_infusion_next_date == date(2026, 5, 15)  # +14 days for biweekly
+
+
+def test_alert_cash_display_does_not_double_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``apply_buy``/``apply_sell`` mutate ``state.available_cash`` in place,
+    so the per-alert running subtotal must seed from the *pre-fill* baseline.
+    Otherwise a single $100 BUY against $1000 cash would print "$800" instead
+    of "$900" — both cash mutation and the printed delta apply.
+    """
+    portfolio = PortfolioConfig(
+        holdings=[],  # no held positions; only a buy will fire
+        available_cash=1000.0,
+    )
+    state_path = tmp_path / "state.yaml"
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Inject a synthetic $100 BUY directly into the order sizer's buy pass; this
+    # bypasses allocator/strategy plumbing while exercising the real apply-fills
+    # and alert-emission paths in ``_tick``.
+    fake_buy = Order(
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=1.0,
+        price=100.0,
+        estimated_value=100.0,
+        context=OrderContext(
+            contributions={"fake": 1.0},
+            blended_score=1.0,
+            target_weight=1.0,
+            current_weight=0.0,
+            reason="test",
+            source="fake",
+        ),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [fake_buy])
+
+    captured: list[float] = []
+
+    def capture_alert(order: Order, remaining_cash: float, *_args: object, **_kw: object) -> None:
+        captured.append(remaining_cash)
+
+    monkeypatch.setattr("midas.live.print_alert", capture_alert)
+
+    engine._tick(["AAPL"])
+
+    # Pre-fill cash $1000 minus $100 buy = $900. If the bug returns,
+    # state.available_cash (already $900 after apply_buy) would be debited again
+    # to $800.
+    assert captured == [pytest.approx(900.0)]
+    assert engine._state.available_cash == pytest.approx(900.0)

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -150,7 +150,7 @@ def test_load_or_seed_warns_on_share_drift(tmp_path: Path, caplog: pytest.LogCap
     with caplog.at_level("WARNING"):
         state = load_or_seed(portfolio_drifted, path)
     assert state.lots["AAPL"][0].shares == 100.0  # state file wins
-    assert any("AAPL" in record.message and "200" in record.message for record in caplog.records)
+    assert any(record.levelname == "WARNING" and "share drift" in record.message for record in caplog.records)
 
 
 def test_load_or_seed_warns_on_cash_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -168,7 +168,7 @@ def test_load_or_seed_warns_on_cash_drift(tmp_path: Path, caplog: pytest.LogCapt
     with caplog.at_level("WARNING"):
         state = load_or_seed(portfolio_drifted, path)
     assert state.available_cash == 1000.0  # state file wins
-    assert any("available_cash" in record.message for record in caplog.records)
+    assert any(record.levelname == "WARNING" and "available_cash drift" in record.message for record in caplog.records)
 
 
 def test_load_or_seed_warns_on_cost_basis_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -191,7 +191,7 @@ def test_load_or_seed_warns_on_cost_basis_drift(tmp_path: Path, caplog: pytest.L
     with caplog.at_level("WARNING"):
         state = load_or_seed(portfolio_drifted, path)
     assert state.lots["AAPL"][0].cost_basis == 150.0  # state file wins
-    assert any("cost_basis" in record.message for record in caplog.records)
+    assert any(record.levelname == "WARNING" and "cost_basis drift" in record.message for record in caplog.records)
 
 
 def test_load_or_seed_does_not_warn_on_cost_basis_within_tolerance(

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -7,7 +7,15 @@ from pathlib import Path
 
 import pytest
 
-from midas.live_state import LiveState, StateFileError, load_or_seed, load_state, save_atomic
+from midas.live_state import (
+    LiveState,
+    StateFileError,
+    aggregate_cost_basis,
+    consume_lots_fifo,
+    load_or_seed,
+    load_state,
+    save_atomic,
+)
 from midas.models import CashInfusion, Holding, PortfolioConfig, PositionLot
 
 
@@ -157,3 +165,49 @@ def test_load_or_seed_raises_when_held_ticker_removed_from_portfolio(tmp_path: P
     )
     with pytest.raises(StateFileError, match=r"AAPL.*100"):
         load_or_seed(portfolio_without, path)
+
+
+def test_aggregate_cost_basis_share_weighted() -> None:
+    lots = [
+        PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0),
+        PositionLot(shares=50.0, purchase_date=date(2026, 4, 12), cost_basis=22.0),
+    ]
+    # (100 * 10 + 50 * 22) / 150 = 14.0
+    assert aggregate_cost_basis(lots) == pytest.approx(14.0)
+
+
+def test_aggregate_cost_basis_empty_returns_zero() -> None:
+    assert aggregate_cost_basis([]) == 0.0
+
+
+def test_consume_lots_fifo_st_only() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=100.0, purchase_date=date(2026, 4, 1), cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=40.0, day=today)
+    assert breakdown.st_shares == 40.0
+    assert breakdown.st_basis == pytest.approx(10.0)
+    assert breakdown.lt_shares == 0.0
+    assert lots[0].shares == 60.0  # mutated in place
+
+
+def test_consume_lots_fifo_straddles_st_lt_boundary() -> None:
+    today = date(2026, 5, 7)
+    # First lot is >365 days old (LT); second is recent (ST).
+    lots = [
+        PositionLot(shares=30.0, purchase_date=date(2025, 4, 1), cost_basis=10.0),
+        PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),
+    ]
+    breakdown = consume_lots_fifo(lots, shares=40.0, day=today)
+    assert breakdown.lt_shares == 30.0
+    assert breakdown.lt_basis == pytest.approx(10.0)
+    assert breakdown.st_shares == 10.0
+    assert breakdown.st_basis == pytest.approx(20.0)
+    assert lots == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+
+
+def test_consume_lots_fifo_unknown_purchase_date_is_short_term() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=50.0, day=today)
+    assert breakdown.st_shares == 50.0
+    assert breakdown.lt_shares == 0.0

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -301,3 +301,14 @@ def test_apply_sell_drops_empty_ticker_entry() -> None:
     )
     apply_sell(state, "AAPL", shares=10.0, price=20.0, day=date(2026, 5, 7))
     assert "AAPL" not in state.lots  # cleared
+
+
+def test_apply_sell_keeps_ticker_with_remaining_shares() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]},
+    )
+    apply_sell(state, "AAPL", shares=4.0, price=20.0, day=date(2026, 5, 7))
+    assert "AAPL" in state.lots
+    assert state.lots["AAPL"][0].shares == 6.0

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from midas.live_state import LiveState, StateFileError, load_state, save_atomic
-from midas.models import PositionLot
+from midas.live_state import LiveState, StateFileError, load_or_seed, load_state, save_atomic
+from midas.models import CashInfusion, Holding, PortfolioConfig, PositionLot
 
 
 def test_save_load_round_trip(tmp_path: Path) -> None:
@@ -59,3 +59,49 @@ def test_save_atomic_leaves_canonical_intact_on_failure(tmp_path: Path, monkeypa
     with pytest.raises(OSError, match="simulated rename failure"):
         save_atomic(LiveState(available_cash=999.99, cash_infusion_next_date=None), path)
     assert path.read_text() == canonical_before
+
+
+def test_load_rejects_non_dict_cash_infusion(tmp_path: Path) -> None:
+    path = tmp_path / "state.yaml"
+    path.write_text("schema_version: 1\navailable_cash: 0\ncash_infusion: today\n")
+    with pytest.raises(StateFileError, match="cash_infusion"):
+        load_state(path)
+
+
+def test_load_or_seed_creates_state_from_portfolio(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[
+            Holding(ticker="AAPL", shares=100.0, cost_basis=150.0),
+            Holding(ticker="NVDA", shares=50.0, cost_basis=49.76),
+        ],
+        available_cash=5000.0,
+        cash_infusion=CashInfusion(amount=1500.0, next_date=date(2026, 5, 15), frequency="biweekly"),
+    )
+    path = tmp_path / "portfolio.state.yaml"
+    assert not path.exists()
+
+    state = load_or_seed(portfolio, path)
+
+    assert path.exists()  # seed wrote the file
+    assert state.available_cash == 5000.0
+    assert state.cash_infusion_next_date == date(2026, 5, 15)
+    assert state.peak_equity is None
+    assert state.high_water_marks == {}
+    assert state.lots == {
+        "AAPL": [PositionLot(shares=100.0, purchase_date=None, cost_basis=150.0)],
+        "NVDA": [PositionLot(shares=50.0, purchase_date=None, cost_basis=49.76)],
+    }
+
+
+def test_load_or_seed_skips_holdings_with_zero_shares(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[
+            Holding(ticker="AAPL", shares=100.0, cost_basis=150.0),
+            Holding(ticker="MSFT", shares=0.0, cost_basis=None),
+        ],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    state = load_or_seed(portfolio, path)
+    assert "AAPL" in state.lots
+    assert "MSFT" not in state.lots

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -330,3 +330,17 @@ def test_apply_sell_keeps_ticker_with_remaining_shares() -> None:
     apply_sell(state, "AAPL", shares=4.0, price=20.0, day=date(2026, 5, 7))
     assert "AAPL" in state.lots
     assert state.lots["AAPL"][0].shares == 6.0
+
+
+def test_apply_sell_raises_on_oversell() -> None:
+    """Mirrors backtest's ``assert new_position >= 0`` invariant: ``apply_sell``
+    must refuse to credit cash for shares that don't exist. ``OrderSizer.size_sells``
+    clamps in production; this guards against a future regression silently
+    fabricating cash."""
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]},
+    )
+    with pytest.raises(AssertionError, match="oversell"):
+        apply_sell(state, "AAPL", shares=999.0, price=20.0, day=date(2026, 5, 7))

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -387,3 +387,31 @@ def test_apply_sell_raises_on_oversell() -> None:
     )
     with pytest.raises(AssertionError, match="oversell"):
         apply_sell(state, "AAPL", shares=999.0, price=20.0, day=date(2026, 5, 7))
+
+
+def test_save_atomic_does_not_emit_yaml_aliases(tmp_path: Path) -> None:
+    """Multiple lots sharing the same purchase_date object would otherwise
+    cause PyYAML to emit ``&id001`` / ``*id001`` anchors and aliases —
+    valid YAML, but ugly when hand-editing the state file."""
+    same_day = date(2026, 4, 12)
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=same_day,  # third reuse of same_day
+        lots={
+            "AAPL": [
+                PositionLot(shares=10.0, purchase_date=same_day, cost_basis=150.0),
+                PositionLot(shares=20.0, purchase_date=same_day, cost_basis=160.0),
+            ],
+            "NVDA": [PositionLot(shares=5.0, purchase_date=same_day, cost_basis=49.76)],
+        },
+    )
+    path = tmp_path / "state.yaml"
+    save_atomic(state, path)
+
+    raw = path.read_text()
+    assert "&id" not in raw, f"unexpected anchor in state file:\n{raw}"
+    assert "*id" not in raw, f"unexpected alias in state file:\n{raw}"
+
+    # Confirm round-trip still works after disabling aliases.
+    loaded = load_state(path)
+    assert loaded == state

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -186,7 +186,9 @@ def test_consume_lots_fifo_st_only() -> None:
     breakdown = consume_lots_fifo(lots, shares=40.0, day=today)
     assert breakdown.st_shares == 40.0
     assert breakdown.st_basis == pytest.approx(10.0)
+    assert breakdown.st_weighted == pytest.approx(400.0)
     assert breakdown.lt_shares == 0.0
+    assert breakdown.lt_weighted == 0.0
     assert lots[0].shares == 60.0  # mutated in place
 
 
@@ -211,3 +213,43 @@ def test_consume_lots_fifo_unknown_purchase_date_is_short_term() -> None:
     breakdown = consume_lots_fifo(lots, shares=50.0, day=today)
     assert breakdown.st_shares == 50.0
     assert breakdown.lt_shares == 0.0
+
+
+def test_consume_lots_fifo_oversell_consumes_all_available() -> None:
+    """Selling more than the lot list holds consumes everything available
+    and reports a partial breakdown. (Oversell-prevention is the caller's
+    responsibility — backtest's _execute asserts new_position >= 0; live's
+    apply_sell will be similarly bounded by the order sizer.)"""
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+    breakdown = consume_lots_fifo(lots, shares=999.0, day=today)
+    assert breakdown.st_shares == 10.0  # only 10 available
+    assert lots == []
+
+
+def test_consume_lots_fifo_zero_shares_no_op() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+    breakdown = consume_lots_fifo(lots, shares=0.0, day=today)
+    assert breakdown.st_shares == 0.0
+    assert breakdown.lt_shares == 0.0
+    assert lots == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+
+
+def test_consume_lots_fifo_exact_365_day_boundary_is_long_term() -> None:
+    """Pin the exact-boundary classification: a lot purchased exactly 365
+    days ago classifies as long-term (>= 365). This matches the existing
+    backtest behavior; do not silently relax to > 365 in a future refactor."""
+    today = date(2026, 5, 7)
+    one_year_ago = today - timedelta(days=365)
+    lots = [PositionLot(shares=10.0, purchase_date=one_year_ago, cost_basis=20.0)]
+    breakdown = consume_lots_fifo(lots, shares=10.0, day=today)
+    assert breakdown.lt_shares == 10.0
+    assert breakdown.st_shares == 0.0
+
+
+def test_consume_lots_fifo_full_consumption_leaves_empty_list() -> None:
+    today = date(2026, 5, 7)
+    lots = [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+    consume_lots_fifo(lots, shares=10.0, day=today)
+    assert lots == []

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -105,3 +105,55 @@ def test_load_or_seed_skips_holdings_with_zero_shares(tmp_path: Path) -> None:
     state = load_or_seed(portfolio, path)
     assert "AAPL" in state.lots
     assert "MSFT" not in state.lots
+
+
+def test_load_or_seed_warns_on_share_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)  # first call seeds
+
+    portfolio_drifted = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=200.0, cost_basis=150.0)],  # state still has 100
+        available_cash=1000.0,
+    )
+    with caplog.at_level("WARNING"):
+        state = load_or_seed(portfolio_drifted, path)
+    assert state.lots["AAPL"][0].shares == 100.0  # state file wins
+    assert any("AAPL" in record.message and "200" in record.message for record in caplog.records)
+
+
+def test_load_or_seed_warns_on_cash_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_drifted = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=9999.99,
+    )
+    with caplog.at_level("WARNING"):
+        state = load_or_seed(portfolio_drifted, path)
+    assert state.available_cash == 1000.0  # state file wins
+    assert any("available_cash" in record.message for record in caplog.records)
+
+
+def test_load_or_seed_raises_when_held_ticker_removed_from_portfolio(tmp_path: Path) -> None:
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_without = PortfolioConfig(
+        holdings=[],  # AAPL removed from portfolio while still held in state
+        available_cash=1000.0,
+    )
+    with pytest.raises(StateFileError, match=r"AAPL.*100"):
+        load_or_seed(portfolio_without, path)

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -11,6 +11,8 @@ from midas.live_state import (
     LiveState,
     StateFileError,
     aggregate_cost_basis,
+    apply_buy,
+    apply_sell,
     consume_lots_fifo,
     load_or_seed,
     load_state,
@@ -253,3 +255,49 @@ def test_consume_lots_fifo_full_consumption_leaves_empty_list() -> None:
     lots = [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
     consume_lots_fifo(lots, shares=10.0, day=today)
     assert lots == []
+
+
+def test_apply_buy_appends_lot_and_decrements_cash() -> None:
+    state = LiveState(available_cash=1000.0, cash_infusion_next_date=None)
+    apply_buy(state, "AAPL", shares=10.0, price=150.0, day=date(2026, 5, 7))
+    assert state.available_cash == pytest.approx(1000.0 - 10.0 * 150.0)
+    assert state.lots["AAPL"] == [PositionLot(shares=10.0, purchase_date=date(2026, 5, 7), cost_basis=150.0)]
+
+
+def test_apply_buy_appends_to_existing_lots() -> None:
+    state = LiveState(
+        available_cash=1000.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=5.0, purchase_date=date(2026, 4, 1), cost_basis=140.0)]},
+    )
+    apply_buy(state, "AAPL", shares=10.0, price=150.0, day=date(2026, 5, 7))
+    assert len(state.lots["AAPL"]) == 2
+    assert state.available_cash == pytest.approx(1000.0 - 10.0 * 150.0)
+
+
+def test_apply_sell_consumes_fifo_and_increments_cash() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={
+            "AAPL": [
+                PositionLot(shares=30.0, purchase_date=date(2025, 4, 1), cost_basis=10.0),  # LT
+                PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),  # ST
+            ]
+        },
+    )
+    st_pnl, lt_pnl = apply_sell(state, "AAPL", shares=40.0, price=25.0, day=date(2026, 5, 7))
+    assert state.available_cash == pytest.approx(40.0 * 25.0)
+    assert state.lots["AAPL"] == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+    assert lt_pnl == pytest.approx(30.0 * (25.0 - 10.0))
+    assert st_pnl == pytest.approx(10.0 * (25.0 - 20.0))
+
+
+def test_apply_sell_drops_empty_ticker_entry() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={"AAPL": [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]},
+    )
+    apply_sell(state, "AAPL", shares=10.0, price=20.0, day=date(2026, 5, 7))
+    assert "AAPL" not in state.lots  # cleared

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -95,12 +95,30 @@ def test_load_or_seed_creates_state_from_portfolio(tmp_path: Path) -> None:
     assert path.exists()  # seed wrote the file
     assert state.available_cash == 5000.0
     assert state.cash_infusion_next_date == date(2026, 5, 15)
-    assert state.peak_equity is None
+    # Seed peak_equity = cash + Σ shares * cost_basis
+    # = 5000 + 100*150 + 50*49.76 = 5000 + 15000 + 2488 = 22488
+    assert state.peak_equity == pytest.approx(22488.0)
     assert state.high_water_marks == {}
     assert state.lots == {
         "AAPL": [PositionLot(shares=100.0, purchase_date=None, cost_basis=150.0)],
         "NVDA": [PositionLot(shares=50.0, purchase_date=None, cost_basis=49.76)],
     }
+
+
+def test_load_or_seed_initializes_peak_equity_to_starting_value(tmp_path: Path) -> None:
+    """Backtest seeds state.peak_value = state.starting_value at _initialize_state;
+    live's load_or_seed must do the same so CPPI/drawdown calcs don't diverge
+    on the first tick when prices are below cost basis."""
+    portfolio = PortfolioConfig(
+        holdings=[
+            Holding(ticker="AAPL", shares=10.0, cost_basis=150.0),
+            Holding(ticker="NVDA", shares=20.0, cost_basis=50.0),
+        ],
+        available_cash=500.0,
+    )
+    state = load_or_seed(portfolio, tmp_path / "state.yaml")
+    # 500 + 10*150 + 20*50 = 500 + 1500 + 1000 = 3000
+    assert state.peak_equity == pytest.approx(3000.0)
 
 
 def test_load_or_seed_skips_holdings_with_zero_shares(tmp_path: Path) -> None:

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -1,0 +1,61 @@
+"""Unit tests for live state persistence."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from midas.live_state import LiveState, StateFileError, load_state, save_atomic
+from midas.models import PositionLot
+
+
+def test_save_load_round_trip(tmp_path: Path) -> None:
+    state = LiveState(
+        available_cash=4823.50,
+        cash_infusion_next_date=date(2026, 5, 15),
+        high_water_marks={"PLTR": 24.18, "NVDA": 142.5},
+        peak_equity=18420.0,
+        lots={
+            "PLTR": [
+                PositionLot(shares=100.0, purchase_date=None, cost_basis=10.0),
+                PositionLot(shares=50.0, purchase_date=date(2026, 4, 12), cost_basis=22.5),
+            ],
+            "NVDA": [PositionLot(shares=100.0, purchase_date=None, cost_basis=49.76)],
+        },
+    )
+    path = tmp_path / "portfolio.state.yaml"
+    save_atomic(state, path)
+    loaded = load_state(path)
+    assert loaded == state
+
+
+def test_load_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "state.yaml"
+    path.write_text("schema_version: 99\navailable_cash: 0\n")
+    with pytest.raises(StateFileError, match="unsupported state version"):
+        load_state(path)
+
+
+def test_load_rejects_unparseable_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "state.yaml"
+    path.write_text(":\n - this isn't\n  valid yaml: ::\n")
+    with pytest.raises(StateFileError):
+        load_state(path)
+
+
+def test_save_atomic_leaves_canonical_intact_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state = LiveState(available_cash=100.0, cash_infusion_next_date=None)
+    path = tmp_path / "state.yaml"
+    save_atomic(state, path)
+    canonical_before = path.read_text()
+
+    def boom(*args: object, **kwargs: object) -> None:
+        msg = "simulated rename failure"
+        raise OSError(msg)
+
+    monkeypatch.setattr("os.replace", boom)
+    with pytest.raises(OSError, match="simulated rename failure"):
+        save_atomic(LiveState(available_cash=999.99, cash_infusion_next_date=None), path)
+    assert path.read_text() == canonical_before

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -171,6 +171,49 @@ def test_load_or_seed_warns_on_cash_drift(tmp_path: Path, caplog: pytest.LogCapt
     assert any("available_cash" in record.message for record in caplog.records)
 
 
+def test_load_or_seed_warns_on_cost_basis_drift(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Hand-edits to portfolio.yaml's cost_basis are the field most likely to
+    surprise the operator (it's exactly what TrailingStop/StopLoss clamp
+    against). Surface it as a warning; state still wins per the documented
+    "runtime fills are authoritative" policy.
+    """
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_drifted = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=200.0)],  # 33% bump
+        available_cash=1000.0,
+    )
+    with caplog.at_level("WARNING"):
+        state = load_or_seed(portfolio_drifted, path)
+    assert state.lots["AAPL"][0].cost_basis == 150.0  # state file wins
+    assert any("cost_basis" in record.message for record in caplog.records)
+
+
+def test_load_or_seed_does_not_warn_on_cost_basis_within_tolerance(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Sub-1% drift (e.g., 150.0 vs 150.5) is within tolerance — no warning."""
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],
+        available_cash=1000.0,
+    )
+    path = tmp_path / "state.yaml"
+    load_or_seed(portfolio, path)
+
+    portfolio_close = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.5)],  # ~0.33% drift
+        available_cash=1000.0,
+    )
+    with caplog.at_level("WARNING"):
+        load_or_seed(portfolio_close, path)
+    assert not any("cost_basis" in record.message for record in caplog.records)
+
+
 def test_load_or_seed_raises_when_held_ticker_removed_from_portfolio(tmp_path: Path) -> None:
     portfolio = PortfolioConfig(
         holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=150.0)],


### PR DESCRIPTION
Closes #36.

## Summary

The live engine previously synthesized one `PositionLot` per ticker on every tick from `Holding.cost_basis` (a single static float). That structurally collapsed three things that worked in backtest:

1. **Weighted-average cost basis after multiple buys** — exit-rule clamps fired against stale YAML basis.
2. **Per-ticker high-water mark** — re-derived as `max(cost_basis, current_price)` per tick, so `TrailingStop`'s drawdown-from-HWM check was always-zero or never-fire.
3. **Short-term vs long-term holding-period classification on sells** — meaningless with one synthetic lot.

It also kept the CPPI overlay (`drawdown_penalty`/`drawdown_floor`) inert in live, since `peak_equity` wasn't carried across runs.

This PR adds a YAML state sidecar that the live engine owns post-seed: lot list per ticker, available cash, per-ticker HWM, peak equity, and the cash-infusion `next_date`. `LiveEngine` loads or seeds at startup, mutates the in-memory state on each tick (alerts == assumed fills), advances HWM/peak/infusion, and atomic-writes back at end of tick. The FIFO consumption logic in `backtest.py` is extracted into shared helpers in `live_state.py`; backtest imports from there with no behavior change (realized P&L is bit-identical).

## What's in scope

- New `src/midas/live_state.py` — `LiveState` dataclass, atomic YAML save/load with schema versioning, drift detection, FIFO primitives, `apply_buy`/`apply_sell` mutators.
- `LiveEngine` rewired: takes `state_path: Path`, reads HWM and weighted-avg basis from state, applies fills, advances peak/infusion, persists per tick. Also: removed obsolete `TrailingStop`-disabled and CPPI-inert warnings; added `flock`-based exclusive lock to prevent two `midas live` processes against the same state silently dropping fills.
- Optional `state_file: Path | None` on `PortfolioConfig`; CLI `live` command resolves sidecar default or honors the explicit path.
- `current_drawdown = (peak - total_value) / peak` threaded to `Allocator.allocate(current_drawdown=...)` so the CPPI overlay actually binds in live mode.
- Cash infusion credited *before* allocator runs, matching backtest's `_run_day` ordering for parity.
- Atomic writes use `tempfile + os.replace` plus `fsync` of file data and (best-effort) parent directory dirent.
- Test count: 308 → 356 (+48). New: `tests/test_live_state.py` (24), `tests/test_live_engine.py` (10), `tests/test_cli_live.py` (2), `tests/test_live_backtest_parity.py` (2).

## What's out of scope (deferred to follow-ups)

- Per-lot HWM and lot-aware exit-rule clamping. Backtest doesn't have per-lot HWM either; per-ticker HWM matches backtest exactly.
- `record-fill` CLI for slippage / manual override. This iteration assumes every emitted alert is filled at the alert price.
- `RestrictionTracker` round-trip-days persistence (still in-memory; restart resets the no-trade window).
- Tax-shaped P&L reporting (#66).
- Windows support — `LiveEngine.__init__` raises a clear `RuntimeError` on import-without-fcntl; `import midas.live` works everywhere.

## Spec & plan

- `docs/specs/2026-05-07-live-per-lot-tracking-design.md`
- `docs/plans/2026-05-07-live-per-lot-tracking.md`

## Test plan

- [ ] `uv run pytest` (356/356 expected to pass)
- [ ] `uv run ruff check . && uv run mypy src` (clean)
- [ ] On first `midas live` run with an existing portfolio.yaml: state file is seeded next to it (or at `state_file:` path), lots match holdings, peak_equity = starting equity, info log line emitted.
- [ ] On subsequent run with hand-edited portfolio.yaml shares/cash: warning emitted naming the drift, state file wins.
- [ ] On portfolio.yaml with a held ticker removed: refuses to start with a clear error.
- [ ] Two `midas live` processes against the same state: second fails with "another midas live process appears to hold the state lock".
- [ ] Backtest tests still pass (FIFO refactor is bit-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)