### PR TITLE
Tax-shaped trade log + realized-P&L report (#66)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,3 +221,10 @@ Exit rules evaluate at the **aggregate position level** — they see a share-wei
 **Execution is FIFO.** When the backtest engine executes a sell order, it consumes lots first-in-first-out. This is the US broker default for equities (IRS default tax-lot identification method) and the approach used universally across backtesting frameworks. Trades are classified as short-term (held less than 365 days) or long-term based on the FIFO lot's purchase date.
 
 A future extension could add configurable lot-consumption methods (LIFO, highest-cost, specific-ID) at the execution layer, but FIFO is the correct default.
+
+## Tax reporting
+
+Both live and backtest emit a unified `trades.csv` shape. Backtest gains
+opt-in after-tax metrics via a `tax:` block in the strategies YAML; the
+`midas tax-report` subcommand consumes either log to produce a Schedule D
+table + CSV. See [`docs/tax-reporting.md`](tax-reporting.md).

--- a/docs/plans/2026-05-08-tax-trade-log.md
+++ b/docs/plans/2026-05-08-tax-trade-log.md
@@ -1,0 +1,2866 @@
+# Tax-Shaped Trade Log + Realized-P&L Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add (1) an append-only `<state>.trades.csv` written by `midas live`, (2) a `midas tax-report --year YYYY` subcommand that emits a Schedule D-shaped report from the trade log, and (3) opt-in after-tax accounting for backtests (after-tax CAGR/TWR, after-tax equity curve overlay, tax-cost-ratio metric) controlled by a new `tax:` block in the strategies YAML.
+
+**Architecture:** Two new modules — `src/midas/trade_log.py` (CSV writer/reader) and `src/midas/tax.py` (pure netting + after-tax-curve math). `consume_lots_fifo` is extended to track per-lot purchase dates so trade-log SELL rows can populate a new `purchase_date` column (single date, `'various'` for mixed-lot buckets, or empty when unknown). `apply_sell` returns the full `SellBreakdown` instead of `(st_pnl, lt_pnl)` so the live engine has the inputs it needs to write bucket rows. Backtest's existing `trades.csv` gains the same `purchase_date` column so a single tax-report reader serves both modes. After-tax pipeline is opt-in via a `TaxConfig` (defaults None → all after-tax fields stay None, no behavior change).
+
+**Tech Stack:** Python 3.14, dataclasses, PyYAML, click, plotext, pytest. No new deps.
+
+**Spec:** `docs/specs/2026-05-08-tax-trade-log-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+- `src/midas/trade_log.py` — append-only writer, strict reader, `TradeLogError`, `LoggedTrade` dataclass.
+- `src/midas/tax.py` — `TaxConfig`, `AnnualTaxSummary`, `compute_tax_summary`, `compute_after_tax_curve`.
+- `tests/test_trade_log.py` — round-trip, header creation, drift detection, `'various'` and empty `purchase_date`, partial-row corruption.
+- `tests/test_tax.py` — pure netting cases, multi-year carryforward, `compute_after_tax_curve`, `tax_cost_ratio`, empty trades.
+- `tests/test_live_trade_log.py` — integration: 3-tick run with planned fills writes the expected log.
+- `tests/test_cli_tax_report.py` — smoke-test the new `tax-report` subcommand.
+- `docs/tax-reporting.md` — operator-facing doc on the YAML block, CLI, and Schedule D caveats.
+
+**Modified:**
+- `src/midas/models.py` — add `TaxConfig`; widen `TradeRecord.purchase_date` to `date | str | None`.
+- `src/midas/config.py` — parse optional `tax:` block; `load_strategies` returns `tax_config` as a 4th tuple element.
+- `src/midas/live_state.py` — `SellBreakdown` gains `st_purchase_dates` / `lt_purchase_dates`; `consume_lots_fifo` populates them; `apply_sell` returns `SellBreakdown` instead of `(float, float)`.
+- `src/midas/live.py` — caller of `apply_sell` updated; new fill-append step writes to `<state_path>.trades.csv` after `save_atomic`.
+- `src/midas/backtest.py` — `_execute` resolves and stores `purchase_date` on each `TradeRecord`.
+- `src/midas/results.py` — `_write_trades_csv` adds `purchase_date` column; `_write_equity_curve_csv` writes parallel `nav_after_tax` column when populated; `_write_summary_json` emits `after_tax_*` fields + `tax_summary` array; `BacktestResult` gains `after_tax_*` fields and `tax_summary`.
+- `src/midas/output.py` — new after-tax block in `print_backtest_summary`.
+- `src/midas/charts.py` — equity-curve renderer overlays `after_tax_equity_curve` when populated.
+- `src/midas/cli.py` — `live` and `backtest` callers thread `tax_config` through; new `tax-report` subcommand.
+- `src/midas/optimizer.py` — `write_strategies_yaml` round-trips the `tax:` block (mirrors how it round-trips `risk:`).
+- `tests/test_config.py` — assert `tax_config` parsing.
+- `tests/test_live_state.py` — update existing `apply_sell` tests for new return type; new tests cover `st_purchase_dates`/`lt_purchase_dates`.
+- `tests/test_live_engine.py` — assert `<state>.trades.csv` is created and grows.
+- `tests/test_backtest.py` — assert `purchase_date` column populated; assert after-tax fields with/without `TaxConfig`.
+- `tests/test_live_backtest_parity.py` — assert trade-log CSVs are byte-identical between modes.
+- `tests/test_charts.py` — snapshot the after-tax overlay.
+- `docs/architecture.md` — pointer to the new tax doc.
+
+---
+
+## Task 1: Add `TaxConfig` and load it from the strategies YAML
+
+**Files:**
+- Modify: `src/midas/models.py`
+- Modify: `src/midas/config.py`
+- Modify: `src/midas/cli.py:163, 229, 352` (call sites)
+- Modify: `src/midas/optimizer.py:785-840` (`write_strategies_yaml` round-trip)
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_config.py`:
+
+```python
+def test_load_strategies_with_tax_block(tmp_path: Path) -> None:
+    """Optional tax: block parses to a TaxConfig."""
+    path = tmp_path / "strategies.yaml"
+    path.write_text(
+        "strategies:\n"
+        "  - name: Momentum\n"
+        "    params: {window: 20}\n"
+        "tax:\n"
+        "  short_term_rate: 0.32\n"
+        "  long_term_rate: 0.15\n"
+        "  deductible_loss_cap: 3000.0\n"
+        "  payment_lag_days: 105\n"
+    )
+    _configs, _constraints, _risk, tax = load_strategies(path)
+    assert tax is not None
+    assert tax.short_term_rate == 0.32
+    assert tax.long_term_rate == 0.15
+    assert tax.deductible_loss_cap == 3000.0
+    assert tax.payment_lag_days == 105
+
+
+def test_load_strategies_without_tax_block(tmp_path: Path) -> None:
+    """Omitting tax: yields tax_config=None — no behavior change for existing configs."""
+    path = tmp_path / "strategies.yaml"
+    path.write_text("strategies:\n  - name: Momentum\n    params: {window: 20}\n")
+    _configs, _constraints, _risk, tax = load_strategies(path)
+    assert tax is None
+```
+
+Update existing `tests/test_config.py:100-101, 147, 165` to unpack four values:
+
+```python
+configs, constraints, _risk, _tax = load_strategies(strategy_yaml)
+# ...
+_configs, _constraints, risk, _tax = load_strategies(path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config.py -v`
+Expected: FAIL with `ImportError` or `ValueError: not enough values to unpack (expected 4, got 3)`.
+
+- [ ] **Step 3: Add `TaxConfig` to `src/midas/models.py`**
+
+Add this dataclass alongside `RiskConfig`:
+
+```python
+@dataclass(frozen=True)
+class TaxConfig:
+    """Optional capital-gains-tax accounting policy.
+
+    All rates are decimal fractions (0.37 == 37%). When None is passed in
+    place of a TaxConfig, after-tax accounting is fully disabled — no extra
+    BacktestResult fields, no equity_curve.csv column, no chart overlay.
+
+    deductible_loss_cap: cap on net losses deducted against ordinary income
+        per year (IRC §1211(b) — $3,000 single-filer / MFJ). Excess carries
+        forward to the next year.
+    payment_lag_days: calendar days from year-end to when tax for that year
+        is deducted from the after-tax equity curve. Defaults to 105 ≈ Apr 15
+        of the following year.
+    """
+
+    short_term_rate: float = 0.37
+    long_term_rate: float = 0.20
+    deductible_loss_cap: float = 3000.0
+    payment_lag_days: int = 105
+
+    def __post_init__(self) -> None:
+        if self.short_term_rate < 0 or self.short_term_rate >= 1:
+            msg = f"short_term_rate must be in [0, 1), got {self.short_term_rate}"
+            raise ValueError(msg)
+        if self.long_term_rate < 0 or self.long_term_rate >= 1:
+            msg = f"long_term_rate must be in [0, 1), got {self.long_term_rate}"
+            raise ValueError(msg)
+        if self.deductible_loss_cap < 0:
+            msg = f"deductible_loss_cap must be >= 0, got {self.deductible_loss_cap}"
+            raise ValueError(msg)
+        if self.payment_lag_days < 0:
+            msg = f"payment_lag_days must be >= 0, got {self.payment_lag_days}"
+            raise ValueError(msg)
+```
+
+- [ ] **Step 4: Update `src/midas/config.py`**
+
+```python
+from midas.models import (
+    DEFAULT_MIN_BUY_DELTA,
+    DEFAULT_MIN_CASH_PCT,
+    DEFAULT_SOFTMAX_TEMPERATURE,
+    DEFAULT_VOL_LOOKBACK_DAYS,
+    AllocationConstraints,
+    CashInfusion,
+    Holding,
+    PortfolioConfig,
+    RiskConfig,
+    StrategyConfig,
+    TaxConfig,
+    TradingRestrictions,
+)
+
+
+def load_strategies(
+    path: Path,
+) -> tuple[list[StrategyConfig], AllocationConstraints, RiskConfig, TaxConfig | None]:
+    """Load strategy configs, allocation knobs, optional risk policy, and optional tax policy.
+
+    Returns (strategies, constraints, risk_config, tax_config). Both risk and tax
+    blocks are optional; omitting either yields the documented default (default
+    RiskConfig for risk, None for tax — meaning after-tax accounting is disabled).
+    """
+    raw = _load_yaml(path)
+    # ... existing strategies/constraints/risk parsing unchanged ...
+
+    tax_raw = raw.get("tax")
+    tax: TaxConfig | None = None
+    if tax_raw is not None:
+        tax = TaxConfig(
+            short_term_rate=float(tax_raw.get("short_term_rate", 0.37)),
+            long_term_rate=float(tax_raw.get("long_term_rate", 0.20)),
+            deductible_loss_cap=float(tax_raw.get("deductible_loss_cap", 3000.0)),
+            payment_lag_days=int(tax_raw.get("payment_lag_days", 105)),
+        )
+
+    return configs, constraints, risk, tax
+```
+
+- [ ] **Step 5: Update CLI call sites in `src/midas/cli.py`**
+
+Three places (lines 162-163, 228-229, 352):
+
+```python
+strat_configs, constraints, risk_config, tax_config = (
+    load_strategies(Path(strategies))
+    if strategies
+    else (None, AllocationConstraints(), RiskConfig(), None)
+)
+```
+
+And at line 352:
+
+```python
+risk_config: RiskConfig = RiskConfig()
+tax_config: TaxConfig | None = None
+if strategies:
+    strat_configs, strat_constraints, risk_config, tax_config = load_strategies(Path(strategies))
+```
+
+Add `TaxConfig` to the import block in `cli.py`:
+
+```python
+from midas.models import (
+    AllocationConstraints,
+    RiskConfig,
+    TaxConfig,
+    # ... existing imports
+)
+```
+
+(Holding `tax_config` in the variable for now; downstream wiring lands in later tasks.)
+
+- [ ] **Step 6: Round-trip the `tax:` block in `optimizer.write_strategies_yaml`**
+
+Mirror the existing `risk_config` round-trip. In `src/midas/optimizer.py`:
+
+```python
+def write_strategies_yaml(
+    params: dict[str, dict[str, float]],
+    path: str,
+    min_cash_pct: float = DEFAULT_MIN_CASH_PCT,
+    risk_config: RiskConfig | None = None,
+    tax_config: TaxConfig | None = None,
+) -> None:
+    """... existing docstring ...
+
+    Args:
+        ...
+        tax_config: Preserved from the user's input config. When present,
+            emitted as a ``tax:`` block. ``None`` is omitted.
+    """
+    # ... existing body up to the risk block ...
+    risk_block = _risk_block_for_yaml(risk_config)
+    if risk_block:
+        output["risk"] = risk_block
+
+    if tax_config is not None:
+        output["tax"] = {
+            "short_term_rate": tax_config.short_term_rate,
+            "long_term_rate": tax_config.long_term_rate,
+            "deductible_loss_cap": tax_config.deductible_loss_cap,
+            "payment_lag_days": tax_config.payment_lag_days,
+        }
+    # ... rest of body unchanged ...
+```
+
+Add `TaxConfig` to optimizer.py imports.
+
+Update the two `write_strategies_yaml` call sites in `cli.py` (lines 388 and 473):
+
+```python
+write_strategies_yaml(
+    wf_result.best_params,
+    output,
+    min_cash_pct=min_cash_pct,
+    risk_config=risk_config,
+    tax_config=tax_config,
+)
+```
+
+(Same change at line 473 for the non-walk-forward path.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py tests/test_optimizer.py -v`
+Expected: PASS for new and existing tests. Mypy & ruff both clean: `uv run ruff check . && uv run mypy src`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/midas/models.py src/midas/config.py src/midas/cli.py src/midas/optimizer.py tests/test_config.py
+git commit -m "Add optional TaxConfig loaded from strategies YAML
+
+No behavior change yet — the loaded TaxConfig is passed to the live
+and backtest entry points but not consumed. Wiring lands in later tasks
+of the #66 implementation plan."
+```
+
+---
+
+## Task 2: `consume_lots_fifo` tracks per-lot purchase dates in `SellBreakdown`
+
+**Files:**
+- Modify: `src/midas/live_state.py:270-352`
+- Test: `tests/test_live_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_live_state.py`:
+
+```python
+def test_consume_lots_fifo_records_purchase_dates_per_bucket() -> None:
+    """SellBreakdown should expose the purchase_date of each consumed lot,
+    grouped by ST/LT bucket, so trade-log writers can resolve to a single
+    date or the literal 'various'."""
+    from midas.live_state import consume_lots_fifo
+
+    lots = [
+        PositionLot(shares=10.0, purchase_date=date(2024, 1, 1), cost_basis=10.0),  # LT
+        PositionLot(shares=10.0, purchase_date=date(2024, 5, 1), cost_basis=12.0),  # LT
+        PositionLot(shares=10.0, purchase_date=date(2026, 1, 1), cost_basis=20.0),  # ST
+    ]
+    # Sell 25 on 2026-05-08 → 20 LT + 5 ST consumed.
+    breakdown = consume_lots_fifo(lots, shares=25.0, day=date(2026, 5, 8))
+    assert breakdown.lt_purchase_dates == (date(2024, 1, 1), date(2024, 5, 1))
+    assert breakdown.st_purchase_dates == (date(2026, 1, 1),)
+
+
+def test_consume_lots_fifo_records_none_purchase_date_in_st_bucket() -> None:
+    """A lot with purchase_date=None classifies as ST and surfaces None in the
+    ST date tuple. The downstream resolver maps tuples containing None to the
+    empty-string CSV value."""
+    from midas.live_state import consume_lots_fifo
+
+    lots = [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=10.0, day=date(2026, 5, 8))
+    assert breakdown.st_purchase_dates == (None,)
+    assert breakdown.lt_purchase_dates == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_live_state.py::test_consume_lots_fifo_records_purchase_dates_per_bucket -v`
+Expected: FAIL with `AttributeError: 'SellBreakdown' object has no attribute 'lt_purchase_dates'`.
+
+- [ ] **Step 3: Extend `SellBreakdown` and `consume_lots_fifo`**
+
+In `src/midas/live_state.py`, replace the `SellBreakdown` and `consume_lots_fifo` definitions:
+
+```python
+@dataclass(frozen=True)
+class SellBreakdown:
+    """Result of consuming lots FIFO for a sell.
+
+    Reports shares and share-weighted cost basis separately for the short-term
+    (held <365 days, or unknown purchase date) and long-term (held >=365 days)
+    buckets. Either bucket may be zero. The ``*_weighted`` fields hold the raw
+    ``sum(take * cost_basis)`` accumulator, useful for callers that need bit-
+    identical reconstructions of total basis (since ``basis * shares`` is only
+    algebraically — not bit-identically — equal in IEEE-754).
+
+    The ``*_purchase_dates`` tuples list the purchase dates of the consumed lot
+    slices in FIFO order; trade-log writers use them to populate the
+    ``purchase_date`` column (single date when all lots in a bucket share one
+    date, otherwise the literal string ``'various'``).
+    """
+
+    st_shares: float
+    st_basis: float
+    st_weighted: float
+    lt_shares: float
+    lt_basis: float
+    lt_weighted: float
+    st_purchase_dates: tuple[date | None, ...] = ()
+    lt_purchase_dates: tuple[date | None, ...] = ()
+
+
+def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> SellBreakdown:
+    """Consume *shares* from *lots* in FIFO order, mutating in place.
+
+    Lots whose ``purchase_date`` is at least 365 days before *day* contribute
+    to the long-term bucket; everything else (including ``purchase_date=None``)
+    goes to the short-term bucket. Each bucket reports a share-weighted cost
+    basis over the consumed slices, plus the per-lot purchase dates of the
+    slices in FIFO order.
+    """
+    if shares <= 0 or not lots:
+        return SellBreakdown(
+            st_shares=0.0,
+            st_basis=0.0,
+            st_weighted=0.0,
+            lt_shares=0.0,
+            lt_basis=0.0,
+            lt_weighted=0.0,
+        )
+
+    st_shares = 0.0
+    st_weighted = 0.0
+    st_dates: list[date | None] = []
+    lt_shares = 0.0
+    lt_weighted = 0.0
+    lt_dates: list[date | None] = []
+    remaining = shares
+    while remaining > 0 and lots:
+        lot = lots[0]
+        take = min(lot.shares, remaining)
+        is_long_term = lot.purchase_date is not None and (day - lot.purchase_date).days >= 365
+        if is_long_term:
+            lt_shares += take
+            lt_weighted += take * lot.cost_basis
+            lt_dates.append(lot.purchase_date)
+        else:
+            st_shares += take
+            st_weighted += take * lot.cost_basis
+            st_dates.append(lot.purchase_date)
+
+        if lot.shares <= remaining:
+            remaining -= lot.shares
+            lots.pop(0)
+        else:
+            lots[0] = PositionLot(
+                shares=lot.shares - remaining,
+                purchase_date=lot.purchase_date,
+                cost_basis=lot.cost_basis,
+            )
+            remaining = 0
+
+    st_basis = st_weighted / st_shares if st_shares > 0 else 0.0
+    lt_basis = lt_weighted / lt_shares if lt_shares > 0 else 0.0
+    return SellBreakdown(
+        st_shares=st_shares,
+        st_basis=st_basis,
+        st_weighted=st_weighted,
+        lt_shares=lt_shares,
+        lt_basis=lt_basis,
+        lt_weighted=lt_weighted,
+        st_purchase_dates=tuple(st_dates),
+        lt_purchase_dates=tuple(lt_dates),
+    )
+```
+
+The two new fields default to `()` so any external code that constructs `SellBreakdown` directly (none in-tree, but a defensive choice) doesn't break.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_live_state.py -v`
+Expected: PASS for new tests + existing FIFO tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live_state.py tests/test_live_state.py
+git commit -m "consume_lots_fifo: track per-lot purchase dates in SellBreakdown
+
+SellBreakdown gains st_purchase_dates and lt_purchase_dates tuples
+populated by consume_lots_fifo as it iterates. Trade-log writers use
+them to populate the new purchase_date column on SELL bucket rows
+(single date when all lots in a bucket share one, otherwise 'various')."
+```
+
+---
+
+## Task 3: Add `purchase_date` to `TradeRecord`; populate in backtest
+
+**Files:**
+- Modify: `src/midas/models.py:119-127`
+- Modify: `src/midas/backtest.py:907-1009`
+- Test: `tests/test_backtest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_backtest.py` (place near the existing `_execute` tests):
+
+```python
+def test_execute_buy_records_purchase_date_as_day() -> None:
+    """BUY records carry the fill date as their purchase_date."""
+    from datetime import date
+    from midas.backtest import BacktestEngine
+    from midas.models import Direction, Order, OrderContext
+
+    engine = _build_minimal_engine()  # existing helper used elsewhere in the file
+    state = _new_sim_state()
+    order = Order(
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=10.0,
+        price=20.0,
+        estimated_value=200.0,
+        context=OrderContext(
+            contributions={"Momentum": 1.0},
+            blended_score=1.0,
+            target_weight=0.5,
+            current_weight=0.0,
+            reason="entry",
+            source="Momentum",
+        ),
+    )
+    records = engine._execute(order, day=date(2026, 5, 8), state=state)
+    trade, _basis = records[0]
+    assert trade.purchase_date == date(2026, 5, 8)
+
+
+def test_execute_sell_single_lot_records_lot_purchase_date() -> None:
+    """SELL bucket consuming one lot records that lot's purchase date."""
+    from datetime import date
+    from midas.backtest import BacktestEngine
+    from midas.models import Direction, Order, OrderContext, PositionLot
+
+    engine = _build_minimal_engine()
+    state = _new_sim_state()
+    state.lots["AAPL"] = [PositionLot(shares=10.0, purchase_date=date(2026, 1, 1), cost_basis=10.0)]
+    state.positions["AAPL"] = 10.0
+    order = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=10.0,
+        price=15.0,
+        estimated_value=150.0,
+        context=OrderContext(
+            contributions={"StopLoss": 1.0},
+            blended_score=0.0,
+            target_weight=0.0,
+            current_weight=0.5,
+            reason="exit",
+            source="StopLoss",
+        ),
+    )
+    records = engine._execute(order, day=date(2026, 5, 8), state=state)
+    trade, _basis = records[0]
+    assert trade.purchase_date == date(2026, 1, 1)
+
+
+def test_execute_sell_mixed_lot_records_various() -> None:
+    """SELL bucket spanning multiple lots with different dates records 'various'."""
+    from datetime import date
+    from midas.backtest import BacktestEngine
+    from midas.models import Direction, Order, OrderContext, PositionLot
+
+    engine = _build_minimal_engine()
+    state = _new_sim_state()
+    state.lots["AAPL"] = [
+        PositionLot(shares=5.0, purchase_date=date(2026, 1, 1), cost_basis=10.0),
+        PositionLot(shares=5.0, purchase_date=date(2026, 2, 1), cost_basis=11.0),
+    ]
+    state.positions["AAPL"] = 10.0
+    order = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=10.0,
+        price=15.0,
+        estimated_value=150.0,
+        context=OrderContext(
+            contributions={"StopLoss": 1.0},
+            blended_score=0.0,
+            target_weight=0.0,
+            current_weight=0.5,
+            reason="exit",
+            source="StopLoss",
+        ),
+    )
+    records = engine._execute(order, day=date(2026, 5, 8), state=state)
+    # Only one ST bucket since both lots are <365 days from sell day
+    trade, _basis = records[0]
+    assert trade.purchase_date == "various"
+```
+
+If `_build_minimal_engine` and `_new_sim_state` helpers don't already exist in `tests/test_backtest.py`, inline the construction. Read the top of `tests/test_backtest.py` to find the existing pattern and adapt.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_backtest.py::test_execute_buy_records_purchase_date_as_day -v`
+Expected: FAIL with `AttributeError: 'TradeRecord' object has no attribute 'purchase_date'` or `TypeError: __init__() got an unexpected keyword argument`.
+
+- [ ] **Step 3: Extend `TradeRecord` in `src/midas/models.py`**
+
+```python
+@dataclass(frozen=True)
+class TradeRecord:
+    date: date
+    ticker: str
+    direction: Direction
+    shares: float
+    price: float
+    strategy_name: str
+    holding_period: HoldingPeriod | None = None
+    purchase_date: date | str | None = None
+    """Purchase date of the consumed lots (SELL) or the fill date (BUY).
+
+    On a SELL bucket row, ``'various'`` is the literal string sentinel for
+    mixed-lot buckets where the consumed lots don't share a single purchase
+    date — matches Schedule D convention. ``None`` indicates an unseeded
+    live lot (purchase date never known).
+    """
+```
+
+- [ ] **Step 4: Resolve and store `purchase_date` in backtest `_execute`**
+
+In `src/midas/backtest.py`, add a helper near `_fifo_consumed_basis`:
+
+```python
+@staticmethod
+def _resolve_purchase_date(dates: tuple[date | None, ...]) -> date | str | None:
+    """Map a tuple of consumed lots' purchase dates to a single CSV value.
+
+    Empty tuple → None. Single unique non-None date → that date. Anything
+    else (multiple dates, any None present) → the literal string 'various'.
+    """
+    if not dates:
+        return None
+    unique = set(dates)
+    if len(unique) == 1:
+        only = next(iter(unique))
+        return only  # may be a date or None
+    return "various"
+```
+
+Update the BUY path in `_execute` to set `purchase_date=day`:
+
+```python
+return [
+    (
+        TradeRecord(
+            date=day,
+            ticker=ticker,
+            direction=Direction.BUY,
+            shares=order.shares,
+            price=order.price,
+            strategy_name=strategy_name,
+            purchase_date=day,
+        ),
+        0.0,
+    )
+]
+```
+
+Update the SELL path to populate `purchase_date` per bucket:
+
+```python
+records: list[tuple[TradeRecord, float]] = []
+if st_shares > 0:
+    records.append(
+        (
+            TradeRecord(
+                date=day,
+                ticker=ticker,
+                direction=Direction.SELL,
+                shares=st_shares,
+                price=order.price,
+                strategy_name=strategy_name,
+                holding_period=HoldingPeriod.SHORT_TERM,
+                purchase_date=self._resolve_purchase_date(breakdown.st_purchase_dates),
+            ),
+            st_weighted_basis / st_shares,
+        )
+    )
+if lt_shares > 0:
+    records.append(
+        (
+            TradeRecord(
+                date=day,
+                ticker=ticker,
+                direction=Direction.SELL,
+                shares=lt_shares,
+                price=order.price,
+                strategy_name=strategy_name,
+                holding_period=HoldingPeriod.LONG_TERM,
+                purchase_date=self._resolve_purchase_date(breakdown.lt_purchase_dates),
+            ),
+            lt_weighted_basis / lt_shares,
+        )
+    )
+return records
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_backtest.py -v`
+Expected: PASS for new and existing tests.
+
+Run: `uv run mypy src` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/midas/models.py src/midas/backtest.py tests/test_backtest.py
+git commit -m "TradeRecord.purchase_date populated in backtest _execute
+
+BUY rows carry the fill date. SELL bucket rows resolve to a single
+purchase date when all consumed lots share one, the literal 'various'
+when they span multiple dates, or None when the consumed lots have
+no recorded date. Sets up the trades.csv column added in a later task."
+```
+
+---
+
+## Task 4: `apply_sell` returns `SellBreakdown`
+
+**Files:**
+- Modify: `src/midas/live_state.py:365-390`
+- Modify: `src/midas/live.py:319-323`
+- Modify: `tests/test_live_state.py:339-355`
+
+- [ ] **Step 1: Update existing `apply_sell` tests for the new return type**
+
+Replace the body of `test_apply_sell_consumes_fifo_and_increments_cash` in `tests/test_live_state.py`:
+
+```python
+def test_apply_sell_consumes_fifo_and_increments_cash() -> None:
+    state = LiveState(
+        available_cash=0.0,
+        cash_infusion_next_date=None,
+        lots={
+            "AAPL": [
+                PositionLot(shares=30.0, purchase_date=date(2025, 4, 1), cost_basis=10.0),  # LT
+                PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),  # ST
+            ]
+        },
+    )
+    breakdown = apply_sell(state, "AAPL", shares=40.0, price=25.0, day=date(2026, 5, 7))
+    assert state.available_cash == pytest.approx(40.0 * 25.0)
+    assert state.lots["AAPL"] == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+
+    lt_pnl = breakdown.lt_shares * 25.0 - breakdown.lt_weighted
+    st_pnl = breakdown.st_shares * 25.0 - breakdown.st_weighted
+    assert lt_pnl == pytest.approx(30.0 * (25.0 - 10.0))
+    assert st_pnl == pytest.approx(10.0 * (25.0 - 20.0))
+    assert breakdown.lt_purchase_dates == (date(2025, 4, 1),)
+    assert breakdown.st_purchase_dates == (date(2026, 4, 1),)
+```
+
+The other apply_sell tests (`drops_empty_ticker_entry`, `keeps_ticker_with_remaining_shares`, `raises_on_oversell`) discard the return value entirely — they don't need updating, but verify they still call `apply_sell(...)` without unpacking a tuple. If any do unpack, replace with a single-name assignment.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_live_state.py::test_apply_sell_consumes_fifo_and_increments_cash -v`
+Expected: FAIL with `TypeError` (still returns a tuple).
+
+- [ ] **Step 3: Change `apply_sell` to return `SellBreakdown`**
+
+In `src/midas/live_state.py`:
+
+```python
+def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: date) -> SellBreakdown:
+    """Consume *shares* of *ticker* FIFO and increment cash by ``shares * price``.
+
+    Mutates *state* in place. Returns the full ``SellBreakdown`` so callers
+    can write trade-log rows with per-bucket shares, basis, and consumed-lot
+    purchase dates. Realized P&L is recoverable as
+    ``breakdown.st_shares * price - breakdown.st_weighted`` (analogous for LT).
+    """
+    lots = state.lots.get(ticker, [])
+    breakdown = consume_lots_fifo(lots, shares, day)
+    total_consumed = breakdown.st_shares + breakdown.lt_shares
+    assert math.isclose(total_consumed, shares), (
+        f"oversell on {ticker}: requested {shares}, consumed {total_consumed}"
+    )
+    state.available_cash += shares * price
+    if not lots:
+        state.lots.pop(ticker, None)
+        state.high_water_marks.pop(ticker, None)
+    return breakdown
+```
+
+- [ ] **Step 4: Update the `live.py` caller**
+
+In `src/midas/live.py:319-323`, replace the apply_sell call (it was previously `apply_sell(self._state, ...)` discarding the return). Hold the breakdown for later:
+
+```python
+for order in filtered:
+    if order.shares <= 0:
+        continue
+    if order.direction == Direction.BUY:
+        apply_buy(self._state, order.ticker, order.shares, order.price, today)
+    else:
+        # apply_sell return now carries per-bucket detail used by the
+        # trade-log append in Task 6 — hold for that wiring.
+        _breakdown = apply_sell(self._state, order.ticker, order.shares, order.price, today)
+    if self._restriction_tracker is not None:
+        self._restriction_tracker.record_trade(order.ticker, order.direction, today)
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_live_state.py tests/test_live_engine.py tests/test_live_backtest_parity.py -v`
+Expected: PASS.
+
+Run: `uv run mypy src` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/midas/live_state.py src/midas/live.py tests/test_live_state.py
+git commit -m "apply_sell returns SellBreakdown instead of (st_pnl, lt_pnl)
+
+Strict superset of the old return: callers can recover realized P&L
+as breakdown.st_shares * price - breakdown.st_weighted (analogous for
+LT) while gaining access to per-bucket shares, basis, and consumed-lot
+purchase dates needed by the trade log."
+```
+
+---
+
+## Task 5: `trade_log` module — append-only CSV writer + strict reader
+
+**Files:**
+- Create: `src/midas/trade_log.py`
+- Test: `tests/test_trade_log.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_trade_log.py`:
+
+```python
+"""Trade-log writer/reader unit tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from midas.models import Direction, HoldingPeriod, TradeRecord
+from midas.trade_log import LoggedTrade, TradeLogError, append_trade, read_trades
+
+TRADE_LOG_HEADER = (
+    "date,ticker,direction,shares,price,strategy,"
+    "holding_period,purchase_date,cost_basis,realized_pnl,return_pct\n"
+)
+
+
+def _buy(day: date) -> TradeRecord:
+    return TradeRecord(
+        date=day,
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=10.0,
+        price=20.0,
+        strategy_name="Momentum",
+        purchase_date=day,
+    )
+
+
+def _sell(day: date, holding: HoldingPeriod, purchase: date | str | None) -> TradeRecord:
+    return TradeRecord(
+        date=day,
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=10.0,
+        price=25.0,
+        strategy_name="StopLoss",
+        holding_period=holding,
+        purchase_date=purchase,
+    )
+
+
+def test_first_append_writes_header(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    contents = path.read_text()
+    assert contents.startswith(TRADE_LOG_HEADER)
+    # one data row after the header
+    assert contents.count("\n") == 2
+
+
+def test_subsequent_appends_do_not_duplicate_header(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    append_trade(path, _buy(date(2026, 5, 9)), cost_basis=None, purchase_date=date(2026, 5, 9))
+    text = path.read_text()
+    assert text.count("date,ticker,direction") == 1
+    assert text.count("\n") == 3  # header + 2 rows
+
+
+def test_round_trip_buy_and_two_bucket_sell(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.SHORT_TERM, "various"),
+        cost_basis=20.5,
+        purchase_date="various",
+    )
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.LONG_TERM, date(2024, 1, 1)),
+        cost_basis=10.0,
+        purchase_date=date(2024, 1, 1),
+    )
+    rows = read_trades(path)
+    assert len(rows) == 3
+    assert rows[0].direction == Direction.BUY
+    assert rows[0].purchase_date == date(2026, 5, 8)
+    assert rows[1].holding_period == HoldingPeriod.SHORT_TERM
+    assert rows[1].purchase_date == "various"
+    assert rows[1].cost_basis == 20.5
+    assert rows[1].realized_pnl == pytest.approx((25.0 - 20.5) * 10.0)
+    assert rows[2].purchase_date == date(2024, 1, 1)
+
+
+def test_purchase_date_none_round_trips_as_empty(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.SHORT_TERM, None),
+        cost_basis=10.0,
+        purchase_date=None,
+    )
+    rows = read_trades(path)
+    assert rows[0].purchase_date is None
+
+
+def test_header_drift_raises_with_named_divergence(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    path.write_text("date,ticker,direction\n2026-05-08,AAPL,BUY\n")
+    with pytest.raises(TradeLogError, match="header"):
+        read_trades(path)
+
+
+def test_partial_row_raises_with_line_number(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    path.write_text(TRADE_LOG_HEADER + "2026-05-08,AAPL\n")  # 2 fields instead of 11
+    with pytest.raises(TradeLogError, match="line 2"):
+        read_trades(path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_trade_log.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'midas.trade_log'`.
+
+- [ ] **Step 3: Implement `src/midas/trade_log.py`**
+
+```python
+"""Append-only trade-log writer and strict reader.
+
+Used by both the live engine (writes to ``<state_path>.trades.csv``) and the
+backtest result writer (writes to ``<output_dir>/trades.csv``). Single shape
+across both modes so ``midas tax-report`` has one reader.
+
+Header drift on read raises :class:`TradeLogError` rather than silently
+returning empty / wrong rows; partial rows raise with the offending line
+number. The log is intentionally permissive on content (negative shares,
+future dates) but strict on shape — hand-edits are an explicit escape valve.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from midas.models import Direction, HoldingPeriod, TradeRecord
+
+TRADE_LOG_COLUMNS: tuple[str, ...] = (
+    "date",
+    "ticker",
+    "direction",
+    "shares",
+    "price",
+    "strategy",
+    "holding_period",
+    "purchase_date",
+    "cost_basis",
+    "realized_pnl",
+    "return_pct",
+)
+
+
+class TradeLogError(ValueError):
+    """Raised on header drift, partial rows, or unparseable values."""
+
+
+@dataclass(frozen=True)
+class LoggedTrade:
+    """In-memory representation of one trade-log row."""
+
+    date: date
+    ticker: str
+    direction: Direction
+    shares: float
+    price: float
+    strategy_name: str
+    holding_period: HoldingPeriod | None
+    purchase_date: date | str | None
+    cost_basis: float | None
+    realized_pnl: float | None
+    return_pct: float | None
+
+
+def _format_purchase_date(value: date | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return value.isoformat()
+
+
+def _format_holding_period(value: HoldingPeriod | None) -> str:
+    return value.value if value is not None else ""
+
+
+def append_trade(
+    path: Path,
+    record: TradeRecord,
+    cost_basis: float | None,
+    purchase_date: date | str | None,
+) -> None:
+    """Append one row to *path*, creating the file with header on first write.
+
+    For BUY rows pass ``cost_basis=None``; the ``cost_basis``, ``realized_pnl``,
+    and ``return_pct`` columns are written empty. For SELL rows the bucket's
+    share-weighted cost basis is required; ``realized_pnl`` and ``return_pct``
+    are derived from it.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    needs_header = not path.exists() or path.stat().st_size == 0
+    with open(path, "a", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        if needs_header:
+            writer.writerow(TRADE_LOG_COLUMNS)
+        if record.direction == Direction.BUY or cost_basis is None:
+            cost_basis_cell: str | float = ""
+            pnl_cell: str | float = ""
+            ret_cell: str | float = ""
+        else:
+            pnl = round((record.price - cost_basis) * record.shares, 4)
+            ret = round((record.price - cost_basis) / cost_basis, 6) if cost_basis != 0 else 0.0
+            cost_basis_cell = round(cost_basis, 4)
+            pnl_cell = pnl
+            ret_cell = ret
+        writer.writerow(
+            [
+                record.date.isoformat(),
+                record.ticker,
+                record.direction.value,
+                record.shares,
+                record.price,
+                record.strategy_name,
+                _format_holding_period(record.holding_period),
+                _format_purchase_date(purchase_date),
+                cost_basis_cell,
+                pnl_cell,
+                ret_cell,
+            ]
+        )
+        handle.flush()
+
+
+def _parse_holding_period(raw: str) -> HoldingPeriod | None:
+    if not raw:
+        return None
+    try:
+        return HoldingPeriod(raw)
+    except ValueError as exc:
+        msg = f"unknown holding_period value {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def _parse_purchase_date(raw: str) -> date | str | None:
+    if not raw:
+        return None
+    if raw == "various":
+        return raw
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        msg = f"unparseable purchase_date {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def _parse_optional_float(raw: str) -> float | None:
+    if raw == "":
+        return None
+    try:
+        return float(raw)
+    except ValueError as exc:
+        msg = f"unparseable float {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def read_trades(path: Path) -> list[LoggedTrade]:
+    """Read all rows from *path* into ``LoggedTrade`` instances.
+
+    Raises :class:`TradeLogError` on header drift or unparseable rows.
+    """
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return []
+        if tuple(header) != TRADE_LOG_COLUMNS:
+            msg = f"trade-log header drift in {path}: expected {TRADE_LOG_COLUMNS}, got {tuple(header)}"
+            raise TradeLogError(msg)
+
+        out: list[LoggedTrade] = []
+        for line_num, row in enumerate(reader, start=2):
+            if len(row) != len(TRADE_LOG_COLUMNS):
+                msg = f"trade-log row at line {line_num} has {len(row)} fields, expected {len(TRADE_LOG_COLUMNS)}"
+                raise TradeLogError(msg)
+            try:
+                trade_date = date.fromisoformat(row[0])
+                direction = Direction(row[2])
+            except ValueError as exc:
+                msg = f"trade-log row at line {line_num}: {exc}"
+                raise TradeLogError(msg) from exc
+            out.append(
+                LoggedTrade(
+                    date=trade_date,
+                    ticker=row[1],
+                    direction=direction,
+                    shares=float(row[3]),
+                    price=float(row[4]),
+                    strategy_name=row[5],
+                    holding_period=_parse_holding_period(row[6]),
+                    purchase_date=_parse_purchase_date(row[7]),
+                    cost_basis=_parse_optional_float(row[8]),
+                    realized_pnl=_parse_optional_float(row[9]),
+                    return_pct=_parse_optional_float(row[10]),
+                )
+            )
+        return out
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_trade_log.py -v`
+Expected: PASS for all 6 tests.
+
+Run: `uv run mypy src` and `uv run ruff check .` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/trade_log.py tests/test_trade_log.py
+git commit -m "Add trade_log module: append-only writer + strict reader
+
+Single CSV shape used by both live and backtest. Header is written on
+first append, never duplicated. Reader raises TradeLogError on header
+drift or partial rows naming the offending line number. 'various' and
+empty purchase_date both round-trip correctly."
+```
+
+---
+
+## Task 6: Live engine appends fills to `<state>.trades.csv`
+
+**Files:**
+- Modify: `src/midas/live.py`
+- Modify: `tests/test_live_engine.py`
+- Create: `tests/test_live_trade_log.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/test_live_trade_log.py`:
+
+```python
+"""Integration test: live engine writes a complete trade log across ticks."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from midas.live_state import LiveState, save_atomic
+from midas.models import PositionLot
+from midas.trade_log import read_trades
+
+# Reuse the existing live-engine harness from tests/test_live_engine.py
+from tests.test_live_engine import (  # type: ignore[import-not-found]
+    StubProvider,
+    build_engine,
+)
+
+
+def test_live_engine_writes_trade_log(tmp_path: Path) -> None:
+    state_path = tmp_path / "portfolio.state.yaml"
+    log_path = tmp_path / "portfolio.state.yaml.trades.csv"
+
+    # Seed state: AAPL held with one LT lot, ample cash.
+    save_atomic(
+        LiveState(
+            available_cash=10000.0,
+            cash_infusion_next_date=None,
+            high_water_marks={"AAPL": 100.0},
+            peak_equity=20000.0,
+            lots={
+                "AAPL": [PositionLot(shares=100.0, purchase_date=date(2024, 1, 1), cost_basis=50.0)],
+            },
+        ),
+        state_path,
+    )
+
+    # Provider: feed three ticks with prices that trigger one full-exit SELL.
+    provider = StubProvider(
+        {
+            "AAPL": pd.DataFrame(
+                {"close": [100.0, 95.0, 30.0]},
+                index=pd.to_datetime(["2026-05-06", "2026-05-07", "2026-05-08"]),
+            )
+        }
+    )
+
+    with build_engine(state_path, provider) as engine:
+        for _ in range(3):
+            engine._tick(["AAPL"])
+
+    trades = read_trades(log_path)
+    sells = [t for t in trades if t.direction.value == "SELL"]
+    assert len(sells) >= 1, f"expected at least one SELL row, got {trades}"
+    # All AAPL lots are LT → SELL bucket should be LT with the original purchase date.
+    sell = sells[0]
+    assert sell.holding_period is not None
+    assert sell.holding_period.value == "long-term"
+    assert sell.purchase_date == date(2024, 1, 1)
+    assert sell.cost_basis == pytest.approx(50.0)
+```
+
+(`StubProvider` and `build_engine` already exist in `tests/test_live_engine.py`; if not, inline construction of a minimal engine matching the existing pattern there — read the file's existing fixtures first.)
+
+Append to `tests/test_live_engine.py`:
+
+```python
+def test_engine_creates_trade_log_alongside_state(tmp_path: Path) -> None:
+    """Smoke: trade-log file appears next to the state file after the first tick that produces fills."""
+    state_path = tmp_path / "portfolio.state.yaml"
+    expected_log = tmp_path / "portfolio.state.yaml.trades.csv"
+    # ... use the existing fixture builders to seed a state that will trigger
+    # at least one BUY on tick 1, then assert expected_log.exists().
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_live_trade_log.py -v`
+Expected: FAIL because the engine doesn't write the log yet.
+
+- [ ] **Step 3: Wire trade-log appends in `live.py`**
+
+In `src/midas/live.py`:
+
+Add to the imports:
+
+```python
+from midas.models import (
+    AllocationConstraints,
+    Direction,
+    HoldingPeriod,
+    PortfolioConfig,
+    TradeRecord,
+)
+from midas.trade_log import append_trade
+```
+
+In `LiveEngine.__init__`, derive the log path from the state path:
+
+```python
+self._state_path = state_path
+self._trade_log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+```
+
+Replace the fill-application loop in `_tick` (currently around lines 316-325) with one that:
+1. Captures `SellBreakdown` per SELL,
+2. Mutates state via `apply_buy` / `apply_sell`,
+3. Saves state atomically,
+4. Then appends rows to the trade log.
+
+```python
+# Apply assumed fills to the in-memory state. Capture per-SELL breakdowns
+# so the trade-log append below has shares/basis/dates per ST/LT bucket.
+sell_breakdowns: dict[int, SellBreakdown] = {}
+for order in filtered:
+    if order.shares <= 0:
+        continue
+    if order.direction == Direction.BUY:
+        apply_buy(self._state, order.ticker, order.shares, order.price, today)
+    else:
+        sell_breakdowns[id(order)] = apply_sell(
+            self._state, order.ticker, order.shares, order.price, today
+        )
+    if self._restriction_tracker is not None:
+        self._restriction_tracker.record_trade(order.ticker, order.direction, today)
+
+# Update peak equity from the current portfolio value (post-fills).
+positions_after = {
+    ticker: sum(lot.shares for lot in self._state.lots.get(ticker, [])) for ticker in active_tickers
+}
+current_equity = self._state.available_cash + sum(
+    positions_after[ticker] * current_prices[ticker] for ticker in active_tickers
+)
+self._state.peak_equity = max(self._state.peak_equity or 0.0, current_equity)
+
+# Persist state at the end of the tick.
+save_atomic(self._state, self._state_path)
+
+# Append a row per BUY and per non-empty ST/LT SELL bucket to the trade log.
+# Order matters: state is durable first; if the append fails, the operator
+# sees the error and re-running re-attempts the append.
+for order in filtered:
+    if order.shares <= 0:
+        continue
+    if order.direction == Direction.BUY:
+        record = TradeRecord(
+            date=today,
+            ticker=order.ticker,
+            direction=Direction.BUY,
+            shares=order.shares,
+            price=order.price,
+            strategy_name=order.context.source,
+            purchase_date=today,
+        )
+        append_trade(self._trade_log_path, record, cost_basis=None, purchase_date=today)
+    else:
+        breakdown = sell_breakdowns[id(order)]
+        if breakdown.st_shares > 0:
+            purchase = _resolve_purchase_date(breakdown.st_purchase_dates)
+            record = TradeRecord(
+                date=today,
+                ticker=order.ticker,
+                direction=Direction.SELL,
+                shares=breakdown.st_shares,
+                price=order.price,
+                strategy_name=order.context.source,
+                holding_period=HoldingPeriod.SHORT_TERM,
+                purchase_date=purchase,
+            )
+            append_trade(
+                self._trade_log_path,
+                record,
+                cost_basis=breakdown.st_basis,
+                purchase_date=purchase,
+            )
+        if breakdown.lt_shares > 0:
+            purchase = _resolve_purchase_date(breakdown.lt_purchase_dates)
+            record = TradeRecord(
+                date=today,
+                ticker=order.ticker,
+                direction=Direction.SELL,
+                shares=breakdown.lt_shares,
+                price=order.price,
+                strategy_name=order.context.source,
+                holding_period=HoldingPeriod.LONG_TERM,
+                purchase_date=purchase,
+            )
+            append_trade(
+                self._trade_log_path,
+                record,
+                cost_basis=breakdown.lt_basis,
+                purchase_date=purchase,
+            )
+```
+
+Add the `_resolve_purchase_date` helper at module level (mirror of `BacktestEngine._resolve_purchase_date`):
+
+```python
+def _resolve_purchase_date(dates: tuple[date | None, ...]) -> date | str | None:
+    """Map a tuple of consumed lots' purchase dates to a single CSV value.
+
+    Empty tuple → None. Single unique non-None date → that date. Anything
+    else (multiple dates, any None present) → the literal string 'various'.
+    """
+    if not dates:
+        return None
+    unique = set(dates)
+    if len(unique) == 1:
+        only = next(iter(unique))
+        return only
+    return "various"
+```
+
+Add `SellBreakdown` to the `live_state` import line in `live.py`:
+
+```python
+from midas.live_state import (
+    LiveState,
+    SellBreakdown,
+    aggregate_cost_basis,
+    apply_buy,
+    apply_sell,
+    load_or_seed,
+    save_atomic,
+)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_live_trade_log.py tests/test_live_engine.py tests/test_live_backtest_parity.py -v`
+Expected: PASS.
+
+Run: `uv run mypy src` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/live.py tests/test_live_engine.py tests/test_live_trade_log.py
+git commit -m "Live engine writes append-only trade log next to state file
+
+After fills are applied and state is saved atomically, append one row
+per BUY and one per non-empty ST/LT SELL bucket to <state>.trades.csv.
+Inherits the engine-wide flock; no new locking primitive."
+```
+
+---
+
+## Task 7: Backtest `trades.csv` adds `purchase_date` column
+
+**Files:**
+- Modify: `src/midas/results.py:84-119`
+- Test: `tests/test_backtest.py` or `tests/test_results.py` (use whichever exists; create a small results test if neither covers `_write_trades_csv`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_backtest.py`:
+
+```python
+def test_trades_csv_includes_purchase_date_column(tmp_path: Path) -> None:
+    """Backtest output's trades.csv has a purchase_date column populated for BUYs and SELLs."""
+    import csv
+    from midas.results import BacktestResult, _write_trades_csv
+    from midas.models import Direction, HoldingPeriod, TradeRecord
+
+    trades = [
+        TradeRecord(
+            date=date(2026, 1, 5),
+            ticker="AAPL",
+            direction=Direction.BUY,
+            shares=10.0,
+            price=20.0,
+            strategy_name="Momentum",
+            purchase_date=date(2026, 1, 5),
+        ),
+        TradeRecord(
+            date=date(2026, 4, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=10.0,
+            price=25.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.SHORT_TERM,
+            purchase_date=date(2026, 1, 5),
+        ),
+    ]
+    result = _make_minimal_result(trades=trades, basis_per_sell=[20.0])
+    out = tmp_path / "trades.csv"
+    _write_trades_csv(result, out)
+    rows = list(csv.DictReader(out.open()))
+    assert "purchase_date" in rows[0]
+    assert rows[0]["purchase_date"] == "2026-01-05"
+    assert rows[1]["purchase_date"] == "2026-01-05"
+```
+
+(Inline `_make_minimal_result` if not present — a `BacktestResult` with placeholder zeros for everything except `trades` and `basis_per_sell`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_backtest.py::test_trades_csv_includes_purchase_date_column -v`
+Expected: FAIL — column missing.
+
+- [ ] **Step 3: Update `_write_trades_csv` in `src/midas/results.py`**
+
+```python
+def _write_trades_csv(result: BacktestResult, path: Path) -> None:
+    sell_basis = {id(trade): basis for trade, basis in _pair_sells_with_basis(result.trades, result.basis_per_sell)}
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "date",
+                "ticker",
+                "direction",
+                "shares",
+                "price",
+                "strategy",
+                "holding_period",
+                "purchase_date",
+                "cost_basis",
+                "realized_pnl",
+                "return_pct",
+            ]
+        )
+        for trade in result.trades:
+            purchase_cell: str
+            if trade.purchase_date is None:
+                purchase_cell = ""
+            elif isinstance(trade.purchase_date, str):
+                purchase_cell = trade.purchase_date
+            else:
+                purchase_cell = trade.purchase_date.isoformat()
+            common = [
+                trade.date.isoformat(),
+                trade.ticker,
+                trade.direction.value,
+                trade.shares,
+                trade.price,
+                trade.strategy_name,
+                trade.holding_period.value if trade.holding_period else "",
+                purchase_cell,
+            ]
+            if trade.direction == Direction.SELL:
+                basis = sell_basis.get(id(trade), trade.price)
+                pnl = round((trade.price - basis) * trade.shares, 4)
+                ret = round((trade.price - basis) / basis, 6) if basis != 0 else 0.0
+                writer.writerow([*common, round(basis, 4), pnl, ret])
+            else:
+                writer.writerow([*common, "", "", ""])
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_backtest.py -v`
+Expected: PASS for new test + existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/results.py tests/test_backtest.py
+git commit -m "trades.csv: add purchase_date column for tax reporting
+
+Same column shape now in backtest's trades.csv and live's
+<state>.trades.csv. The new tax-report subcommand has one reader for
+both modes."
+```
+
+---
+
+## Task 8: `tax.py` netting math — `compute_tax_summary`
+
+**Files:**
+- Create: `src/midas/tax.py`
+- Test: `tests/test_tax.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_tax.py`:
+
+```python
+"""Unit tests for capital-gains tax computation."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from midas.models import Direction, HoldingPeriod, TaxConfig, TradeRecord
+from midas.tax import (
+    AnnualTaxSummary,
+    compute_after_tax_curve,
+    compute_tax_summary,
+)
+
+
+CONFIG = TaxConfig(
+    short_term_rate=0.30,
+    long_term_rate=0.15,
+    deductible_loss_cap=3000.0,
+    payment_lag_days=105,
+)
+
+
+def _sell(year: int, period: HoldingPeriod, shares: float, price: float) -> TradeRecord:
+    return TradeRecord(
+        date=date(year, 6, 1),
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=shares,
+        price=price,
+        strategy_name="StopLoss",
+        holding_period=period,
+    )
+
+
+def test_pure_st_gain_taxed_at_short_term_rate() -> None:
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]  # gain = (30 - 20) * 10 = 100
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    assert len(summary) == 1
+    s = summary[0]
+    assert s.year == 2026
+    assert s.st_realized == pytest.approx(100.0)
+    assert s.lt_realized == 0.0
+    assert s.tax_owed == pytest.approx(100.0 * 0.30)
+    assert s.carry_forward == 0.0
+
+
+def test_st_gain_lt_loss_cross_nets() -> None:
+    """ST $100 gain, LT $40 loss → cross-net leaves $60 ST gain after offset.
+
+    Per IRS Schedule D, an LT loss first offsets LT gains; with no LT gain,
+    excess LT loss carries to ST. Result: $60 net ST gain taxed at ST rate.
+    """
+    trades = [
+        _sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0),  # +$100
+        _sell(2026, HoldingPeriod.LONG_TERM, 10.0, 16.0),   # -$40 vs basis=$20
+    ]
+    basis = [20.0, 20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    assert summary[0].net_after_cross == pytest.approx(60.0)
+    assert summary[0].tax_owed == pytest.approx(60.0 * 0.30)
+
+
+def test_net_loss_below_cap_full_deductible() -> None:
+    """Net loss of $1,200 → full $1,200 deducted at ST rate; no carry."""
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 8.0)]  # -$1200
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    s = summary[0]
+    assert s.net_after_cross == pytest.approx(-1200.0)
+    assert s.deductible_loss == pytest.approx(1200.0)
+    assert s.tax_owed == pytest.approx(-1200.0 * 0.30)  # negative → refund/credit
+    assert s.carry_forward == 0.0
+
+
+def test_net_loss_above_cap_caps_deductible_carries_remainder() -> None:
+    """Net loss of $5,000 → $3,000 deducted, $2,000 carries forward."""
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 30.0)]  # -$5000 vs $80 basis
+    basis = [80.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    s = summary[0]
+    assert s.net_after_cross == pytest.approx(-5000.0)
+    assert s.deductible_loss == pytest.approx(3000.0)
+    assert s.tax_owed == pytest.approx(-3000.0 * 0.30)
+    assert s.carry_forward == pytest.approx(2000.0)
+
+
+def test_carry_forward_absorbs_next_year_gain() -> None:
+    """$5K loss in year 1 ($2K carries) absorbs $1.5K gain in year 2.
+
+    Year 2's net post-carry = $1.5K - $2K = -$500 → fully deductible at ST,
+    no remaining carry.
+    """
+    trades = [
+        _sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 30.0),  # -$5000
+        _sell(2027, HoldingPeriod.SHORT_TERM, 100.0, 35.0),  # +$1500 vs $20 basis
+    ]
+    basis = [80.0, 20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 12, 31))
+    assert len(summary) == 2
+    assert summary[0].carry_forward == pytest.approx(2000.0)
+    assert summary[1].net_after_cross == pytest.approx(-500.0)
+    assert summary[1].deductible_loss == pytest.approx(500.0)
+    assert summary[1].tax_owed == pytest.approx(-500.0 * 0.30)
+    assert summary[1].carry_forward == 0.0
+
+
+def test_empty_trades_returns_empty_summary() -> None:
+    summary = compute_tax_summary([], [], CONFIG, end_date=date(2026, 12, 31))
+    assert summary == []
+
+
+def test_payment_date_is_year_end_plus_lag() -> None:
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 12, 31))
+    # Dec 31 2026 + 105 days = Apr 15 2027
+    assert summary[0].payment_date == date(2027, 4, 15)
+
+
+def test_payment_date_clamped_to_end_date() -> None:
+    """If the natural payment date falls past end_date, clamp to end_date.
+
+    Year 2026 sale, end_date 2027-02-15 (before Apr 15) → deduct on 2027-02-15.
+    """
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 2, 15))
+    assert summary[0].payment_date == date(2027, 2, 15)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_tax.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `src/midas/tax.py` (netting half)**
+
+```python
+"""Capital-gains tax accounting (reporting layer, not strategy).
+
+Pure functions: ``compute_tax_summary`` runs IRS Schedule D-style annual
+netting + $3K deductible + carryforward across realized SELLs;
+``compute_after_tax_curve`` applies each year's tax owed to a gross equity
+curve at the configured payment date. Used by both ``BacktestResult``
+construction and the ``midas tax-report`` subcommand so backtest after-tax
+numbers and tax-report numbers are bit-identical when fed identical inputs.
+
+Simplifications: carryforward is a single signed scalar that loses ST/LT
+character on rollover (IRS preserves character). Wash-sale detection,
+specific-lot accounting, state taxes, and bracketed rates are out of scope
+— the engine is FIFO and the rates are flat.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from midas.metrics import _pair_sells_with_basis
+from midas.models import Direction, HoldingPeriod, TaxConfig, TradeRecord
+
+
+@dataclass(frozen=True)
+class AnnualTaxSummary:
+    """Per-year realized-P&L tax breakdown.
+
+    ``st_realized`` / ``lt_realized`` are pre-netting raw bucket sums
+    (gross gain - gross loss within bucket). ``net_after_cross`` is the
+    post-cross-bucket-netting figure. ``deductible_loss`` is the portion
+    of an overall loss deducted against ordinary income this year (capped
+    at ``TaxConfig.deductible_loss_cap``). ``carry_forward`` is the unused
+    loss rolling into next year. ``tax_owed`` is signed: positive means
+    cash deducted from the equity curve, negative means a refund/credit.
+    """
+
+    year: int
+    st_realized: float
+    lt_realized: float
+    net_after_cross: float
+    deductible_loss: float
+    carry_forward: float
+    tax_owed: float
+    payment_date: date
+
+
+def _payment_date_for_year(year: int, lag_days: int, end_date: date) -> date:
+    """Year-end + lag, clamped to end_date if it would fall past it."""
+    natural = date(year, 12, 31) + timedelta(days=lag_days)
+    return min(natural, end_date)
+
+
+def compute_tax_summary(
+    trades: Sequence[TradeRecord],
+    basis_per_sell: Sequence[float],
+    config: TaxConfig,
+    end_date: date,
+) -> list[AnnualTaxSummary]:
+    """Group SELLs by calendar year; net per-bucket then cross-bucket; carry losses.
+
+    Args:
+        trades: All TradeRecords from the backtest or live trade log. BUYs are
+            ignored. SELL records must carry a non-None ``holding_period``.
+        basis_per_sell: Parallel list of share-weighted cost basis per SELL,
+            in the same order as SELL records appear in ``trades``.
+        config: Tax-rate policy. None disables tax accounting; callers should
+            check before invoking.
+        end_date: Last bar of the backtest (or report-period end). Years whose
+            natural payment date falls past this are clamped to it.
+
+    Returns:
+        One AnnualTaxSummary per calendar year that contained at least one
+        SELL or that received a carryforward from the prior year. Sorted by
+        year ascending.
+    """
+    paired = _pair_sells_with_basis(list(trades), list(basis_per_sell))
+    by_year_st: dict[int, float] = defaultdict(float)
+    by_year_lt: dict[int, float] = defaultdict(float)
+
+    for trade, basis in paired:
+        if trade.direction != Direction.SELL or trade.holding_period is None:
+            continue
+        pnl = (trade.price - basis) * trade.shares
+        if trade.holding_period == HoldingPeriod.LONG_TERM:
+            by_year_lt[trade.date.year] += pnl
+        else:
+            by_year_st[trade.date.year] += pnl
+
+    years_with_activity = sorted(set(by_year_st) | set(by_year_lt))
+    if not years_with_activity:
+        return []
+
+    summaries: list[AnnualTaxSummary] = []
+    carry_in = 0.0  # signed; positive == accumulated loss available to offset gains
+    for year in years_with_activity:
+        st_raw = by_year_st.get(year, 0.0)
+        lt_raw = by_year_lt.get(year, 0.0)
+
+        # Per-bucket netting is the raw sum (already done by accumulation).
+        # Cross-bucket: if signs differ, net them.
+        st_after_cross = st_raw
+        lt_after_cross = lt_raw
+        if st_raw > 0 and lt_raw < 0:
+            offset = min(st_raw, -lt_raw)
+            st_after_cross -= offset
+            lt_after_cross += offset
+        elif lt_raw > 0 and st_raw < 0:
+            offset = min(lt_raw, -st_raw)
+            lt_after_cross -= offset
+            st_after_cross += offset
+
+        # Apply prior-year carry to remaining gains (loses ST/LT character).
+        net_pre_carry = st_after_cross + lt_after_cross
+        if carry_in > 0 and net_pre_carry > 0:
+            offset = min(carry_in, net_pre_carry)
+            # Shave the offset off whichever bucket is positive, ST first.
+            if st_after_cross > 0:
+                shave = min(offset, st_after_cross)
+                st_after_cross -= shave
+                offset -= shave
+            if offset > 0 and lt_after_cross > 0:
+                lt_after_cross -= offset
+            carry_in -= min(carry_in, net_pre_carry)
+
+        net_after_cross = st_after_cross + lt_after_cross
+        deductible_loss = 0.0
+        carry_out = 0.0
+
+        if net_after_cross >= 0:
+            tax_owed = st_after_cross * config.short_term_rate + lt_after_cross * config.long_term_rate
+        else:
+            absolute = -net_after_cross
+            deductible_loss = min(absolute, config.deductible_loss_cap)
+            carry_out = absolute - deductible_loss
+            # Negative tax_owed == credit at ST rate (matches §1211(b) treatment
+            # of net capital loss as an offset against ordinary income).
+            tax_owed = -deductible_loss * config.short_term_rate
+
+        # Roll any unused prior-year carry into this year's carry_out, since
+        # carryforward accumulates indefinitely (loses character either way).
+        carry_out += carry_in
+        carry_in = carry_out
+
+        summaries.append(
+            AnnualTaxSummary(
+                year=year,
+                st_realized=st_raw,
+                lt_realized=lt_raw,
+                net_after_cross=net_after_cross,
+                deductible_loss=deductible_loss,
+                carry_forward=carry_out,
+                tax_owed=tax_owed,
+                payment_date=_payment_date_for_year(year, config.payment_lag_days, end_date),
+            )
+        )
+    return summaries
+
+
+def compute_after_tax_curve(
+    equity_curve: Sequence[tuple[date, float]],
+    summaries: Sequence[AnnualTaxSummary],
+    end_date: date,
+) -> list[tuple[date, float]]:
+    """Apply each year's tax_owed to *equity_curve* at its payment_date.
+
+    Refunds (negative tax_owed) increase the curve. The original curve is not
+    mutated. If summaries is empty, returns the gross curve as a copy.
+    """
+    if not summaries:
+        return list(equity_curve)
+    pending = sorted(((s.payment_date, s.tax_owed) for s in summaries), key=lambda item: item[0])
+    out: list[tuple[date, float]] = []
+    cumulative_deduction = 0.0
+    payment_idx = 0
+    for day, value in equity_curve:
+        while payment_idx < len(pending) and pending[payment_idx][0] <= day:
+            cumulative_deduction += pending[payment_idx][1]
+            payment_idx += 1
+        out.append((day, value - cumulative_deduction))
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_tax.py -v`
+Expected: PASS for all 8 tests.
+
+Run: `uv run mypy src` and `uv run ruff check .` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/tax.py tests/test_tax.py
+git commit -m "Add tax module: annual ST/LT netting + \$3K deductible + carryforward
+
+compute_tax_summary groups SELLs by year, runs IRS Schedule D-style
+per-bucket then cross-bucket netting, applies the \$3,000 ordinary-income
+offset, and threads carryforward across years.
+
+compute_after_tax_curve applies each year's tax_owed to a gross equity
+curve at the configured payment date (Dec 31 + payment_lag_days,
+defaulting to ~Apr 15 of the following year), clamped to backtest end."
+```
+
+---
+
+## Task 9: After-tax fields in `BacktestResult` + result writers
+
+**Files:**
+- Modify: `src/midas/results.py` (`BacktestResult`, `write_backtest_results`, `_write_equity_curve_csv`, `_write_summary_json`)
+- Modify: `src/midas/backtest.py:_build_result` (compute and populate the new fields)
+- Modify: `src/midas/cli.py:179-191` (thread `tax_config` into `BacktestEngine.run`)
+- Test: `tests/test_backtest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_backtest.py`:
+
+```python
+def test_backtest_result_after_tax_fields_populated_with_tax_config() -> None:
+    """End-to-end: a 2-year backtest with TaxConfig set populates after_tax_*."""
+    from midas.models import TaxConfig
+    # ... use the existing backtest harness used for full-engine tests in this file
+    tax = TaxConfig(short_term_rate=0.30, long_term_rate=0.15)
+    result = _run_backtest_with(tax_config=tax)  # implement this helper alongside
+    assert result.after_tax_final_value is not None
+    assert result.after_tax_cagr is not None
+    assert result.tax_summary  # non-empty
+    assert result.tax_cost_ratio is not None
+
+
+def test_backtest_result_after_tax_fields_none_without_tax_config() -> None:
+    """Backwards-compatible: without TaxConfig, all after-tax fields are None/empty."""
+    result = _run_backtest_with(tax_config=None)
+    assert result.after_tax_final_value is None
+    assert result.after_tax_equity_curve == []
+    assert result.tax_summary == []
+    assert result.tax_cost_ratio is None
+```
+
+(Use the test patterns already in `tests/test_backtest.py` to construct `_run_backtest_with`. Read existing `BacktestEngine` calling tests as a template.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_backtest.py::test_backtest_result_after_tax_fields_populated_with_tax_config -v`
+Expected: FAIL — fields don't exist.
+
+- [ ] **Step 3: Add fields to `BacktestResult` in `src/midas/results.py`**
+
+```python
+from midas.tax import AnnualTaxSummary
+from midas.models import Direction, TaxConfig, TradeRecord
+
+
+@dataclass
+class BacktestResult:
+    """Complete output of a single backtest run."""
+
+    trades: list[TradeRecord]
+    final_value: float
+    starting_value: float
+    buy_and_hold_value: float
+    train_trades: list[TradeRecord]
+    test_trades: list[TradeRecord]
+    train_return: float
+    test_return: float
+    train_bh_return: float
+    test_bh_return: float
+    split_date: date | None
+    twr: float
+    equity_curve: list[tuple[date, float]]
+    total_days: int
+    train_days: int
+    test_days: int
+    cagr: float
+    max_drawdown: float
+    sharpe_ratio: float
+    sortino_ratio: float
+    win_rate: float
+    profit_factor: float
+    avg_win: float
+    avg_loss: float
+    efficiency_ratio: float
+    strategy_stats: list[StrategyStats]
+    unrealized_pnl: float
+    unrealized_pnl_by_ticker: dict[str, float]
+    basis_per_sell: list[float]
+    risk_metrics: RiskMetrics | None = None
+    risk_history: RiskHistory | None = None
+    bh_equity_curve: list[tuple[date, float]] = field(default_factory=list)
+    """Per-bar buy-and-hold equity, parallel to ``equity_curve``."""
+    after_tax_final_value: float | None = None
+    after_tax_total_return: float | None = None
+    after_tax_cagr: float | None = None
+    after_tax_twr: float | None = None
+    after_tax_equity_curve: list[tuple[date, float]] = field(default_factory=list)
+    tax_cost_ratio: float | None = None
+    tax_summary: list[AnnualTaxSummary] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Compute the after-tax fields in `_build_result`**
+
+Read `src/midas/backtest.py` to find `_build_result` (~line 1011). After all gross fields are computed, add:
+
+```python
+# After-tax accounting (opt-in via TaxConfig). When tax_config is None all
+# fields stay at their dataclass defaults (None / []) — no behavior change
+# for users who don't configure tax rates.
+after_tax_final_value: float | None = None
+after_tax_total_return: float | None = None
+after_tax_cagr_value: float | None = None
+after_tax_twr_value: float | None = None
+after_tax_curve: list[tuple[date, float]] = []
+tax_cost_ratio: float | None = None
+tax_summary: list[AnnualTaxSummary] = []
+
+if self._tax_config is not None:
+    end_d = trading_days[-1]
+    tax_summary = compute_tax_summary(
+        state.trades,
+        state.basis_per_sell,
+        self._tax_config,
+        end_date=end_d,
+    )
+    after_tax_curve = compute_after_tax_curve(state.equity_curve, tax_summary, end_d)
+    if after_tax_curve:
+        after_tax_final_value = after_tax_curve[-1][1]
+        if portfolio.available_cash > 0:
+            starting = state.starting_value
+            after_tax_total_return = (
+                (after_tax_final_value - starting) / starting if starting > 0 else 0.0
+            )
+            after_tax_cagr_value = compute_cagr(starting, after_tax_final_value, total_days)
+            # After-tax TWR mirrors gross TWR construction: compound each
+            # sub-period's return on the after-tax curve. Approximation:
+            # piecewise scaling of the gross sub-periods by (after/gross) at
+            # period close — acceptable since tax payments are pointwise.
+            after_tax_twr_value = (
+                ((1.0 + state.twr_pre_compound) * (after_tax_final_value / state.final_pre_tax))
+                - 1.0
+                if state.final_pre_tax > 0
+                else twr
+            )
+            if cagr > 0:
+                tax_cost_ratio = (cagr - after_tax_cagr_value) / cagr
+            else:
+                tax_cost_ratio = 0.0
+
+return BacktestResult(
+    # ... all existing fields ...
+    after_tax_final_value=after_tax_final_value,
+    after_tax_total_return=after_tax_total_return,
+    after_tax_cagr=after_tax_cagr_value,
+    after_tax_twr=after_tax_twr_value,
+    after_tax_equity_curve=after_tax_curve,
+    tax_cost_ratio=tax_cost_ratio,
+    tax_summary=tax_summary,
+)
+```
+
+(If `state.twr_pre_compound` and `state.final_pre_tax` aren't already tracked, replace the after-tax TWR with `compute_cagr(starting, after_tax_final_value, total_days)`-equivalent or simply `None` and document. Keep this scope tight — the implementer may simplify TWR to "same as CAGR for post-tax" if upstream state plumbing is invasive; the spec only requires the field to be populated.)
+
+Add `tax_config` to `BacktestEngine.__init__`:
+
+```python
+def __init__(
+    self,
+    *,
+    allocator: Allocator,
+    order_sizer: OrderSizer,
+    exit_rules: list[ExitRule] | None = None,
+    constraints: AllocationConstraints | None = None,
+    train_pct: float = DEFAULT_TRAIN_PCT,
+    enable_split: bool = True,
+    log_fn: Callable[[str], None] | None = None,
+    execution_mode: ExecutionMode = "next_open",
+    tax_config: TaxConfig | None = None,
+) -> None:
+    # existing body
+    self._tax_config = tax_config
+```
+
+Add necessary imports:
+
+```python
+from midas.tax import AnnualTaxSummary, compute_after_tax_curve, compute_tax_summary
+from midas.metrics import compute_cagr  # if not already imported
+```
+
+- [ ] **Step 5: Thread `tax_config` from `cli.py` into `BacktestEngine`**
+
+In `src/midas/cli.py:179-188`:
+
+```python
+engine = BacktestEngine(
+    allocator=allocator,
+    order_sizer=order_sizer,
+    exit_rules=exit_rules,
+    constraints=constraints,
+    train_pct=train_pct,
+    enable_split=not no_split,
+    log_fn=print_status,
+    execution_mode=execution_mode,
+    tax_config=tax_config,
+)
+```
+
+- [ ] **Step 6: Update `_write_equity_curve_csv` to include `nav_after_tax` when populated**
+
+In `src/midas/results.py`:
+
+```python
+def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
+    drawdowns = _drawdown_series(result.equity_curve)
+    has_after_tax = (
+        len(result.after_tax_equity_curve) == len(result.equity_curve)
+        and result.after_tax_equity_curve
+    )
+    after_tax_by_date = (
+        {dt: nav for dt, nav in result.after_tax_equity_curve} if has_after_tax else {}
+    )
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        header = ["date", "nav", "drawdown"]
+        if has_after_tax:
+            header.append("nav_after_tax")
+        writer.writerow(header)
+        for (dt, nav), drawdown in zip(result.equity_curve, drawdowns, strict=True):
+            row = [dt.isoformat(), round(nav, 2), round(drawdown, 6)]
+            if has_after_tax:
+                row.append(round(after_tax_by_date.get(dt, nav), 2))
+            writer.writerow(row)
+```
+
+- [ ] **Step 7: Update `_write_summary_json` for after-tax fields and tax_summary**
+
+```python
+def _write_summary_json(result: BacktestResult, path: Path) -> None:
+    # ... existing summary dict construction ...
+
+    if result.after_tax_final_value is not None:
+        summary["after_tax_final_value"] = result.after_tax_final_value
+        summary["after_tax_total_return"] = round(result.after_tax_total_return or 0.0, 6)
+        summary["after_tax_cagr"] = round(result.after_tax_cagr or 0.0, 6)
+        if result.after_tax_twr is not None:
+            summary["after_tax_twr"] = round(result.after_tax_twr, 6)
+        summary["tax_cost_ratio"] = round(result.tax_cost_ratio or 0.0, 6)
+
+    if result.tax_summary:
+        summary["tax_summary"] = [
+            {
+                "year": s.year,
+                "st_realized": round(s.st_realized, 4),
+                "lt_realized": round(s.lt_realized, 4),
+                "net_after_cross": round(s.net_after_cross, 4),
+                "deductible_loss": round(s.deductible_loss, 4),
+                "carry_forward": round(s.carry_forward, 4),
+                "tax_owed": round(s.tax_owed, 4),
+                "payment_date": s.payment_date.isoformat(),
+            }
+            for s in result.tax_summary
+        ]
+
+    with open(path, "w") as f:
+        json.dump(summary, f, indent=2)
+        f.write("\n")
+```
+
+- [ ] **Step 8: Run tests to verify pass**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS for new and existing tests; existing `tests/test_backtest.py` may need touch-ups in fixture construction if it instantiates `BacktestEngine` directly — add `tax_config=None` to those calls.
+
+Run: `uv run mypy src && uv run ruff check .` — clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/midas/results.py src/midas/backtest.py src/midas/cli.py tests/test_backtest.py
+git commit -m "BacktestResult: opt-in after-tax fields, equity-curve column, summary.json
+
+When TaxConfig is set in the strategies YAML, BacktestResult gains
+after_tax_final_value, after_tax_total_return, after_tax_cagr,
+after_tax_twr, after_tax_equity_curve, tax_cost_ratio, and tax_summary.
+equity_curve.csv gains a parallel nav_after_tax column; summary.json
+gains the after-tax block and a per-year tax_summary array.
+
+Without TaxConfig all fields stay None/empty — no behavior change for
+existing configs."
+```
+
+---
+
+## Task 10: After-tax block in summary print + chart overlay
+
+**Files:**
+- Modify: `src/midas/output.py:_return_row` (no change) and `print_backtest_summary`
+- Modify: `src/midas/charts.py:_render_equity` to overlay after-tax curve when populated
+- Test: `tests/test_charts.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_charts.py`:
+
+```python
+def test_render_equity_includes_after_tax_overlay_when_populated(capsys, monkeypatch) -> None:
+    """When BacktestResult.after_tax_equity_curve is non-empty, the equity chart plots both."""
+    import plotext as plt
+    from midas.charts import _render_equity
+    from midas.results import BacktestResult
+    # ... build a minimal BacktestResult with equity_curve and a parallel after_tax_equity_curve
+
+    plot_calls: list[str] = []
+    real_plot = plt.plot
+    def spy(*args, **kwargs):
+        plot_calls.append(kwargs.get("label", ""))
+        return real_plot(*args, **kwargs)
+    monkeypatch.setattr(plt, "plot", spy)
+
+    _render_equity(_make_result_with_after_tax())
+    # Two series: gross + after-tax → two plot calls inside _render_equity.
+    assert any("After-Tax" in label for label in plot_calls)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_charts.py::test_render_equity_includes_after_tax_overlay_when_populated -v`
+Expected: FAIL — the renderer plots only the gross curve.
+
+- [ ] **Step 3: Update `_render_equity` in `src/midas/charts.py`**
+
+```python
+def _render_equity(result: BacktestResult) -> None:
+    dates = [dt.isoformat() for dt, _ in result.equity_curve]
+    equity = [value for _, value in result.equity_curve]
+    _setup_single_figure()
+    has_after_tax = (
+        len(result.after_tax_equity_curve) == len(result.equity_curve)
+        and result.after_tax_equity_curve
+    )
+    if has_after_tax:
+        plt.plot(dates, equity, color="cyan", label="Gross", marker="braille")
+        after_tax = [value for _, value in result.after_tax_equity_curve]
+        plt.plot(dates, after_tax, color="magenta", label="After-Tax", marker="braille")
+    else:
+        plt.plot(dates, equity, color="cyan", marker="braille")
+    plt.ylabel("Portfolio $")
+    title = "Equity Curve (Gross vs After-Tax)" if has_after_tax else "Equity Curve"
+    _flush_centered(title)
+```
+
+- [ ] **Step 4: Add an after-tax block to `print_backtest_summary` in `src/midas/output.py`**
+
+Insert after the existing Performance section (around line 175):
+
+```python
+if result.after_tax_final_value is not None:
+    after_tax = make_metric_table("After-Tax Performance")
+    after_tax.add_row("After-Tax Final Value", f"${result.after_tax_final_value:,.2f}")
+    after_tax.add_row(
+        "After-Tax Total Return",
+        _return_row(result.after_tax_total_return or 0.0, total_days),
+    )
+    after_tax.add_row("After-Tax CAGR", color_signed(result.after_tax_cagr or 0.0))
+    if result.tax_cost_ratio is not None:
+        after_tax.add_row("Tax Cost Ratio", f"{result.tax_cost_ratio:.2%}")
+    print_centered(after_tax)
+
+    if result.tax_summary:
+        tax_table = make_wide_table("Realized Tax (per year)")
+        tax_table.add_column("Year", style="bold")
+        tax_table.add_column("ST Realized", justify="right")
+        tax_table.add_column("LT Realized", justify="right")
+        tax_table.add_column("Net (after netting)", justify="right")
+        tax_table.add_column("Tax Owed", justify="right")
+        tax_table.add_column("Carry Forward", justify="right")
+        for s in result.tax_summary:
+            tax_table.add_row(
+                str(s.year),
+                f"${s.st_realized:+,.2f}",
+                f"${s.lt_realized:+,.2f}",
+                f"${s.net_after_cross:+,.2f}",
+                f"${s.tax_owed:+,.2f}",
+                f"${s.carry_forward:,.2f}",
+            )
+        print_centered(tax_table)
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `uv run pytest tests/ -v`
+Expected: PASS.
+
+Manual smoke: run a 2-year backtest with a `tax:` block in the strategies YAML and visually inspect that the after-tax block prints under Performance and the chart overlays the two curves.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/midas/output.py src/midas/charts.py tests/test_charts.py
+git commit -m "Print summary: after-tax block + per-year tax table; chart overlay
+
+print_backtest_summary now prints an After-Tax Performance block under
+the gross Performance block when TaxConfig is set, plus a per-year
+Realized Tax table (ST/LT/Net/Tax Owed/Carry Forward).
+
+The equity-curve chart overlays the after-tax curve in magenta when
+populated; otherwise renders the gross curve alone (no behavior change
+for users without TaxConfig)."
+```
+
+---
+
+## Task 11: `midas tax-report` CLI subcommand
+
+**Files:**
+- Modify: `src/midas/cli.py` (add new click command)
+- Test: `tests/test_cli_tax_report.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_cli_tax_report.py`:
+
+```python
+"""Smoke tests for the `midas tax-report` subcommand."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from midas.cli import cli
+from midas.models import Direction, HoldingPeriod, TradeRecord
+from midas.trade_log import append_trade
+
+
+def _seed_log(path: Path) -> None:
+    append_trade(
+        path,
+        TradeRecord(
+            date=date(2026, 6, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=10.0,
+            price=30.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.SHORT_TERM,
+            purchase_date=date(2026, 1, 1),
+        ),
+        cost_basis=20.0,
+        purchase_date=date(2026, 1, 1),
+    )
+    append_trade(
+        path,
+        TradeRecord(
+            date=date(2026, 7, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=5.0,
+            price=40.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.LONG_TERM,
+            purchase_date=date(2024, 1, 1),
+        ),
+        cost_basis=15.0,
+        purchase_date=date(2024, 1, 1),
+    )
+
+
+def test_tax_report_emits_csv_and_prints_totals(tmp_path: Path) -> None:
+    log = tmp_path / "trades.csv"
+    output = tmp_path / "schedule_d_2026.csv"
+    _seed_log(log)
+    # Inline strategies file with tax block
+    strategies = tmp_path / "strategies.yaml"
+    strategies.write_text(
+        "strategies:\n  - name: Momentum\n    params: {window: 20}\n"
+        "tax:\n  short_term_rate: 0.30\n  long_term_rate: 0.15\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tax-report",
+            "--from-trades",
+            str(log),
+            "--strategies",
+            str(strategies),
+            "--year",
+            "2026",
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Short-Term" in result.output
+    assert "Long-Term" in result.output
+    assert output.exists()
+    csv_text = output.read_text()
+    assert "AAPL" in csv_text
+
+
+def test_tax_report_no_sells_in_year_prints_message(tmp_path: Path) -> None:
+    log = tmp_path / "trades.csv"
+    _seed_log(log)
+    strategies = tmp_path / "strategies.yaml"
+    strategies.write_text(
+        "strategies:\n  - name: Momentum\n    params: {window: 20}\n"
+        "tax:\n  short_term_rate: 0.30\n  long_term_rate: 0.15\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tax-report",
+            "--from-trades",
+            str(log),
+            "--strategies",
+            str(strategies),
+            "--year",
+            "2099",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "No realized sales" in result.output
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cli_tax_report.py -v`
+Expected: FAIL with `Error: No such command 'tax-report'`.
+
+- [ ] **Step 3: Implement the subcommand in `src/midas/cli.py`**
+
+Add the click command (placement: after the `live` command, before `optimize`):
+
+```python
+@cli.command(name="tax-report")
+@click.option(
+    "--portfolio",
+    "-p",
+    default=None,
+    type=click.Path(exists=True),
+    help="Portfolio YAML; resolves the trade log next to its state file unless --from-trades is given.",
+)
+@click.option(
+    "--strategies",
+    "-s",
+    required=True,
+    type=click.Path(exists=True),
+    help="Strategies YAML containing the tax: block. Required — rates have no defaults at the CLI.",
+)
+@click.option(
+    "--from-trades",
+    "from_trades",
+    default=None,
+    type=click.Path(exists=True),
+    help="Explicit path to a trades.csv. Overrides --portfolio resolution.",
+)
+@click.option("--year", type=int, default=None, help="Calendar year to report (e.g. 2026).")
+@click.option("--start", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--end", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Output CSV path. Defaults to schedule_d_<year>.csv (or schedule_d_<start>_<end>.csv).",
+)
+def tax_report(
+    portfolio: str | None,
+    strategies: str,
+    from_trades: str | None,
+    year: int | None,
+    start: datetime | None,
+    end: datetime | None,
+    output: str | None,
+) -> None:
+    """Year-end realized-P&L report (Schedule D-shaped) from a trade log."""
+    from midas.tax import compute_tax_summary
+    from midas.trade_log import LoggedTrade, read_trades
+
+    if year is None and (start is None or end is None):
+        msg = "either --year or both --start and --end must be provided"
+        raise click.UsageError(msg)
+
+    _strats, _constraints, _risk, tax_config = load_strategies(Path(strategies))
+    if tax_config is None:
+        msg = (
+            "strategies file has no `tax:` block; tax-report requires configured rates "
+            "(short_term_rate, long_term_rate). See docs/tax-reporting.md."
+        )
+        raise click.UsageError(msg)
+
+    if from_trades is not None:
+        trades_path = Path(from_trades)
+    else:
+        if portfolio is None:
+            raise click.UsageError("either --portfolio or --from-trades is required")
+        port = load_portfolio(Path(portfolio))
+        portfolio_path = Path(portfolio)
+        state_path = port.state_file if port.state_file is not None else portfolio_path.with_suffix(".state.yaml")
+        trades_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+        if not trades_path.exists():
+            msg = f"trade log not found at {trades_path}"
+            raise click.UsageError(msg)
+
+    if year is not None:
+        start_d = date(year, 1, 1)
+        end_d = date(year, 12, 31)
+        period_label = str(year)
+    else:
+        assert start is not None and end is not None  # guarded above
+        start_d = _to_date(start)
+        end_d = _to_date(end)
+        period_label = f"{start_d.isoformat()}_{end_d.isoformat()}"
+
+    rows: list[LoggedTrade] = [
+        row for row in read_trades(trades_path)
+        if row.direction == Direction.SELL and start_d <= row.date <= end_d
+    ]
+
+    if not rows:
+        click.echo(f"No realized sales in {period_label}.")
+        if output is not None:
+            Path(output).write_text(",".join(_TAX_REPORT_COLUMNS) + "\n")
+        return
+
+    out_path = Path(output) if output is not None else Path(f"schedule_d_{period_label}.csv")
+
+    # Convert filtered LoggedTrade rows to TradeRecord for compute_tax_summary;
+    # basis_per_sell parallel list comes from each row's cost_basis.
+    trade_records: list[TradeRecord] = []
+    basis_per_sell: list[float] = []
+    for row in rows:
+        trade_records.append(
+            TradeRecord(
+                date=row.date,
+                ticker=row.ticker,
+                direction=row.direction,
+                shares=row.shares,
+                price=row.price,
+                strategy_name=row.strategy_name,
+                holding_period=row.holding_period,
+                purchase_date=row.purchase_date,
+            )
+        )
+        basis_per_sell.append(row.cost_basis if row.cost_basis is not None else row.price)
+
+    summary = compute_tax_summary(trade_records, basis_per_sell, tax_config, end_date=end_d)
+    _print_tax_report(rows, basis_per_sell, summary, period_label)
+    _write_tax_report_csv(rows, basis_per_sell, summary, out_path)
+    click.echo(f"\nWrote {out_path}")
+```
+
+Add the column constants and helper functions at the bottom of `cli.py`:
+
+```python
+_TAX_REPORT_COLUMNS = (
+    "ticker",
+    "shares",
+    "purchase_date",
+    "sale_date",
+    "cost_basis",
+    "proceeds",
+    "realized_pnl",
+    "holding_period_days",
+    "classification",
+)
+
+
+def _print_tax_report(
+    rows: list[LoggedTrade],
+    basis_per_sell: list[float],
+    summary: list[AnnualTaxSummary],
+    period_label: str,
+) -> None:
+    from midas.output import make_wide_table, print_centered
+
+    table = make_wide_table(f"Schedule D — {period_label}")
+    table.add_column("Ticker", style="bold")
+    table.add_column("Shares", justify="right")
+    table.add_column("Purchase Date")
+    table.add_column("Sale Date")
+    table.add_column("Cost Basis", justify="right")
+    table.add_column("Proceeds", justify="right")
+    table.add_column("Realized P&L", justify="right")
+    table.add_column("Days Held", justify="right")
+    table.add_column("Classification")
+
+    for row, basis in zip(rows, basis_per_sell, strict=True):
+        proceeds = row.shares * row.price
+        pnl = proceeds - basis * row.shares
+        if isinstance(row.purchase_date, date):
+            days_held = (row.date - row.purchase_date).days
+            purchase_disp = row.purchase_date.isoformat()
+            days_disp = str(days_held)
+        else:
+            purchase_disp = row.purchase_date or ""
+            days_disp = ""
+        classification = row.holding_period.value if row.holding_period else ""
+        table.add_row(
+            row.ticker,
+            f"{row.shares:.4f}",
+            purchase_disp,
+            row.date.isoformat(),
+            f"${basis:,.2f}",
+            f"${proceeds:,.2f}",
+            f"${pnl:+,.2f}",
+            days_disp,
+            classification,
+        )
+    print_centered(table)
+
+    for s in summary:
+        click.echo(
+            f"\nYear {s.year}: ST {s.st_realized:+,.2f}  LT {s.lt_realized:+,.2f}  "
+            f"Net {s.net_after_cross:+,.2f}  Deductible {s.deductible_loss:,.2f}  "
+            f"Tax {s.tax_owed:+,.2f}  Carry-Forward {s.carry_forward:,.2f}"
+        )
+
+
+def _write_tax_report_csv(
+    rows: list[LoggedTrade],
+    basis_per_sell: list[float],
+    summary: list[AnnualTaxSummary],
+    path: Path,
+) -> None:
+    import csv
+
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(_TAX_REPORT_COLUMNS)
+        for row, basis in zip(rows, basis_per_sell, strict=True):
+            proceeds = row.shares * row.price
+            pnl = proceeds - basis * row.shares
+            if isinstance(row.purchase_date, date):
+                days_held: object = (row.date - row.purchase_date).days
+                purchase_cell: str = row.purchase_date.isoformat()
+            else:
+                days_held = ""
+                purchase_cell = row.purchase_date or ""
+            writer.writerow(
+                [
+                    row.ticker,
+                    row.shares,
+                    purchase_cell,
+                    row.date.isoformat(),
+                    round(basis, 4),
+                    round(proceeds, 4),
+                    round(pnl, 4),
+                    days_held,
+                    row.holding_period.value if row.holding_period else "",
+                ]
+            )
+        # Footer: per-year aggregates
+        for s in summary:
+            writer.writerow([])
+            writer.writerow([f"Year {s.year}", "", "", "", "", "", "", "", ""])
+            writer.writerow(["ST realized", "", "", "", "", "", round(s.st_realized, 4), "", ""])
+            writer.writerow(["LT realized", "", "", "", "", "", round(s.lt_realized, 4), "", ""])
+            writer.writerow(["Net (after netting)", "", "", "", "", "", round(s.net_after_cross, 4), "", ""])
+            writer.writerow(["Deductible loss", "", "", "", "", "", round(s.deductible_loss, 4), "", ""])
+            writer.writerow(["Tax owed", "", "", "", "", "", round(s.tax_owed, 4), "", ""])
+            writer.writerow(["Carry forward", "", "", "", "", "", round(s.carry_forward, 4), "", ""])
+```
+
+Add the missing imports at the top of `cli.py`:
+
+```python
+from datetime import datetime  # if not already
+from midas.models import Direction, TradeRecord
+from midas.tax import AnnualTaxSummary
+from midas.trade_log import LoggedTrade
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_cli_tax_report.py -v`
+Expected: PASS for both tests.
+
+Run the full suite: `uv run pytest -v && uv run mypy src && uv run ruff check .`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/midas/cli.py tests/test_cli_tax_report.py
+git commit -m "Add midas tax-report subcommand
+
+Reads <state>.trades.csv (or --from-trades <path>) and emits a
+Schedule D-shaped table to stdout plus a CSV at --output. Per-row
+columns: ticker, shares, purchase/sale dates, basis, proceeds, P&L,
+days held, classification. Per-year footer: ST/LT/Net/Tax Owed/
+Carry-Forward computed via the same netting code backtest uses, so
+backtest after-tax numbers and tax-report numbers agree exactly."
+```
+
+---
+
+## Task 12: Documentation
+
+**Files:**
+- Create: `docs/tax-reporting.md`
+- Modify: `docs/architecture.md` (add a one-line pointer)
+
+- [ ] **Step 1: Write `docs/tax-reporting.md`**
+
+```markdown
+# Tax reporting
+
+Midas can report realized capital gains in a Schedule D-shaped format and (in
+backtest mode only) compute after-tax return metrics. Tax accounting is opt-in:
+without a `tax:` block in the strategies YAML, all output is unchanged from
+pre-#66 behavior.
+
+## Configuring rates
+
+Add a `tax:` block to the strategies YAML alongside the existing top-level
+keys (`min_cash_pct`, `softmax_temperature`, optional `risk:`):
+
+\`\`\`yaml
+tax:
+  short_term_rate: 0.37   # decimal fraction; default top federal bracket
+  long_term_rate: 0.20    # decimal fraction; default top federal LTCG
+  deductible_loss_cap: 3000.0
+  payment_lag_days: 105   # Dec 31 → ~Apr 15 of following year
+\`\`\`
+
+All four fields have defaults; the block is parsed leniently.
+
+## Backtest: after-tax metrics
+
+Running `midas backtest` with a `tax:` block in the strategies YAML adds:
+
+- `after_tax_final_value`, `after_tax_total_return`, `after_tax_cagr`,
+  `after_tax_twr` to `summary.json`.
+- A `nav_after_tax` column in `equity_curve.csv` parallel to `nav`.
+- A `tax_summary` array in `summary.json` with one entry per calendar year
+  containing realized sales (`st_realized`, `lt_realized`, `net_after_cross`,
+  `deductible_loss`, `carry_forward`, `tax_owed`, `payment_date`).
+- A `tax_cost_ratio` field equal to `(cagr - after_tax_cagr) / cagr`.
+
+The summary terminal output gains an "After-Tax Performance" block and a
+per-year "Realized Tax" table. The equity-curve chart overlays gross and
+after-tax curves in cyan and magenta.
+
+Tax owed for year Y is deducted from the after-tax curve at
+`Dec 31 of Y + payment_lag_days` (default Apr 15 of Y+1). If the payment
+date falls past the end of the backtest, it's clamped to the final bar
+— a known overstatement of tax drag in the run-end year.
+
+## Live: trade log
+
+Each tick that produces fills appends rows to `<state>.trades.csv` next to
+the state file. Format matches `<output>/trades.csv` from `midas backtest`,
+plus a `purchase_date` column added in both modes:
+
+| Column | Notes |
+|---|---|
+| `date` | Fill date. |
+| `ticker` | Symbol. |
+| `direction` | `BUY` or `SELL`. |
+| `shares`, `price` | Numeric. |
+| `strategy` | Source signal name. |
+| `holding_period` | `short-term` / `long-term` / empty for buys. |
+| `purchase_date` | Buy date for BUYs. SELL bucket: a single date when all consumed lots share one, the literal string `various` for mixed-lot buckets, or empty when the lot's date was unknown. |
+| `cost_basis` | Share-weighted bucket basis on SELL bucket rows. |
+| `realized_pnl` | `(price - cost_basis) * shares` on SELL rows. |
+| `return_pct` | `(price - cost_basis) / cost_basis` on SELL rows. |
+
+The log is append-only. Hand-edits are an explicit escape valve (correcting
+a recorded price after broker confirms a different fill). The reader is
+strict on schema (header drift or partial rows raise `TradeLogError` with a
+line number) and lenient on content.
+
+## `midas tax-report`
+
+\`\`\`
+midas tax-report --strategies strategies.yaml \\
+                 --portfolio portfolio.yaml --year 2026 \\
+                 [--output schedule_d_2026.csv]
+\`\`\`
+
+Or against an explicit log path (e.g. backtest output):
+
+\`\`\`
+midas tax-report --strategies strategies.yaml \\
+                 --from-trades output/trades.csv --year 2026
+\`\`\`
+
+Prints a per-row table (ticker, shares, purchase/sale dates, basis,
+proceeds, P&L, days held, classification) and writes the same data plus a
+per-year aggregate footer to `--output`.
+
+`--start` / `--end` accept arbitrary date ranges instead of `--year`.
+
+## Caveats
+
+- **No wash-sale detection.** Broker 1099-B handles it; we don't replicate
+  broker-specific adjustments.
+- **No tax-aware allocation.** The allocator is and stays tax-blind. See
+  issue #69 for the in-progress follow-up that adds an after-tax objective
+  to the optimizer.
+- **FIFO only.** Specific-lot or LIFO accounting is out of scope.
+- **Carryforward loses ST/LT character on rollover.** IRS preserves
+  character; we use a single signed scalar. For most operators the
+  difference is small (carryforward rate is the higher of ST/LT in the
+  year it's used).
+- **Pre-existing live deployments upgrading mid-year:** the trade log
+  starts fresh on the first post-upgrade tick. Year-end report for the
+  upgrade year is partial; merge with broker statements.
+```
+
+- [ ] **Step 2: Add a one-line pointer to `docs/architecture.md`**
+
+Read the existing `docs/architecture.md` and append a short reference under the most appropriate section (likely a "Reporting & output" or similar). Example line:
+
+```markdown
+- **Tax reporting:** `<state>.trades.csv` (live) and `output/trades.csv` (backtest) share one shape and feed `midas tax-report`. Backtest gains opt-in after-tax metrics via a `tax:` block in the strategies YAML. See `docs/tax-reporting.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/tax-reporting.md docs/architecture.md
+git commit -m "Docs: add tax-reporting guide; reference from architecture.md"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full test suite + lint + types**
+
+Run all four checks; all must pass.
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy src
+```
+
+Expected: all green.
+
+- [ ] **Manual smoke**
+
+Run a 2-year backtest with a `tax:` block in the strategies YAML and verify:
+
+1. `output/trades.csv` has the new `purchase_date` column populated for both buys and sells.
+2. `output/equity_curve.csv` has a `nav_after_tax` column with values strictly less than or equal to `nav` after the first tax payment date.
+3. `output/summary.json` has `after_tax_*` fields and a `tax_summary` array.
+4. The terminal summary prints "After-Tax Performance" and "Realized Tax" tables.
+5. The equity-curve chart shows two overlaid lines.
+
+Run a brief `midas live --dry-run` against a portfolio with one BUY signal; verify `<state>.trades.csv` is created next to the state file with a single row + header.
+
+Run `midas tax-report --year 2026 -p portfolio.yaml -s strategies.yaml`; verify it prints a Schedule D-style table and writes `schedule_d_2026.csv`.
+
+- [ ] **Open the PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "Tax-shaped trade log + realized-P&L report (#66)" --body "$(cat <<'EOF'
+Closes #66.
+
+## Summary
+
+Adds (1) an append-only `<state>.trades.csv` written by `midas live` next to the state file, (2) a new `midas tax-report --year YYYY` subcommand that emits a Schedule D-shaped table + CSV from any trade log, and (3) opt-in after-tax accounting for backtests — after-tax CAGR/TWR, nav_after_tax column in equity_curve.csv, equity-chart overlay, per-year tax_summary in summary.json, and a tax-cost-ratio metric.
+
+## Spec & plan
+
+- `docs/specs/2026-05-08-tax-trade-log-design.md`
+- `docs/plans/2026-05-08-tax-trade-log.md`
+
+## Out of scope (deferred)
+
+- Tax-aware optimizer objective — follow-up issue #69.
+- Wash-sale detection, specific-lot/LIFO, state taxes — explicit guardrails per #66.
+
+## Test plan
+
+- [ ] `uv run pytest` (all green)
+- [ ] `uv run ruff check . && uv run mypy src` (clean)
+- [ ] Manual smoke: backtest with `tax:` block produces after-tax block + chart overlay.
+- [ ] Manual smoke: `midas live --dry-run` creates `<state>.trades.csv`.
+- [ ] Manual smoke: `midas tax-report --year` against a fixture log emits Schedule D table + CSV.
+EOF
+)"
+```

--- a/docs/specs/2026-05-08-tax-trade-log-design.md
+++ b/docs/specs/2026-05-08-tax-trade-log-design.md
@@ -1,0 +1,341 @@
+# Tax-shaped trade log + realized-P&L report (issue #66)
+
+**Status:** Design
+**Date:** 2026-05-08
+**Issue:** [#66](https://github.com/jugegp16/Midas/issues/66)
+**Predecessor:** PR #67 (live per-lot tracking, #36)
+
+## Problem
+
+Live mode (after #67) keeps per-lot positions in `<portfolio>.state.yaml` but
+discards trade history: `apply_sell` returns `(st_realized_pnl, lt_realized_pnl)`
+per fill and the engine throws it away. After a year of `midas live`, the
+operator has current state but no record of fills — nothing for Schedule D.
+
+Backtest already has the data: `BacktestResult.trades` is the authoritative
+list, and `_write_trades_csv` already emits a CSV with `holding_period`,
+`cost_basis`, and `realized_pnl` columns. What's missing is a `purchase_date`
+column and a year-end aggregator that produces a Schedule D-shaped report.
+
+The operator also wants to see how capital-gains tax drag affects backtested
+returns: an after-tax equity curve, after-tax CAGR/TWR, and a tax-cost ratio.
+
+## Scope
+
+In:
+
+1. Live mode writes an append-only `<state_path>.trades.csv` with the same shape
+   as backtest's existing `trades.csv` (plus a new `purchase_date` column added
+   to both modes).
+2. New `midas tax-report --year YYYY -p portfolio.yaml` subcommand consumes the
+   trade log and emits a Schedule D-style printed table + CSV.
+3. Backtest gains optional after-tax accounting controlled by an opt-in
+   `TaxConfig` block in the strategies YAML: after-tax fields on
+   `BacktestResult`, after-tax equity curve column in `equity_curve.csv`, chart
+   overlay, and a tax-cost-ratio metric in `summary.json`.
+
+Out (deferred to follow-ups):
+
+- Tax-aware optimizer objective (`--objective gross|after_tax`) — separate issue.
+- Wash-sale detection — broker 1099-B handles it, replication is broker-specific.
+- Tax-aware allocation at runtime — explicit guardrail in #66; allocator stays
+  tax-blind.
+- LIFO / specific-lot accounting — engine is FIFO-only.
+- Per-strategy after-tax breakdown in `strategy_breakdown.csv` — tax netting
+  doesn't decompose cleanly across strategies; defer.
+
+## Decisions
+
+### Trade log shape
+
+- One row per BUY fill.
+- One row per non-empty ST/LT *bucket* on each SELL fill (mixed-lot sells emit
+  up to two rows). This matches backtest's existing `TradeRecord` semantics; we
+  do not split into per-lot-slice rows.
+- `purchase_date` column is new. For BUYs it is the fill date. For SELL bucket
+  rows, it is the consumed lots' single shared date when all lots in the bucket
+  share one date, otherwise the literal string `various` (Schedule D convention).
+  Empty when an unseeded live lot has `purchase_date=None`.
+
+### Trade log location
+
+- Sibling of state file: `state_path.with_suffix(state_path.suffix + ".trades.csv")`,
+  e.g. `portfolio.state.yaml` → `portfolio.state.yaml.trades.csv`. Inherits the
+  engine's existing `flock` on the state file; no new locking primitive.
+- Backtest continues to write `<output_dir>/trades.csv` via `write_backtest_results`.
+  Same column shape as live; `tax-report --from-trades <path>` can consume either.
+
+### Tax configuration
+
+`TaxConfig` is opt-in via the strategies YAML, alongside `RiskConfig`:
+
+```yaml
+tax:
+  short_term_rate: 0.37
+  long_term_rate: 0.20
+  deductible_loss_cap: 3000.0
+  payment_lag_days: 105   # Dec 31 → ~Apr 15 of following year
+```
+
+Defaults match top federal brackets. Omitting the block disables tax accounting
+entirely (after-tax fields stay `None`, no extra CSV column, no chart overlay).
+
+### Tax timing & netting
+
+- Tax owed for calendar year Y is deducted from the after-tax equity curve at
+  `Dec 31 of Y + payment_lag_days`. If that date falls past `end_d`, deduct on
+  the final bar instead — known overstatement of tax drag, documented.
+- Annual netting follows IRS Schedule D math:
+  1. Net within ST bucket; net within LT bucket.
+  2. If signs differ, cross-net buckets.
+  3. If net is a loss, deduct up to `deductible_loss_cap` (default $3,000)
+     against ordinary income — credited at `short_term_rate`.
+  4. Remainder carries forward.
+- Carryforward is a single signed scalar per portfolio threaded chronologically;
+  it loses ST/LT character on rollover (simplification — IRS preserves character,
+  but this is a reporting-layer approximation, documented).
+
+### `apply_sell` signature
+
+Currently returns `(st_pnl: float, lt_pnl: float)`. Changes to return the
+already-existing `SellBreakdown` dataclass, with two new fields added:
+
+```python
+@dataclass(frozen=True)
+class SellBreakdown:
+    st_shares: float
+    st_basis: float
+    st_weighted: float
+    lt_shares: float
+    lt_basis: float
+    lt_weighted: float
+    st_purchase_dates: tuple[date | None, ...]   # new
+    lt_purchase_dates: tuple[date | None, ...]   # new
+```
+
+Strict superset of today's return; one internal caller in `live.py` and the
+test suite update.
+
+## Architecture
+
+### New modules
+
+**`src/midas/trade_log.py`** — append-only writer/reader.
+
+```python
+def append_trade(
+    path: Path,
+    record: TradeRecord,
+    cost_basis: float | None,
+    purchase_date: date | str | None,
+) -> None: ...
+
+def read_trades(path: Path) -> list[LoggedTrade]: ...
+
+class TradeLogError(ValueError): ...
+```
+
+`LoggedTrade` is a small dataclass mirroring the CSV columns (date, ticker,
+direction, shares, price, strategy, holding_period, purchase_date, cost_basis,
+realized_pnl, return_pct).
+
+`append_trade` creates the file with header on first write, appends rows only
+afterwards. Header drift on read raises `TradeLogError` naming the divergence.
+
+**`src/midas/tax.py`** — pure tax math.
+
+```python
+@dataclass(frozen=True)
+class TaxConfig:
+    short_term_rate: float = 0.37
+    long_term_rate: float = 0.20
+    deductible_loss_cap: float = 3000.0
+    payment_lag_days: int = 105
+
+@dataclass(frozen=True)
+class AnnualTaxSummary:
+    year: int
+    st_realized: float
+    lt_realized: float
+    net_after_cross: float
+    deductible_loss: float
+    carry_forward: float
+    tax_owed: float
+    payment_date: date
+
+def compute_tax_summary(
+    trades: Sequence[TradeRecord],
+    basis_per_sell: Sequence[float],
+    config: TaxConfig,
+    end_date: date,
+) -> list[AnnualTaxSummary]: ...
+
+def compute_after_tax_curve(
+    equity_curve: Sequence[tuple[date, float]],
+    summaries: Sequence[AnnualTaxSummary],
+    end_date: date,
+) -> list[tuple[date, float]]: ...
+```
+
+All math here. Reused by `BacktestResult` construction and by the `tax-report`
+subcommand so backtest after-tax numbers and tax-report numbers are bit-identical
+when fed identical trade rows.
+
+### Extended types
+
+**`models.TaxConfig`** — frozen dataclass added alongside `RiskConfig`. Loaded
+from the optional `tax:` block in the strategies YAML.
+
+**`models.TradeRecord.purchase_date`** — new field, type `date | str | None`.
+`'various'` is permitted as a string sentinel for mixed-lot bucket sells.
+
+**`live_state.SellBreakdown`** — gains `st_purchase_dates` and
+`lt_purchase_dates` tuples. `consume_lots_fifo` populates them as it iterates
+the lot list.
+
+**`live_state.apply_sell`** — return type changes from `tuple[float, float]` to
+`SellBreakdown`. Existing pnl is recoverable as
+`breakdown.st_shares * price - breakdown.st_weighted` (and analogous for LT),
+matching today's math exactly.
+
+**`results.BacktestResult`** — new fields, all `None`/empty when
+`TaxConfig` is not set:
+
+```python
+after_tax_final_value: float | None = None
+after_tax_total_return: float | None = None
+after_tax_cagr: float | None = None
+after_tax_twr: float | None = None
+after_tax_equity_curve: list[tuple[date, float]] = field(default_factory=list)
+tax_cost_ratio: float | None = None
+tax_summary: list[AnnualTaxSummary] = field(default_factory=list)
+```
+
+### CLI
+
+```
+midas tax-report --year YYYY -p <portfolio.yaml> [--output <csv-path>] [--from-trades <path>]
+```
+
+- Resolves trade-log path the same way `midas live` resolves the state path,
+  then suffixes `.trades.csv`. `--from-trades` overrides for backtest output
+  paths or arbitrary log files.
+- Prints a Schedule D-style table to stdout: per-row (ticker, shares,
+  purchase_date, sale_date, basis, proceeds, pnl, holding_period_days,
+  classification) + footer (ST total, LT total, net, deductible, tax_owed at
+  configured rates).
+- Writes a CSV at `--output` (default `schedule_d_<year>.csv`) with the same rows.
+- `--start` / `--end` flags accepted as an alternative to `--year` for
+  arbitrary date ranges.
+
+## Data flow
+
+### Live tick
+
+1. `_tick` runs as today through fill emission.
+2. For each fill: `apply_buy` mutates state OR `apply_sell` returns `SellBreakdown`.
+3. **Order: append to log, then `save_atomic` state, then print alerts.**
+   If the log append fails, state is at its pre-fill snapshot and the operator
+   sees the error; re-running re-applies fills and re-attempts the append. State
+   and log can never silently disagree about whether a fill happened.
+4. Append uses the existing engine-wide `flock`; no new lock.
+
+### Backtest result construction
+
+1. `state.trades` and `state.basis_per_sell` accumulate as today, plus
+   `purchase_date` populated per record (single date, `'various'`, or `None`).
+2. `_write_trades_csv` emits the new `purchase_date` column.
+3. If `TaxConfig` is set:
+   - `compute_tax_summary(state.trades, state.basis_per_sell, tax_config, end_d)`
+     groups SELL records by year, runs IRS netting + carryforward.
+   - `compute_after_tax_curve(equity_curve, summaries, end_d)` deducts each
+     year's `tax_owed` at its `payment_date` (clamped to `end_d`).
+   - `after_tax_*` metrics derived via the same metrics functions used for
+     gross.
+   - `tax_cost_ratio = (cagr - after_tax_cagr) / cagr` if `cagr > 0` else `0.0`.
+4. `equity_curve.csv` gains a parallel `nav_after_tax` column.
+5. `summary.json` gains `after_tax_*`, `tax_cost_ratio`, and a `tax_summary`
+   array (one entry per year).
+6. `print_backtest_summary` prints an after-tax block under the gross block;
+   chart overlays both curves.
+
+### `tax-report`
+
+1. Resolve trade-log path; read via `trade_log.read_trades`.
+2. Filter SELL rows to the requested period.
+3. Run `compute_tax_summary` (same call backtest uses).
+4. Render console table + write CSV.
+
+## Edge cases
+
+| Case | Behavior |
+|---|---|
+| `TaxConfig=None` | All after-tax fields stay `None`; `equity_curve.csv` omits the new column; chart skips overlay; no behavior change vs. today. |
+| Backtest ends mid-year | Year's `tax_owed` deducted at `end_d`. `tax_summary[-1].payment_date` records actual Apr 15 for honest reporting. |
+| Empty trades | `compute_tax_summary` returns `[]`. After-tax curve == gross curve. `tax_cost_ratio=0.0`. |
+| `tax-report` with no SELLs in range | Print "No realized sales in `<year>`"; emit header-only CSV; exit 0. |
+| Pre-existing live deployments upgrading mid-year | First tick after upgrade creates fresh trade log. Pre-upgrade fills are gone (live didn't record them). Year-end report for upgrade year is partial; operator merges with broker statement. |
+| Hand-edited log | Strict CSV parser. Schema mismatch → `TradeLogError` naming the row. Content (negative shares, future dates, etc.) flows through. |
+| Partial-write log corruption | Strict reader raises with offending line number. No auto-recovery; operator restores from git or hand-fixes. |
+| Header drift on existing log | Refuses to start at engine init with the divergence printed. Operator renames or hand-fixes; we don't auto-migrate. |
+| Mixed-lot SELL bucket | `purchase_date='various'`; `cost_basis` is the share-weighted bucket basis (already true today). |
+| `purchase_date=None` (unseeded lot) | Empty string in CSV. Counts as ST in classification per existing `consume_lots_fifo` semantics. |
+
+## Testing
+
+**`tests/test_trade_log.py` (new)**
+- Round-trip BUYs + SELLs (mixed bucket cases).
+- Header creation on first write, append on subsequent.
+- Header drift raises with row 0 named.
+- `'various'` and empty `purchase_date` round-trip correctly.
+- Partial-row corruption → strict reader raises with line number.
+
+**`tests/test_tax.py` (new)**
+- Pure netting:
+  - All ST gain.
+  - ST gain + LT loss → cross-bucket netting.
+  - Net loss `< $3K` → full deductible at ST rate.
+  - Net loss `> $3K` → cap deductible, carry remainder.
+  - Multi-year carryforward absorbing future gains.
+- `compute_after_tax_curve` with payment-date scenarios (lag inside range, lag past `end_d`).
+- `tax_cost_ratio` math: `cagr > 0` and `cagr == 0` paths.
+- Empty trades → empty summary, after-tax == gross.
+
+**`tests/test_live_trade_log.py` (new) — integration**
+- 3-tick run with planned fills (BUY, mixed-lot SELL, full-exit SELL).
+- Assert row count, `purchase_date` per row, header presence.
+- Kill mid-tick → state at last good snapshot; log never half-written.
+
+**Additions**
+- `tests/test_backtest.py`: extend trades.csv parity test for the new column;
+  2-year backtest asserts `after_tax_*` populated with `TaxConfig` and `None` without.
+- `tests/test_live_state.py`: update `apply_sell` tests for the new return shape;
+  cover `st_purchase_dates`/`lt_purchase_dates` aggregation.
+- `tests/test_live_engine.py`: assert `<state>.trades.csv` is created and grows.
+- `tests/test_live_backtest_parity.py`: assert trade-log CSVs from a backtest
+  run and equivalent live replay are byte-identical (strong guarantee tax math
+  cannot diverge between modes).
+- `tests/test_cli_live.py`: smoke test `tax-report` against a fixture log;
+  assert footer numbers and exit code.
+- `tests/test_charts.py`: snapshot test the after-tax overlay.
+
+`uv run mypy src` and `uv run ruff check .` clean across new modules.
+
+## Implementation order
+
+A natural build order falls out of the dependency graph:
+
+1. `models.TaxConfig` + strategies-loader wiring (no behavior change yet).
+2. `models.TradeRecord.purchase_date` + `live_state.SellBreakdown` field
+   additions + `consume_lots_fifo` purchase-date tracking.
+3. `live_state.apply_sell` return-type change + caller updates.
+4. `src/midas/trade_log.py` + tests.
+5. Backtest `trades.csv` `purchase_date` column + parity test extension.
+6. Live engine wiring: append fills to `<state>.trades.csv`.
+7. `src/midas/tax.py` + tests.
+8. `BacktestResult` after-tax fields, `equity_curve.csv` column, `summary.json`
+   additions, summary print block, chart overlay.
+9. `midas tax-report` CLI subcommand.
+10. Documentation: brief mention in `docs/architecture.md`; a new
+    `docs/tax-reporting.md` covering the YAML block, CLI, and Schedule D
+    interpretation caveats.

--- a/docs/tax-reporting.md
+++ b/docs/tax-reporting.md
@@ -1,0 +1,106 @@
+# Tax reporting
+
+Midas can report realized capital gains in a Schedule D-shaped format and (in
+backtest mode only) compute after-tax return metrics. Tax accounting is opt-in:
+without a `tax:` block in the strategies YAML, all output is unchanged from
+pre-#66 behavior.
+
+## Configuring rates
+
+Add a `tax:` block to the strategies YAML alongside the existing top-level
+keys (`min_cash_pct`, `softmax_temperature`, optional `risk:`):
+
+```yaml
+tax:
+  short_term_rate: 0.37   # decimal fraction; default top federal bracket
+  long_term_rate: 0.20    # decimal fraction; default top federal LTCG
+  deductible_loss_cap: 3000.0
+  payment_lag_days: 105   # Dec 31 → ~Apr 15 of following year
+```
+
+All four fields have defaults; the block is parsed leniently. The validator
+also enforces `long_term_rate <= short_term_rate` to catch transposed values.
+
+## Backtest: after-tax metrics
+
+Running `midas backtest` with a `tax:` block in the strategies YAML adds:
+
+- `after_tax_final_value`, `after_tax_total_return`, `after_tax_cagr`,
+  `after_tax_twr` to `summary.json`.
+- A `nav_after_tax` column in `equity_curve.csv` parallel to `nav`.
+- A `tax_summary` array in `summary.json` with one entry per calendar year
+  containing realized sales (`st_realized`, `lt_realized`, `net_after_cross`,
+  `deductible_loss`, `carry_forward`, `tax_owed`, `payment_date`).
+- A `tax_cost_ratio` field equal to `(cagr - after_tax_cagr) / cagr` (or
+  `null` when CAGR is non-positive — taxes can't reduce a losing run's
+  return measurably and the ratio is undefined).
+
+The summary terminal output gains an "After-Tax Performance" block and a
+per-year "Realized Tax" table. The equity-curve chart overlays gross and
+after-tax curves in cyan and magenta.
+
+Tax owed for year Y is deducted from the after-tax curve at
+`Dec 31 of Y + payment_lag_days` (default Apr 15 of Y+1). If the payment
+date falls past the end of the backtest, it's clamped to the final bar
+— a known overstatement of tax drag in the run-end year.
+
+## Live: trade log
+
+Each tick that produces fills appends rows to `<state>.trades.csv` next to
+the state file. Format matches `<output>/trades.csv` from `midas backtest`,
+plus a `purchase_date` column added in both modes:
+
+| Column | Notes |
+|---|---|
+| `date` | Fill date. |
+| `ticker` | Symbol. |
+| `direction` | `BUY` or `SELL`. |
+| `shares`, `price` | Numeric. |
+| `strategy` | Source signal name. |
+| `holding_period` | `short-term` / `long-term` / empty for buys. |
+| `purchase_date` | Buy date for BUYs. SELL bucket: a single date when all consumed lots share one, the literal string `various` for mixed-lot buckets, or empty when the lot's date was unknown. |
+| `cost_basis` | Share-weighted bucket basis on SELL bucket rows. |
+| `realized_pnl` | `(price - cost_basis) * shares` on SELL rows. |
+| `return_pct` | `(price - cost_basis) / cost_basis` on SELL rows. |
+
+The log is append-only. Hand-edits are an explicit escape valve (correcting
+a recorded price after broker confirms a different fill). The reader is
+strict on schema (header drift or partial rows raise `TradeLogError` with a
+line number) and lenient on content.
+
+## `midas tax-report`
+
+```
+midas tax-report --strategies strategies.yaml \
+                 --portfolio portfolio.yaml --year 2026 \
+                 [--output schedule_d_2026.csv]
+```
+
+Or against an explicit log path (e.g. backtest output):
+
+```
+midas tax-report --strategies strategies.yaml \
+                 --from-trades output/trades.csv --year 2026
+```
+
+Prints a per-row table (ticker, shares, purchase/sale dates, basis,
+proceeds, P&L, days held, classification) and writes the same data plus a
+per-year aggregate footer to `--output`.
+
+`--start` / `--end` accept arbitrary date ranges instead of `--year`.
+
+## Caveats
+
+- **No wash-sale detection.** Broker 1099-B handles it; we don't replicate
+  broker-specific adjustments.
+- **No tax-aware allocation.** The allocator is and stays tax-blind. See
+  issue #69 for the in-progress follow-up that adds an after-tax objective
+  to the optimizer.
+- **FIFO only.** Specific-lot or LIFO accounting is out of scope.
+- **Carryforward loses ST/LT character on rollover.** IRS preserves
+  character; we use a single signed scalar. For most operators the
+  difference is small (carryforward rate is the higher of ST/LT in the
+  year it's used).
+- **Pre-existing live deployments upgrading mid-year:** the trade log
+  starts fresh on the first post-upgrade tick. Year-end report for the
+  upgrade year is partial; merge with broker statements.

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -1156,14 +1156,15 @@ class BacktestEngine:
                     after_tax_total_return = (after_tax_final_value - starting_val) / starting_val
                     after_tax_cagr_value = compute_cagr(starting_val, after_tax_final_value, total_days)
                     # Approximation: scale gross TWR by the after-tax/gross final-value
-                    # ratio. Tax payments are pointwise withdrawals from the curve, so
-                    # this is a reasonable single-number approximation. A bar-by-bar
-                    # TWR re-derivation would require sub-period boundaries that the
-                    # current state machine doesn't expose.
+                    # ratio. This is exact only when there are no mid-period cash infusions;
+                    # with infusions the terminal-value ratio mixes capital contributions
+                    # with tax drag, so interpret this figure cautiously on portfolios with
+                    # CashInfusion configured. A bar-by-bar re-derivation would require
+                    # sub-period boundaries that the current state machine doesn't expose.
                     after_tax_twr_value = (
                         ((1.0 + twr) * (after_tax_final_value / final_value)) - 1.0 if final_value > 0 else twr
                     )
-                    tax_cost_ratio = (cagr - after_tax_cagr_value) / cagr if cagr > 0 else 0.0
+                    tax_cost_ratio = (cagr - after_tax_cagr_value) / cagr if cagr > 0 else None
 
         return BacktestResult(
             trades=state.trades,

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -883,6 +883,29 @@ class BacktestEngine:
             state.cash -= order.estimated_value
 
     @staticmethod
+    def _resolve_purchase_date(dates: tuple[date | None, ...]) -> date | str | None:
+        """Map a tuple of consumed lots' purchase dates to a single CSV value.
+
+        Empty tuple → None. Single unique non-None date → that date. Anything
+        else (multiple dates, any None present) → the literal string 'various'.
+
+        Args:
+            dates: Purchase dates of the lots consumed by a single SELL bucket,
+                in FIFO order. May contain ``None`` for unseeded lots.
+
+        Returns:
+            The single shared date, the literal string ``'various'``, or
+            ``None`` when there are no consumed lots.
+        """
+        if not dates:
+            return None
+        unique = set(dates)
+        if len(unique) == 1:
+            only = next(iter(unique))
+            return only  # may be a date or None
+        return "various"
+
+    @staticmethod
     def _fifo_consumed_basis(lots: list[PositionLot], shares: float) -> float:
         """Share-weighted cost basis of the first *shares* shares in FIFO order.
 
@@ -936,6 +959,7 @@ class BacktestEngine:
                         shares=order.shares,
                         price=order.price,
                         strategy_name=strategy_name,
+                        purchase_date=day,
                     ),
                     0.0,
                 )
@@ -987,6 +1011,7 @@ class BacktestEngine:
                         price=order.price,
                         strategy_name=strategy_name,
                         holding_period=HoldingPeriod.SHORT_TERM,
+                        purchase_date=self._resolve_purchase_date(breakdown.st_purchase_dates),
                     ),
                     st_weighted_basis / st_shares,
                 )
@@ -1002,6 +1027,7 @@ class BacktestEngine:
                         price=order.price,
                         strategy_name=strategy_name,
                         holding_period=HoldingPeriod.LONG_TERM,
+                        purchase_date=self._resolve_purchase_date(breakdown.lt_purchase_dates),
                     ),
                     lt_weighted_basis / lt_shares,
                 )

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from midas.allocator import AllocationResult, Allocator, AllocatorRiskTelemetry
 from midas.data.price_history import PriceHistory
-from midas.live_state import aggregate_cost_basis, consume_lots_fifo
+from midas.live_state import aggregate_cost_basis, consume_lots_fifo, resolve_purchase_date
 from midas.metrics import (
     compute_annualized_return,
     compute_cagr,
@@ -883,35 +883,6 @@ class BacktestEngine:
             state.cash -= order.estimated_value
 
     @staticmethod
-    def _resolve_purchase_date(dates: tuple[date | None, ...]) -> date | str | None:
-        """Map a tuple of consumed lots' purchase dates to a single CSV value.
-
-        - Empty tuple → ``None``.
-        - All consumed lots share one ``purchase_date`` (a date OR all-``None``)
-          → that single value (the date, or ``None`` if every consumed lot was
-          unseeded).
-        - Multiple distinct values, including the ``date + None`` mix → the
-          literal string ``'various'`` (Schedule D convention for mixed-lot
-          sales).
-
-        Args:
-            dates: Purchase dates of the lots consumed by a single SELL bucket,
-                in FIFO order. May contain ``None`` for unseeded lots.
-
-        Returns:
-            The single shared date, ``None`` (empty tuple or all unseeded
-            lots), or the literal string ``'various'`` when consumed lots
-            disagree.
-        """
-        if not dates:
-            return None
-        unique = set(dates)
-        if len(unique) == 1:
-            only = next(iter(unique))
-            return only  # may be a date or None
-        return "various"
-
-    @staticmethod
     def _fifo_consumed_basis(lots: list[PositionLot], shares: float) -> float:
         """Share-weighted cost basis of the first *shares* shares in FIFO order.
 
@@ -1017,7 +988,7 @@ class BacktestEngine:
                         price=order.price,
                         strategy_name=strategy_name,
                         holding_period=HoldingPeriod.SHORT_TERM,
-                        purchase_date=self._resolve_purchase_date(breakdown.st_purchase_dates),
+                        purchase_date=resolve_purchase_date(breakdown.st_purchase_dates),
                     ),
                     st_weighted_basis / st_shares,
                 )
@@ -1033,7 +1004,7 @@ class BacktestEngine:
                         price=order.price,
                         strategy_name=strategy_name,
                         holding_period=HoldingPeriod.LONG_TERM,
-                        purchase_date=self._resolve_purchase_date(breakdown.lt_purchase_dates),
+                        purchase_date=resolve_purchase_date(breakdown.lt_purchase_dates),
                     ),
                     lt_weighted_basis / lt_shares,
                 )

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -886,16 +886,22 @@ class BacktestEngine:
     def _resolve_purchase_date(dates: tuple[date | None, ...]) -> date | str | None:
         """Map a tuple of consumed lots' purchase dates to a single CSV value.
 
-        Empty tuple → None. Single unique non-None date → that date. Anything
-        else (multiple dates, any None present) → the literal string 'various'.
+        - Empty tuple → ``None``.
+        - All consumed lots share one ``purchase_date`` (a date OR all-``None``)
+          → that single value (the date, or ``None`` if every consumed lot was
+          unseeded).
+        - Multiple distinct values, including the ``date + None`` mix → the
+          literal string ``'various'`` (Schedule D convention for mixed-lot
+          sales).
 
         Args:
             dates: Purchase dates of the lots consumed by a single SELL bucket,
                 in FIFO order. May contain ``None`` for unseeded lots.
 
         Returns:
-            The single shared date, the literal string ``'various'``, or
-            ``None`` when there are no consumed lots.
+            The single shared date, ``None`` (empty tuple or all unseeded
+            lots), or the literal string ``'various'`` when consumed lots
+            disagree.
         """
         if not dates:
             return None

--- a/src/midas/backtest.py
+++ b/src/midas/backtest.py
@@ -30,6 +30,7 @@ from midas.models import (
     Order,
     PortfolioConfig,
     PositionLot,
+    TaxConfig,
     TradeRecord,
 )
 from midas.order_sizer import OrderSizer
@@ -38,6 +39,7 @@ from midas.results import BacktestResult
 from midas.risk import per_ticker_vol_contribution
 from midas.risk_metrics import RiskHistory, compute_risk_metrics
 from midas.strategies.base import ExitRule, max_warmup
+from midas.tax import AnnualTaxSummary, compute_after_tax_curve, compute_tax_summary
 
 # ---------------------------------------------------------------------------
 # Constants & type aliases
@@ -263,6 +265,7 @@ class BacktestEngine:
         enable_split: bool = True,
         log_fn: Callable[[str], None] | None = None,
         execution_mode: ExecutionMode = "next_open",
+        tax_config: TaxConfig | None = None,
     ) -> None:
         self._allocator = allocator
         self._order_sizer = order_sizer
@@ -272,6 +275,7 @@ class BacktestEngine:
         self._enable_split = enable_split
         self._log = log_fn or (lambda _msg: None)
         self._execution_mode: ExecutionMode = execution_mode
+        self._tax_config = tax_config
 
     def run(
         self,
@@ -1126,6 +1130,41 @@ class BacktestEngine:
             for strat, share in attr.items():
                 attributed_strategy_pnl[strat] = attributed_strategy_pnl.get(strat, 0.0) + ticker_unrealized * share
 
+        # After-tax accounting (opt-in via TaxConfig). When tax_config is None all
+        # fields stay at their dataclass defaults — no behavior change for users
+        # who don't configure tax rates.
+        after_tax_final_value: float | None = None
+        after_tax_total_return: float | None = None
+        after_tax_cagr_value: float | None = None
+        after_tax_twr_value: float | None = None
+        after_tax_curve: list[tuple[date, float]] = []
+        tax_cost_ratio: float | None = None
+        tax_summary: list[AnnualTaxSummary] = []
+
+        if self._tax_config is not None:
+            end_d = trading_days[-1]
+            tax_summary = compute_tax_summary(
+                state.trades,
+                state.basis_per_sell,
+                self._tax_config,
+                end_date=end_d,
+            )
+            after_tax_curve = compute_after_tax_curve(state.equity_curve, tax_summary)
+            if after_tax_curve:
+                after_tax_final_value = after_tax_curve[-1][1]
+                if starting_val > 0:
+                    after_tax_total_return = (after_tax_final_value - starting_val) / starting_val
+                    after_tax_cagr_value = compute_cagr(starting_val, after_tax_final_value, total_days)
+                    # Approximation: scale gross TWR by the after-tax/gross final-value
+                    # ratio. Tax payments are pointwise withdrawals from the curve, so
+                    # this is a reasonable single-number approximation. A bar-by-bar
+                    # TWR re-derivation would require sub-period boundaries that the
+                    # current state machine doesn't expose.
+                    after_tax_twr_value = (
+                        ((1.0 + twr) * (after_tax_final_value / final_value)) - 1.0 if final_value > 0 else twr
+                    )
+                    tax_cost_ratio = (cagr - after_tax_cagr_value) / cagr if cagr > 0 else 0.0
+
         return BacktestResult(
             trades=state.trades,
             final_value=round(final_value, 2),
@@ -1166,6 +1205,13 @@ class BacktestEngine:
             ),
             risk_history=state.risk_history,
             bh_equity_curve=state.bh_equity_curve,
+            after_tax_final_value=(round(after_tax_final_value, 2) if after_tax_final_value is not None else None),
+            after_tax_total_return=(round(after_tax_total_return, 4) if after_tax_total_return is not None else None),
+            after_tax_cagr=(round(after_tax_cagr_value, 4) if after_tax_cagr_value is not None else None),
+            after_tax_twr=(round(after_tax_twr_value, 4) if after_tax_twr_value is not None else None),
+            after_tax_equity_curve=after_tax_curve,
+            tax_cost_ratio=(round(tax_cost_ratio, 6) if tax_cost_ratio is not None else None),
+            tax_summary=tax_summary,
         )
 
     def _end_state_vol_contribution(

--- a/src/midas/charts.py
+++ b/src/midas/charts.py
@@ -126,9 +126,18 @@ def _render_equity(result: BacktestResult) -> None:
     dates = [dt.isoformat() for dt, _ in result.equity_curve]
     equity = [value for _, value in result.equity_curve]
     _setup_single_figure()
-    plt.plot(dates, equity, color="cyan", marker="braille")
+    has_after_tax = len(result.after_tax_equity_curve) == len(result.equity_curve) and bool(
+        result.after_tax_equity_curve
+    )
+    if has_after_tax:
+        plt.plot(dates, equity, color="cyan", label="Gross", marker="braille")
+        after_tax = [value for _, value in result.after_tax_equity_curve]
+        plt.plot(dates, after_tax, color="magenta", label="After-Tax", marker="braille")
+    else:
+        plt.plot(dates, equity, color="cyan", marker="braille")
     plt.ylabel("Portfolio $")
-    _flush_centered("Equity Curve")
+    title = "Equity Curve (Gross vs After-Tax)" if has_after_tax else "Equity Curve"
+    _flush_centered(title)
 
 
 def _render_excess_return(result: BacktestResult) -> None:

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -160,7 +160,7 @@ def backtest(
 ) -> None:
     """Run a backtest over historical data."""
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints, risk_config, _ = (
+    strat_configs, constraints, risk_config, tax_config = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig(), None)
     )
 
@@ -186,6 +186,7 @@ def backtest(
         enable_split=not no_split,
         log_fn=print_status,
         execution_mode=execution_mode,
+        tax_config=tax_config,
     )
 
     print_status("Running backtest...")

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -344,7 +344,7 @@ def tax_report(
     if not rows:
         click.echo(f"No realized sales in {period_label}.")
         if output is not None:
-            Path(output).write_text(",".join(_TAX_REPORT_COLUMNS) + "\n")
+            Path(output).write_text(",".join(TAX_REPORT_COLUMNS) + "\n")
         return
 
     out_path = Path(output) if output is not None else Path(f"schedule_d_{period_label}.csv")
@@ -627,7 +627,7 @@ def list_strategies() -> None:
     print_strategy_table([cls() for cls in STRATEGY_REGISTRY.values()])
 
 
-_TAX_REPORT_COLUMNS = (
+TAX_REPORT_COLUMNS = (
     "ticker",
     "shares",
     "purchase_date",
@@ -706,7 +706,7 @@ def _write_tax_report_csv(
 
     with open(path, "w", newline="", encoding="utf-8") as handle:
         writer = csv.writer(handle)
-        writer.writerow(_TAX_REPORT_COLUMNS)
+        writer.writerow(TAX_REPORT_COLUMNS)
         for row, basis in zip(rows, basis_per_sell, strict=True):
             proceeds = row.shares * row.price
             pnl = proceeds - basis * row.shares

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -14,16 +14,20 @@ from midas.config import load_portfolio, load_strategies
 from midas.data import CachedYFinanceProvider
 from midas.models import (
     AllocationConstraints,
+    Direction,
     PortfolioConfig,
     RiskConfig,
     StrategyConfig,
     TaxConfig,
+    TradeRecord,
 )
 from midas.order_sizer import OrderSizer
 from midas.output import print_backtest_summary, print_status, print_strategy_table
 from midas.results import write_backtest_results
 from midas.strategies import STRATEGY_REGISTRY, EntrySignal, ExitRule, Strategy
 from midas.strategies.base import max_warmup, warmup_bars_to_calendar_days
+from midas.tax import AnnualTaxSummary
+from midas.trade_log import LoggedTrade
 
 
 def _build_strategy(cfg: StrategyConfig) -> Strategy:
@@ -252,6 +256,120 @@ def live(
         dry_run=dry_run,
     ) as engine:
         engine.run()
+
+
+@cli.command(name="tax-report")
+@click.option(
+    "--portfolio",
+    "-p",
+    default=None,
+    type=click.Path(exists=True),
+    help="Portfolio YAML; resolves the trade log next to its state file unless --from-trades is given.",
+)
+@click.option(
+    "--strategies",
+    "-s",
+    required=True,
+    type=click.Path(exists=True),
+    help="Strategies YAML containing the tax: block. Required — rates have no defaults at the CLI.",
+)
+@click.option(
+    "--from-trades",
+    "from_trades",
+    default=None,
+    type=click.Path(exists=True),
+    help="Explicit path to a trades.csv. Overrides --portfolio resolution.",
+)
+@click.option("--year", type=int, default=None, help="Calendar year to report (e.g. 2026).")
+@click.option("--start", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option("--end", type=click.DateTime(formats=["%Y-%m-%d"]), default=None)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Output CSV path. Defaults to schedule_d_<year>.csv (or schedule_d_<start>_<end>.csv).",
+)
+def tax_report(
+    portfolio: str | None,
+    strategies: str,
+    from_trades: str | None,
+    year: int | None,
+    start: datetime | None,
+    end: datetime | None,
+    output: str | None,
+) -> None:
+    """Year-end realized-P&L report (Schedule D-shaped) from a trade log."""
+    from midas.tax import compute_tax_summary
+    from midas.trade_log import read_trades
+
+    if year is None and (start is None or end is None):
+        msg = "either --year or both --start and --end must be provided"
+        raise click.UsageError(msg)
+
+    _strats, _constraints, _risk, tax_config = load_strategies(Path(strategies))
+    if tax_config is None:
+        msg = (
+            "strategies file has no `tax:` block; tax-report requires configured rates "
+            "(short_term_rate, long_term_rate). See docs/tax-reporting.md."
+        )
+        raise click.UsageError(msg)
+
+    if from_trades is not None:
+        trades_path = Path(from_trades)
+    else:
+        if portfolio is None:
+            raise click.UsageError("either --portfolio or --from-trades is required")
+        port = load_portfolio(Path(portfolio))
+        portfolio_path = Path(portfolio)
+        state_path = port.state_file if port.state_file is not None else portfolio_path.with_suffix(".state.yaml")
+        trades_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+        if not trades_path.exists():
+            msg = f"trade log not found at {trades_path}"
+            raise click.UsageError(msg)
+
+    if year is not None:
+        start_d = date(year, 1, 1)
+        end_d = date(year, 12, 31)
+        period_label = str(year)
+    else:
+        assert start is not None and end is not None
+        start_d = _to_date(start)
+        end_d = _to_date(end)
+        period_label = f"{start_d.isoformat()}_{end_d.isoformat()}"
+
+    rows: list[LoggedTrade] = [
+        row for row in read_trades(trades_path) if row.direction == Direction.SELL and start_d <= row.date <= end_d
+    ]
+
+    if not rows:
+        click.echo(f"No realized sales in {period_label}.")
+        if output is not None:
+            Path(output).write_text(",".join(_TAX_REPORT_COLUMNS) + "\n")
+        return
+
+    out_path = Path(output) if output is not None else Path(f"schedule_d_{period_label}.csv")
+
+    trade_records: list[TradeRecord] = []
+    basis_per_sell: list[float] = []
+    for row in rows:
+        trade_records.append(
+            TradeRecord(
+                date=row.date,
+                ticker=row.ticker,
+                direction=row.direction,
+                shares=row.shares,
+                price=row.price,
+                strategy_name=row.strategy_name,
+                holding_period=row.holding_period,
+                purchase_date=row.purchase_date,
+            )
+        )
+        basis_per_sell.append(row.cost_basis if row.cost_basis is not None else row.price)
+
+    summary = compute_tax_summary(trade_records, basis_per_sell, tax_config, end_date=end_d)
+    _print_tax_report(rows, basis_per_sell, summary, period_label)
+    _write_tax_report_csv(rows, basis_per_sell, summary, out_path)
+    click.echo(f"\nWrote {out_path}")
 
 
 @cli.command()
@@ -507,3 +625,116 @@ def optimize(
 def list_strategies() -> None:
     """List all available strategies."""
     print_strategy_table([cls() for cls in STRATEGY_REGISTRY.values()])
+
+
+_TAX_REPORT_COLUMNS = (
+    "ticker",
+    "shares",
+    "purchase_date",
+    "sale_date",
+    "cost_basis",
+    "proceeds",
+    "realized_pnl",
+    "holding_period_days",
+    "classification",
+)
+
+
+def _print_tax_report(
+    rows: list[LoggedTrade],
+    basis_per_sell: list[float],
+    summary: list[AnnualTaxSummary],
+    period_label: str,
+) -> None:
+    from rich.console import Console
+
+    from midas.output import make_wide_table
+
+    table_width = 140
+    table = make_wide_table(f"Schedule D — {period_label}", width=table_width)
+    table.add_column("Ticker", style="bold")
+    table.add_column("Shares", justify="right")
+    table.add_column("Purchase Date")
+    table.add_column("Sale Date")
+    table.add_column("Cost Basis", justify="right")
+    table.add_column("Proceeds", justify="right")
+    table.add_column("Realized P&L", justify="right")
+    table.add_column("Days Held", justify="right")
+    table.add_column("Classification")
+
+    for row, basis in zip(rows, basis_per_sell, strict=True):
+        proceeds = row.shares * row.price
+        pnl = proceeds - basis * row.shares
+        if isinstance(row.purchase_date, date):
+            days_held = (row.date - row.purchase_date).days
+            purchase_disp = row.purchase_date.isoformat()
+            days_disp = str(days_held)
+        else:
+            purchase_disp = row.purchase_date or ""
+            days_disp = ""
+        classification = row.holding_period.value if row.holding_period else ""
+        table.add_row(
+            row.ticker,
+            f"{row.shares:.4f}",
+            purchase_disp,
+            row.date.isoformat(),
+            f"${basis:,.2f}",
+            f"${proceeds:,.2f}",
+            f"${pnl:+,.2f}",
+            days_disp,
+            classification,
+        )
+    # Use a width-pinned console so the rendered table isn't truncated when
+    # stdout isn't a TTY (e.g. piped output, CliRunner in tests).
+    Console(width=table_width).print(table, justify="center")
+
+    for s in summary:
+        click.echo(
+            f"\nYear {s.year}: ST {s.st_realized:+,.2f}  LT {s.lt_realized:+,.2f}  "
+            f"Net {s.net_after_cross:+,.2f}  Deductible {s.deductible_loss:,.2f}  "
+            f"Tax {s.tax_owed:+,.2f}  Carry-Forward {s.carry_forward:,.2f}"
+        )
+
+
+def _write_tax_report_csv(
+    rows: list[LoggedTrade],
+    basis_per_sell: list[float],
+    summary: list[AnnualTaxSummary],
+    path: Path,
+) -> None:
+    import csv
+
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(_TAX_REPORT_COLUMNS)
+        for row, basis in zip(rows, basis_per_sell, strict=True):
+            proceeds = row.shares * row.price
+            pnl = proceeds - basis * row.shares
+            if isinstance(row.purchase_date, date):
+                days_held: object = (row.date - row.purchase_date).days
+                purchase_cell: str = row.purchase_date.isoformat()
+            else:
+                days_held = ""
+                purchase_cell = row.purchase_date or ""
+            writer.writerow(
+                [
+                    row.ticker,
+                    row.shares,
+                    purchase_cell,
+                    row.date.isoformat(),
+                    round(basis, 4),
+                    round(proceeds, 4),
+                    round(pnl, 4),
+                    days_held,
+                    row.holding_period.value if row.holding_period else "",
+                ]
+            )
+        for s in summary:
+            writer.writerow([])
+            writer.writerow([f"Year {s.year}", "", "", "", "", "", "", "", ""])
+            writer.writerow(["ST realized", "", "", "", "", "", round(s.st_realized, 4), "", ""])
+            writer.writerow(["LT realized", "", "", "", "", "", round(s.lt_realized, 4), "", ""])
+            writer.writerow(["Net (after netting)", "", "", "", "", "", round(s.net_after_cross, 4), "", ""])
+            writer.writerow(["Deductible loss", "", "", "", "", "", round(s.deductible_loss, 4), "", ""])
+            writer.writerow(["Tax owed", "", "", "", "", "", round(s.tax_owed, 4), "", ""])
+            writer.writerow(["Carry forward", "", "", "", "", "", round(s.carry_forward, 4), "", ""])

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -17,6 +17,7 @@ from midas.models import (
     PortfolioConfig,
     RiskConfig,
     StrategyConfig,
+    TaxConfig,
 )
 from midas.order_sizer import OrderSizer
 from midas.output import print_backtest_summary, print_status, print_strategy_table
@@ -159,8 +160,8 @@ def backtest(
 ) -> None:
     """Run a backtest over historical data."""
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints, risk_config = (
-        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
+    strat_configs, constraints, risk_config, _tax_config = (
+        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig(), None)
     )
 
     start_d, end_d = _to_date(start), _to_date(end)
@@ -225,8 +226,8 @@ def live(
     portfolio_path = Path(portfolio)
     port = load_portfolio(portfolio_path)
     state_path = port.state_file if port.state_file is not None else portfolio_path.with_suffix(".state.yaml")
-    strat_configs, constraints, risk_config = (
-        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig())
+    strat_configs, constraints, risk_config, _tax_config = (
+        load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig(), None)
     )
     provider = CachedYFinanceProvider()
 
@@ -348,8 +349,9 @@ def optimize(
     strategy_names: list[str] | None = None
     min_cash_pct = AllocationConstraints().min_cash_pct
     risk_config: RiskConfig = RiskConfig()
+    tax_config: TaxConfig | None = None
     if strategies:
-        strat_configs, strat_constraints, risk_config = load_strategies(Path(strategies))
+        strat_configs, strat_constraints, risk_config, tax_config = load_strategies(Path(strategies))
         strategy_names = [cfg.name for cfg in strat_configs]
         min_cash_pct = strat_constraints.min_cash_pct
 
@@ -385,7 +387,13 @@ def optimize(
             risk_config=risk_config,
         )
 
-        write_strategies_yaml(wf_result.best_params, output, min_cash_pct=min_cash_pct, risk_config=risk_config)
+        write_strategies_yaml(
+            wf_result.best_params,
+            output,
+            min_cash_pct=min_cash_pct,
+            risk_config=risk_config,
+            tax_config=tax_config,
+        )
 
         console.print()
 
@@ -470,7 +478,13 @@ def optimize(
             risk_config=risk_config,
         )
 
-        write_strategies_yaml(result.best_params, output, min_cash_pct=min_cash_pct, risk_config=risk_config)
+        write_strategies_yaml(
+            result.best_params,
+            output,
+            min_cash_pct=min_cash_pct,
+            risk_config=risk_config,
+            tax_config=tax_config,
+        )
 
         console.print()
 

--- a/src/midas/cli.py
+++ b/src/midas/cli.py
@@ -160,7 +160,7 @@ def backtest(
 ) -> None:
     """Run a backtest over historical data."""
     port = load_portfolio(Path(portfolio))
-    strat_configs, constraints, risk_config, _tax_config = (
+    strat_configs, constraints, risk_config, _ = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig(), None)
     )
 
@@ -226,7 +226,7 @@ def live(
     portfolio_path = Path(portfolio)
     port = load_portfolio(portfolio_path)
     state_path = port.state_file if port.state_file is not None else portfolio_path.with_suffix(".state.yaml")
-    strat_configs, constraints, risk_config, _tax_config = (
+    strat_configs, constraints, risk_config, _ = (
         load_strategies(Path(strategies)) if strategies else (None, AllocationConstraints(), RiskConfig(), None)
     )
     provider = CachedYFinanceProvider()

--- a/src/midas/config.py
+++ b/src/midas/config.py
@@ -19,6 +19,7 @@ from midas.models import (
     PortfolioConfig,
     RiskConfig,
     StrategyConfig,
+    TaxConfig,
     TradingRestrictions,
 )
 
@@ -82,11 +83,13 @@ def load_portfolio(path: Path) -> PortfolioConfig:
 
 def load_strategies(
     path: Path,
-) -> tuple[list[StrategyConfig], AllocationConstraints, RiskConfig]:
-    """Load strategy configs, allocation knobs, and optional risk policy from YAML.
+) -> tuple[list[StrategyConfig], AllocationConstraints, RiskConfig, TaxConfig | None]:
+    """Load strategy configs, allocation knobs, optional risk policy, and optional tax policy.
 
-    Returns (strategies, constraints, risk_config). The risk block is optional;
-    omitting it yields a default ``RiskConfig`` (all features off, current behavior).
+    Returns (strategies, constraints, risk_config, tax_config). Both risk and tax
+    blocks are optional; omitting either yields the documented default (default
+    ``RiskConfig`` for risk, ``None`` for tax — meaning after-tax accounting is
+    disabled).
     """
     raw = _load_yaml(path)
 
@@ -124,4 +127,14 @@ def load_strategies(
         drawdown_floor=(float(risk_raw["drawdown_floor"]) if risk_raw.get("drawdown_floor") is not None else None),
     )
 
-    return configs, constraints, risk
+    tax_raw = raw.get("tax")
+    tax: TaxConfig | None = None
+    if tax_raw is not None:
+        tax = TaxConfig(
+            short_term_rate=float(tax_raw.get("short_term_rate", 0.37)),
+            long_term_rate=float(tax_raw.get("long_term_rate", 0.20)),
+            deductible_loss_cap=float(tax_raw.get("deductible_loss_cap", 3000.0)),
+            payment_lag_days=int(tax_raw.get("payment_lag_days", 105)),
+        )
+
+    return configs, constraints, risk, tax

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -320,7 +320,9 @@ class LiveEngine:
             if order.direction == Direction.BUY:
                 apply_buy(self._state, order.ticker, order.shares, order.price, today)
             else:
-                apply_sell(self._state, order.ticker, order.shares, order.price, today)
+                # apply_sell return now carries per-bucket detail used by the
+                # trade-log append in Task 6 — hold for that wiring.
+                _breakdown = apply_sell(self._state, order.ticker, order.shares, order.price, today)
             if self._restriction_tracker is not None:
                 self._restriction_tracker.record_trade(order.ticker, order.direction, today)
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -320,9 +320,9 @@ class LiveEngine:
             if order.direction == Direction.BUY:
                 apply_buy(self._state, order.ticker, order.shares, order.price, today)
             else:
-                # apply_sell return now carries per-bucket detail used by the
-                # trade-log append in Task 6 — hold for that wiring.
-                _breakdown = apply_sell(self._state, order.ticker, order.shares, order.price, today)
+                # apply_sell return carries per-bucket detail used by the trade-log
+                # append in Task 6; discarding here keeps semantics identical to before.
+                _ = apply_sell(self._state, order.ticker, order.shares, order.price, today)
             if self._restriction_tracker is not None:
                 self._restriction_tracker.record_trade(order.ticker, order.direction, today)
 

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -26,6 +26,7 @@ from midas.live_state import (
     apply_buy,
     apply_sell,
     load_or_seed,
+    resolve_purchase_date,
     save_atomic,
 )
 from midas.models import (
@@ -39,26 +40,9 @@ from midas.order_sizer import OrderSizer
 from midas.output import print_alert, print_status
 from midas.restrictions import RestrictionTracker
 from midas.strategies.base import ExitRule, max_warmup, warmup_bars_to_calendar_days
-from midas.trade_log import PurchaseDate, append_trade
+from midas.trade_log import append_trade
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_purchase_date(dates: tuple[date | None, ...]) -> PurchaseDate:
-    """Map a tuple of consumed lots' purchase dates to a single CSV value.
-
-    - Empty tuple -> ``None``.
-    - All consumed lots share one ``purchase_date`` (a date OR all-``None``)
-      -> that single value.
-    - Multiple distinct values, including the ``date + None`` mix -> the
-      literal string ``'various'``.
-    """
-    if not dates:
-        return None
-    unique = set(dates)
-    if len(unique) == 1:
-        return next(iter(unique))
-    return "various"
 
 
 class LiveEngine:
@@ -344,6 +328,9 @@ class LiveEngine:
 
         # Apply assumed fills to the in-memory state. Capture per-SELL breakdowns
         # so the trade-log append below has shares/basis/dates per ST/LT bucket.
+        # Order is a frozen dataclass but contains an OrderContext with a dict
+        # field (contributions), making it unhashable. Use id(order) — safe
+        # because filtered is a stable list across both passes within _tick.
         sell_breakdowns: dict[int, SellBreakdown] = {}
         for order in filtered:
             if order.shares <= 0:
@@ -393,7 +380,7 @@ class LiveEngine:
             else:
                 breakdown = sell_breakdowns[id(order)]
                 if breakdown.st_shares > 0:
-                    st_purchase = _resolve_purchase_date(breakdown.st_purchase_dates)
+                    st_purchase = resolve_purchase_date(breakdown.st_purchase_dates)
                     st_record = TradeRecord(
                         date=today,
                         ticker=order.ticker,
@@ -411,7 +398,7 @@ class LiveEngine:
                         purchase_date=st_purchase,
                     )
                 if breakdown.lt_shares > 0:
-                    lt_purchase = _resolve_purchase_date(breakdown.lt_purchase_dates)
+                    lt_purchase = resolve_purchase_date(breakdown.lt_purchase_dates)
                     lt_record = TradeRecord(
                         date=today,
                         ticker=order.ticker,

--- a/src/midas/live.py
+++ b/src/midas/live.py
@@ -19,18 +19,46 @@ except ImportError:  # Windows
 from midas.allocator import AllocationResult, Allocator
 from midas.data.price_history import PriceHistory
 from midas.data.provider import DataProvider
-from midas.live_state import LiveState, aggregate_cost_basis, apply_buy, apply_sell, load_or_seed, save_atomic
+from midas.live_state import (
+    LiveState,
+    SellBreakdown,
+    aggregate_cost_basis,
+    apply_buy,
+    apply_sell,
+    load_or_seed,
+    save_atomic,
+)
 from midas.models import (
     AllocationConstraints,
     Direction,
+    HoldingPeriod,
     PortfolioConfig,
+    TradeRecord,
 )
 from midas.order_sizer import OrderSizer
 from midas.output import print_alert, print_status
 from midas.restrictions import RestrictionTracker
 from midas.strategies.base import ExitRule, max_warmup, warmup_bars_to_calendar_days
+from midas.trade_log import PurchaseDate, append_trade
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_purchase_date(dates: tuple[date | None, ...]) -> PurchaseDate:
+    """Map a tuple of consumed lots' purchase dates to a single CSV value.
+
+    - Empty tuple -> ``None``.
+    - All consumed lots share one ``purchase_date`` (a date OR all-``None``)
+      -> that single value.
+    - Multiple distinct values, including the ``date + None`` mix -> the
+      literal string ``'various'``.
+    """
+    if not dates:
+        return None
+    unique = set(dates)
+    if len(unique) == 1:
+        return next(iter(unique))
+    return "various"
 
 
 class LiveEngine:
@@ -54,6 +82,7 @@ class LiveEngine:
             )
             raise RuntimeError(msg)
         self._state_path = state_path
+        self._trade_log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
         # Take an exclusive non-blocking advisory lock on a sidecar lockfile
         # before touching the state. Two ``midas live`` processes against the
         # same state file would otherwise both load, both compute, both write
@@ -313,16 +342,16 @@ class LiveEngine:
         # running subtotal from state after fills would double-count.
         pre_fill_cash = self._state.available_cash
 
-        # Apply assumed fills to the in-memory state.
+        # Apply assumed fills to the in-memory state. Capture per-SELL breakdowns
+        # so the trade-log append below has shares/basis/dates per ST/LT bucket.
+        sell_breakdowns: dict[int, SellBreakdown] = {}
         for order in filtered:
             if order.shares <= 0:
                 continue
             if order.direction == Direction.BUY:
                 apply_buy(self._state, order.ticker, order.shares, order.price, today)
             else:
-                # apply_sell return carries per-bucket detail used by the trade-log
-                # append in Task 6; discarding here keeps semantics identical to before.
-                _ = apply_sell(self._state, order.ticker, order.shares, order.price, today)
+                sell_breakdowns[id(order)] = apply_sell(self._state, order.ticker, order.shares, order.price, today)
             if self._restriction_tracker is not None:
                 self._restriction_tracker.record_trade(order.ticker, order.direction, today)
 
@@ -338,6 +367,67 @@ class LiveEngine:
         # Persist state at the end of the tick (HWM/peak/infusion always advance,
         # even on no-change ticks where alert printing is suppressed below).
         save_atomic(self._state, self._state_path)
+
+        # Append a row per BUY and per non-empty ST/LT SELL bucket to the trade log.
+        # Order matters: state is durable first; if the append fails, the operator
+        # sees the error and re-running re-attempts the append.
+        for order in filtered:
+            if order.shares <= 0:
+                continue
+            if order.direction == Direction.BUY:
+                buy_record = TradeRecord(
+                    date=today,
+                    ticker=order.ticker,
+                    direction=Direction.BUY,
+                    shares=order.shares,
+                    price=order.price,
+                    strategy_name=order.context.source,
+                    purchase_date=today,
+                )
+                append_trade(
+                    self._trade_log_path,
+                    buy_record,
+                    cost_basis=None,
+                    purchase_date=today,
+                )
+            else:
+                breakdown = sell_breakdowns[id(order)]
+                if breakdown.st_shares > 0:
+                    st_purchase = _resolve_purchase_date(breakdown.st_purchase_dates)
+                    st_record = TradeRecord(
+                        date=today,
+                        ticker=order.ticker,
+                        direction=Direction.SELL,
+                        shares=breakdown.st_shares,
+                        price=order.price,
+                        strategy_name=order.context.source,
+                        holding_period=HoldingPeriod.SHORT_TERM,
+                        purchase_date=st_purchase,
+                    )
+                    append_trade(
+                        self._trade_log_path,
+                        st_record,
+                        cost_basis=breakdown.st_basis,
+                        purchase_date=st_purchase,
+                    )
+                if breakdown.lt_shares > 0:
+                    lt_purchase = _resolve_purchase_date(breakdown.lt_purchase_dates)
+                    lt_record = TradeRecord(
+                        date=today,
+                        ticker=order.ticker,
+                        direction=Direction.SELL,
+                        shares=breakdown.lt_shares,
+                        price=order.price,
+                        strategy_name=order.context.source,
+                        holding_period=HoldingPeriod.LONG_TERM,
+                        purchase_date=lt_purchase,
+                    )
+                    append_trade(
+                        self._trade_log_path,
+                        lt_record,
+                        cost_basis=breakdown.lt_basis,
+                        purchase_date=lt_purchase,
+                    )
 
         # Emit alerts only when the order set changes
         current_keys = {(order.ticker, order.direction, order.shares) for order in filtered if order.shares > 0}

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -277,6 +277,11 @@ class SellBreakdown:
     ``sum(take * cost_basis)`` accumulator, useful for callers that need bit-
     identical reconstructions of total basis (since ``basis * shares`` is only
     algebraically — not bit-identically — equal in IEEE-754).
+
+    The ``*_purchase_dates`` tuples list the purchase dates of the consumed lot
+    slices in FIFO order; trade-log writers use them to populate the
+    ``purchase_date`` column (single date when all lots in a bucket share one
+    date, otherwise the literal string ``'various'``).
     """
 
     st_shares: float
@@ -285,6 +290,8 @@ class SellBreakdown:
     lt_shares: float
     lt_basis: float
     lt_weighted: float
+    st_purchase_dates: tuple[date | None, ...] = ()
+    lt_purchase_dates: tuple[date | None, ...] = ()
 
 
 def aggregate_cost_basis(lots: Sequence[PositionLot]) -> float:
@@ -300,8 +307,9 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
 
     Lots whose ``purchase_date`` is at least 365 days before *day* contribute
     to the long-term bucket; everything else (including ``purchase_date=None``)
-    goes to the short-term bucket. Each bucket reports a share-weighted
-    cost basis over the consumed slices.
+    goes to the short-term bucket. Each bucket reports a share-weighted cost
+    basis over the consumed slices, plus the per-lot purchase dates of the
+    slices in FIFO order.
     """
     if shares <= 0 or not lots:
         return SellBreakdown(
@@ -315,8 +323,10 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
 
     st_shares = 0.0
     st_weighted = 0.0
+    st_dates: list[date | None] = []
     lt_shares = 0.0
     lt_weighted = 0.0
+    lt_dates: list[date | None] = []
     remaining = shares
     while remaining > 0 and lots:
         lot = lots[0]
@@ -325,9 +335,11 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
         if is_long_term:
             lt_shares += take
             lt_weighted += take * lot.cost_basis
+            lt_dates.append(lot.purchase_date)
         else:
             st_shares += take
             st_weighted += take * lot.cost_basis
+            st_dates.append(lot.purchase_date)
 
         if lot.shares <= remaining:
             remaining -= lot.shares
@@ -349,6 +361,8 @@ def consume_lots_fifo(lots: list[PositionLot], shares: float, day: date) -> Sell
         lt_shares=lt_shares,
         lt_basis=lt_basis,
         lt_weighted=lt_weighted,
+        st_purchase_dates=tuple(st_dates),
+        lt_purchase_dates=tuple(lt_dates),
     )
 
 

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -376,13 +376,13 @@ def apply_buy(state: LiveState, ticker: str, shares: float, price: float, day: d
     state.available_cash -= shares * price
 
 
-def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: date) -> tuple[float, float]:
+def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: date) -> SellBreakdown:
     """Consume *shares* of *ticker* FIFO and increment cash by ``shares * price``.
 
-    Mutates *state* in place. Returns ``(st_realized_pnl, lt_realized_pnl)``
-    matching backtest's ST/LT classification (lots with purchase_date >=365
-    days before *day* count as long-term; everything else, including
-    ``purchase_date=None``, counts as short-term).
+    Mutates *state* in place. Returns the full ``SellBreakdown`` so callers
+    can write trade-log rows with per-bucket shares, basis, and consumed-lot
+    purchase dates. Realized P&L is recoverable as
+    ``breakdown.st_shares * price - breakdown.st_weighted`` (analogous for LT).
     """
     lots = state.lots.get(ticker, [])
     breakdown = consume_lots_fifo(lots, shares, day)
@@ -399,6 +399,4 @@ def apply_sell(state: LiveState, ticker: str, shares: float, price: float, day: 
         # Mirrors backtest's ``state.high_water_marks.pop(ticker, None)`` on
         # ``new_position == 0``.
         state.high_water_marks.pop(ticker, None)
-    st_pnl = breakdown.st_shares * price - breakdown.st_weighted
-    lt_pnl = breakdown.lt_shares * price - breakdown.lt_weighted
-    return st_pnl, lt_pnl
+    return breakdown

--- a/src/midas/live_state.py
+++ b/src/midas/live_state.py
@@ -18,13 +18,36 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
 from midas.models import PortfolioConfig, PositionLot
 
 logger = logging.getLogger(__name__)
+
+type PurchaseDate = date | Literal["various"] | None
+
+
+def resolve_purchase_date(dates: tuple[date | None, ...]) -> PurchaseDate:
+    """Map a tuple of consumed lots' purchase dates to a single CSV value.
+
+    - Empty tuple -> ``None``.
+    - All consumed lots share one ``purchase_date`` (a date OR all-``None``)
+      -> that single value.
+    - Multiple distinct values, including the ``date + None`` mix -> the
+      literal string ``'various'``.
+
+    Used by both the live engine and the backtest engine to derive the
+    ``purchase_date`` column on a SELL bucket row in the trade log.
+    """
+    if not dates:
+        return None
+    unique = set(dates)
+    if len(unique) == 1:
+        return next(iter(unique))
+    return "various"
+
 
 SCHEMA_VERSION = 1
 # When bumping SCHEMA_VERSION, add a migration path in ``load_state`` so

--- a/src/midas/metrics.py
+++ b/src/midas/metrics.py
@@ -50,7 +50,12 @@ def _drawdown_series(equity_curve: list[tuple[date, float]]) -> list[float]:
     return result
 
 
-def _pair_sells_with_basis(
+# ---------------------------------------------------------------------------
+# Public compute functions
+# ---------------------------------------------------------------------------
+
+
+def pair_sells_with_basis(
     trades: list[TradeRecord],
     basis_per_sell: list[float],
 ) -> list[tuple[TradeRecord, float]]:
@@ -65,11 +70,6 @@ def _pair_sells_with_basis(
         basis = basis_per_sell[idx] if idx < len(basis_per_sell) else trade.price
         paired.append((trade, basis))
     return paired
-
-
-# ---------------------------------------------------------------------------
-# Public compute functions
-# ---------------------------------------------------------------------------
 
 
 def compute_cagr(starting: float, final: float, days: int) -> float:
@@ -159,7 +159,7 @@ def compute_trade_stats(
 
     Breakeven sells (`pnl == 0`) are counted as wins by convention.
     """
-    paired = _pair_sells_with_basis(trades, basis_per_sell)
+    paired = pair_sells_with_basis(trades, basis_per_sell)
     if not paired:
         return 0.0, 0.0, 0.0, 0.0
 
@@ -192,7 +192,7 @@ def compute_strategy_stats(
     basis_per_sell: list[float],
 ) -> list[StrategyStats]:
     """Compute per-(strategy, ticker) trade breakdown."""
-    sell_basis: dict[int, float] = {id(trade): basis for trade, basis in _pair_sells_with_basis(trades, basis_per_sell)}
+    sell_basis: dict[int, float] = {id(trade): basis for trade, basis in pair_sells_with_basis(trades, basis_per_sell)}
 
     by_key: dict[tuple[str, str], list[TradeRecord]] = defaultdict(list)
     for trade in trades:

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from enum import Enum
@@ -118,6 +119,23 @@ class PositionLot:
 
 @dataclass(frozen=True)
 class TradeRecord:
+    """A single executed trade.
+
+    Attributes:
+        date: Fill date.
+        ticker: Symbol.
+        direction: BUY or SELL.
+        shares: Filled share count.
+        price: Fill price per share.
+        strategy_name: Attribution source for this fill.
+        holding_period: SHORT_TERM or LONG_TERM on a SELL bucket; ``None`` on a BUY.
+        purchase_date: Purchase date of the consumed lots (SELL) or the fill date
+            (BUY). On a SELL bucket row, ``'various'`` is the literal string
+            sentinel for mixed-lot buckets where the consumed lots don't share a
+            single purchase date — matches Schedule D convention. ``None``
+            indicates an unseeded live lot (purchase date never known).
+    """
+
     date: date
     ticker: str
     direction: Direction
@@ -125,6 +143,7 @@ class TradeRecord:
     price: float
     strategy_name: str
     holding_period: HoldingPeriod | None = None
+    purchase_date: datetime.date | str | None = None
 
 
 @dataclass

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -214,3 +214,9 @@ class TaxConfig:
         if self.payment_lag_days < 0:
             msg = f"payment_lag_days must be >= 0, got {self.payment_lag_days}"
             raise ValueError(msg)
+        if self.long_term_rate > self.short_term_rate:
+            msg = (
+                f"long_term_rate ({self.long_term_rate}) must be <= short_term_rate "
+                f"({self.short_term_rate}); preferential LT rate is always <= the ST rate"
+            )
+            raise ValueError(msg)

--- a/src/midas/models.py
+++ b/src/midas/models.py
@@ -178,3 +178,39 @@ class RiskConfig:
             missing = "drawdown_floor" if self.drawdown_penalty is not None else "drawdown_penalty"
             msg = f"drawdown_penalty and drawdown_floor must both be set or both omitted; missing {missing}"
             raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class TaxConfig:
+    """Optional capital-gains-tax accounting policy.
+
+    All rates are decimal fractions (0.37 == 37%). When None is passed in
+    place of a TaxConfig, after-tax accounting is fully disabled — no extra
+    BacktestResult fields, no equity_curve.csv column, no chart overlay.
+
+    deductible_loss_cap: cap on net losses deducted against ordinary income
+        per year (IRC §1211(b) — $3,000 single-filer / MFJ). Excess carries
+        forward to the next year.
+    payment_lag_days: calendar days from year-end to when tax for that year
+        is deducted from the after-tax equity curve. Defaults to 105 ≈ Apr 15
+        of the following year.
+    """
+
+    short_term_rate: float = 0.37
+    long_term_rate: float = 0.20
+    deductible_loss_cap: float = 3000.0
+    payment_lag_days: int = 105
+
+    def __post_init__(self) -> None:
+        if self.short_term_rate < 0 or self.short_term_rate >= 1:
+            msg = f"short_term_rate must be in [0, 1), got {self.short_term_rate}"
+            raise ValueError(msg)
+        if self.long_term_rate < 0 or self.long_term_rate >= 1:
+            msg = f"long_term_rate must be in [0, 1), got {self.long_term_rate}"
+            raise ValueError(msg)
+        if self.deductible_loss_cap < 0:
+            msg = f"deductible_loss_cap must be >= 0, got {self.deductible_loss_cap}"
+            raise ValueError(msg)
+        if self.payment_lag_days < 0:
+            msg = f"payment_lag_days must be >= 0, got {self.payment_lag_days}"
+            raise ValueError(msg)

--- a/src/midas/optimizer.py
+++ b/src/midas/optimizer.py
@@ -24,6 +24,7 @@ from midas.models import (
     AllocationConstraints,
     PortfolioConfig,
     RiskConfig,
+    TaxConfig,
 )
 from midas.order_sizer import OrderSizer
 from midas.results import BacktestResult
@@ -787,13 +788,15 @@ def write_strategies_yaml(
     path: str,
     min_cash_pct: float = DEFAULT_MIN_CASH_PCT,
     risk_config: RiskConfig | None = None,
+    tax_config: TaxConfig | None = None,
 ) -> None:
     """Write optimized parameters to a strategies YAML file.
 
-    The optimizer does not search risk knobs (risk is policy, not a tunable).
-    When the user supplied a ``risk:`` block in the input, it must round-trip
-    to the optimized output unchanged so the next run honors the same policy;
-    otherwise the optimized YAML silently drops the user's risk config.
+    The optimizer does not search risk or tax knobs (both are policy, not
+    tunables). When the user supplied a ``risk:`` or ``tax:`` block in the
+    input, it must round-trip to the optimized output unchanged so the next
+    run honors the same policy; otherwise the optimized YAML silently drops
+    the user's config.
 
     Args:
         params: Per-strategy parameter dict from the optimizer (also includes
@@ -803,6 +806,8 @@ def write_strategies_yaml(
         risk_config: Preserved from the user's input config. When present and
             differing from defaults, emitted as a ``risk:`` block. ``None`` or
             an all-default ``RiskConfig`` is omitted.
+        tax_config: Preserved from the user's input config. When present,
+            emitted as a ``tax:`` block. ``None`` is omitted.
     """
     output: dict[str, object] = {}
 
@@ -817,6 +822,14 @@ def write_strategies_yaml(
     risk_block = _risk_block_for_yaml(risk_config)
     if risk_block:
         output["risk"] = risk_block
+
+    if tax_config is not None:
+        output["tax"] = {
+            "short_term_rate": tax_config.short_term_rate,
+            "long_term_rate": tax_config.long_term_rate,
+            "deductible_loss_cap": tax_config.deductible_loss_cap,
+            "payment_lag_days": tax_config.payment_lag_days,
+        }
 
     strategies = []
     for name, param_dict in params.items():

--- a/src/midas/output.py
+++ b/src/midas/output.py
@@ -182,6 +182,38 @@ def print_backtest_summary(result: BacktestResult, *, show_charts: bool = False)
             justify="center",
         )
 
+    # --- After-Tax Performance ---
+    if result.after_tax_final_value is not None:
+        after_tax = make_metric_table("After-Tax Performance")
+        after_tax.add_row("After-Tax Final Value", f"${result.after_tax_final_value:,.2f}")
+        after_tax.add_row(
+            "After-Tax Total Return",
+            _return_row(result.after_tax_total_return or 0.0, total_days),
+        )
+        after_tax.add_row("After-Tax CAGR", color_signed(result.after_tax_cagr or 0.0))
+        if result.tax_cost_ratio is not None:
+            after_tax.add_row("Tax Cost Ratio", f"{result.tax_cost_ratio:.2%}")
+        print_centered(after_tax)
+
+        if result.tax_summary:
+            tax_table = make_wide_table("Realized Tax (per year)")
+            tax_table.add_column("Year", style="bold")
+            tax_table.add_column("ST Realized", justify="right")
+            tax_table.add_column("LT Realized", justify="right")
+            tax_table.add_column("Net (after netting)", justify="right")
+            tax_table.add_column("Tax Owed", justify="right")
+            tax_table.add_column("Carry Forward", justify="right")
+            for s in result.tax_summary:
+                tax_table.add_row(
+                    str(s.year),
+                    f"${s.st_realized:+,.2f}",
+                    f"${s.lt_realized:+,.2f}",
+                    f"${s.net_after_cross:+,.2f}",
+                    f"${s.tax_owed:+,.2f}",
+                    f"${s.carry_forward:,.2f}",
+                )
+            print_centered(tax_table)
+
     # --- Train / Test Split ---
     if result.split_date:
         split = make_metric_table("Train / Test Split")

--- a/src/midas/results.py
+++ b/src/midas/results.py
@@ -22,6 +22,7 @@ from midas.metrics import (
 )
 from midas.models import Direction, TradeRecord
 from midas.risk_metrics import RiskHistory, RiskMetrics
+from midas.trade_log import format_holding_period, format_purchase_date
 
 
 @dataclass
@@ -101,13 +102,6 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
             ]
         )
         for trade in result.trades:
-            purchase_cell: str
-            if trade.purchase_date is None:
-                purchase_cell = ""
-            elif isinstance(trade.purchase_date, str):
-                purchase_cell = trade.purchase_date
-            else:
-                purchase_cell = trade.purchase_date.isoformat()
             common = [
                 trade.date.isoformat(),
                 trade.ticker,
@@ -115,8 +109,8 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
                 trade.shares,
                 trade.price,
                 trade.strategy_name,
-                trade.holding_period.value if trade.holding_period else "",
-                purchase_cell,
+                format_holding_period(trade.holding_period),
+                format_purchase_date(trade.purchase_date),
             ]
             if trade.direction == Direction.SELL:
                 basis = sell_basis.get(id(trade), trade.price)

--- a/src/midas/results.py
+++ b/src/midas/results.py
@@ -146,7 +146,7 @@ def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
         for (dt, nav), drawdown in zip(result.equity_curve, drawdowns, strict=True):
             row: list[object] = [dt.isoformat(), round(nav, 2), round(drawdown, 6)]
             if has_after_tax:
-                row.append(round(after_tax_by_date.get(dt, nav), 2))
+                row.append(round(after_tax_by_date[dt], 2))
             writer.writerow(row)
 
 
@@ -199,11 +199,11 @@ def _write_summary_json(result: BacktestResult, path: Path) -> None:
     if result.after_tax_final_value is not None:
         summary["after_tax_final_value"] = result.after_tax_final_value
         if result.after_tax_total_return is not None:
-            summary["after_tax_total_return"] = round(result.after_tax_total_return, 6)
+            summary["after_tax_total_return"] = round(result.after_tax_total_return, 4)
         if result.after_tax_cagr is not None:
-            summary["after_tax_cagr"] = round(result.after_tax_cagr, 6)
+            summary["after_tax_cagr"] = round(result.after_tax_cagr, 4)
         if result.after_tax_twr is not None:
-            summary["after_tax_twr"] = round(result.after_tax_twr, 6)
+            summary["after_tax_twr"] = round(result.after_tax_twr, 4)
         if result.tax_cost_ratio is not None:
             summary["tax_cost_ratio"] = round(result.tax_cost_ratio, 6)
 

--- a/src/midas/results.py
+++ b/src/midas/results.py
@@ -22,6 +22,7 @@ from midas.metrics import (
 )
 from midas.models import Direction, TradeRecord
 from midas.risk_metrics import RiskHistory, RiskMetrics
+from midas.tax import AnnualTaxSummary
 from midas.trade_log import format_holding_period, format_purchase_date
 
 
@@ -62,6 +63,13 @@ class BacktestResult:
     risk_history: RiskHistory | None = None  # per-bar risk telemetry across the run
     bh_equity_curve: list[tuple[date, float]] = field(default_factory=list)
     """Per-bar buy-and-hold equity, parallel to ``equity_curve``."""
+    after_tax_final_value: float | None = None
+    after_tax_total_return: float | None = None
+    after_tax_cagr: float | None = None
+    after_tax_twr: float | None = None
+    after_tax_equity_curve: list[tuple[date, float]] = field(default_factory=list)
+    tax_cost_ratio: float | None = None
+    tax_summary: list[AnnualTaxSummary] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -123,11 +131,23 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
 
 def _write_equity_curve_csv(result: BacktestResult, path: Path) -> None:
     drawdowns = _drawdown_series(result.equity_curve)
+    has_after_tax = len(result.after_tax_equity_curve) == len(result.equity_curve) and bool(
+        result.after_tax_equity_curve
+    )
+    after_tax_by_date: dict[date, float] = (
+        {dt: nav for dt, nav in result.after_tax_equity_curve} if has_after_tax else {}
+    )
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["date", "nav", "drawdown"])
+        header = ["date", "nav", "drawdown"]
+        if has_after_tax:
+            header.append("nav_after_tax")
+        writer.writerow(header)
         for (dt, nav), drawdown in zip(result.equity_curve, drawdowns, strict=True):
-            writer.writerow([dt.isoformat(), round(nav, 2), round(drawdown, 6)])
+            row: list[object] = [dt.isoformat(), round(nav, 2), round(drawdown, 6)]
+            if has_after_tax:
+                row.append(round(after_tax_by_date.get(dt, nav), 2))
+            writer.writerow(row)
 
 
 def _write_summary_json(result: BacktestResult, path: Path) -> None:
@@ -175,6 +195,32 @@ def _write_summary_json(result: BacktestResult, path: Path) -> None:
             "train_trades": len(result.train_trades),
             "test_trades": len(result.test_trades),
         }
+
+    if result.after_tax_final_value is not None:
+        summary["after_tax_final_value"] = result.after_tax_final_value
+        if result.after_tax_total_return is not None:
+            summary["after_tax_total_return"] = round(result.after_tax_total_return, 6)
+        if result.after_tax_cagr is not None:
+            summary["after_tax_cagr"] = round(result.after_tax_cagr, 6)
+        if result.after_tax_twr is not None:
+            summary["after_tax_twr"] = round(result.after_tax_twr, 6)
+        if result.tax_cost_ratio is not None:
+            summary["tax_cost_ratio"] = round(result.tax_cost_ratio, 6)
+
+    if result.tax_summary:
+        summary["tax_summary"] = [
+            {
+                "year": s.year,
+                "st_realized": round(s.st_realized, 4),
+                "lt_realized": round(s.lt_realized, 4),
+                "net_after_cross": round(s.net_after_cross, 4),
+                "deductible_loss": round(s.deductible_loss, 4),
+                "carry_forward": round(s.carry_forward, 4),
+                "tax_owed": round(s.tax_owed, 4),
+                "payment_date": s.payment_date.isoformat(),
+            }
+            for s in result.tax_summary
+        ]
 
     with open(path, "w") as f:
         json.dump(summary, f, indent=2)

--- a/src/midas/results.py
+++ b/src/midas/results.py
@@ -16,9 +16,9 @@ from pathlib import Path
 from midas.metrics import (
     StrategyStats,
     _drawdown_series,
-    _pair_sells_with_basis,
     aggregate_strategy_stats,
     compute_annualized_return,
+    pair_sells_with_basis,
 )
 from midas.models import Direction, TradeRecord
 from midas.risk_metrics import RiskHistory, RiskMetrics
@@ -83,7 +83,7 @@ def write_backtest_results(result: BacktestResult, output_dir: Path) -> None:
 
 
 def _write_trades_csv(result: BacktestResult, path: Path) -> None:
-    sell_basis = {id(trade): basis for trade, basis in _pair_sells_with_basis(result.trades, result.basis_per_sell)}
+    sell_basis = {id(trade): basis for trade, basis in pair_sells_with_basis(result.trades, result.basis_per_sell)}
     with open(path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(

--- a/src/midas/results.py
+++ b/src/midas/results.py
@@ -94,12 +94,20 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
                 "price",
                 "strategy",
                 "holding_period",
+                "purchase_date",
                 "cost_basis",
                 "realized_pnl",
                 "return_pct",
             ]
         )
         for trade in result.trades:
+            purchase_cell: str
+            if trade.purchase_date is None:
+                purchase_cell = ""
+            elif isinstance(trade.purchase_date, str):
+                purchase_cell = trade.purchase_date
+            else:
+                purchase_cell = trade.purchase_date.isoformat()
             common = [
                 trade.date.isoformat(),
                 trade.ticker,
@@ -108,6 +116,7 @@ def _write_trades_csv(result: BacktestResult, path: Path) -> None:
                 trade.price,
                 trade.strategy_name,
                 trade.holding_period.value if trade.holding_period else "",
+                purchase_cell,
             ]
             if trade.direction == Direction.SELL:
                 basis = sell_basis.get(id(trade), trade.price)

--- a/src/midas/tax.py
+++ b/src/midas/tax.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
 
-from midas.metrics import _pair_sells_with_basis
+from midas.metrics import pair_sells_with_basis
 from midas.models import Direction, HoldingPeriod, TaxConfig, TradeRecord
 
 
@@ -74,8 +74,12 @@ def compute_tax_summary(
         One AnnualTaxSummary per calendar year that contained at least one
         SELL or that received a carryforward from the prior year. Sorted by
         year ascending.
+
+        Years with no SELL activity are omitted even if a non-zero
+        ``carry_forward`` is alive — the carry threads forward silently to the
+        next year that has activity.
     """
-    paired = _pair_sells_with_basis(list(trades), list(basis_per_sell))
+    paired = pair_sells_with_basis(list(trades), list(basis_per_sell))
     by_year_st: dict[int, float] = defaultdict(float)
     by_year_lt: dict[int, float] = defaultdict(float)
 
@@ -128,6 +132,8 @@ def compute_tax_summary(
             lt_after_cross -= shave
             remaining_carry -= shave
         # Any still-remaining carry is pure loss applied to ST bucket.
+        # Residual carry after exhausting gains in both buckets is pure ST loss
+        # (carryforward already lost ST/LT character on rollover).
         st_after_cross -= remaining_carry
 
         net_after_cross = st_after_cross + lt_after_cross
@@ -140,8 +146,9 @@ def compute_tax_summary(
             absolute = -net_after_cross
             deductible_loss = min(absolute, config.deductible_loss_cap)
             carry_out = absolute - deductible_loss
-            # Negative tax_owed == credit at ST rate (matches §1211(b) treatment
-            # of net capital loss as an offset against ordinary income).
+            # Negative tax_owed == reduction in tax otherwise owed on ordinary income.
+            # Deduction is capped at TaxConfig.deductible_loss_cap (default $3,000)
+            # per IRC §1211(b); we model the resulting savings as `cap * short_term_rate`.
             tax_owed = -deductible_loss * config.short_term_rate
 
         carry_in = carry_out
@@ -164,7 +171,6 @@ def compute_tax_summary(
 def compute_after_tax_curve(
     equity_curve: Sequence[tuple[date, float]],
     summaries: Sequence[AnnualTaxSummary],
-    end_date: date,
 ) -> list[tuple[date, float]]:
     """Apply each year's tax_owed to *equity_curve* at its payment_date.
 

--- a/src/midas/tax.py
+++ b/src/midas/tax.py
@@ -1,0 +1,185 @@
+"""Capital-gains tax accounting (reporting layer, not strategy).
+
+Pure functions: ``compute_tax_summary`` runs IRS Schedule D-style annual
+netting + $3K deductible + carryforward across realized SELLs;
+``compute_after_tax_curve`` applies each year's tax owed to a gross equity
+curve at the configured payment date. Used by both ``BacktestResult``
+construction and the ``midas tax-report`` subcommand so backtest after-tax
+numbers and tax-report numbers are bit-identical when fed identical inputs.
+
+Simplifications: carryforward is a single signed scalar that loses ST/LT
+character on rollover (IRS preserves character). Wash-sale detection,
+specific-lot accounting, state taxes, and bracketed rates are out of scope
+— the engine is FIFO and the rates are flat.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from midas.metrics import _pair_sells_with_basis
+from midas.models import Direction, HoldingPeriod, TaxConfig, TradeRecord
+
+
+@dataclass(frozen=True)
+class AnnualTaxSummary:
+    """Per-year realized-P&L tax breakdown.
+
+    ``st_realized`` / ``lt_realized`` are pre-netting raw bucket sums
+    (gross gain - gross loss within bucket). ``net_after_cross`` is the
+    post-cross-bucket-netting figure. ``deductible_loss`` is the portion
+    of an overall loss deducted against ordinary income this year (capped
+    at ``TaxConfig.deductible_loss_cap``). ``carry_forward`` is the unused
+    loss rolling into next year. ``tax_owed`` is signed: positive means
+    cash deducted from the equity curve, negative means a refund/credit.
+    """
+
+    year: int
+    st_realized: float
+    lt_realized: float
+    net_after_cross: float
+    deductible_loss: float
+    carry_forward: float
+    tax_owed: float
+    payment_date: date
+
+
+def _payment_date_for_year(year: int, lag_days: int, end_date: date) -> date:
+    """Year-end + lag, clamped to end_date if it would fall past it."""
+    natural = date(year, 12, 31) + timedelta(days=lag_days)
+    return min(natural, end_date)
+
+
+def compute_tax_summary(
+    trades: Sequence[TradeRecord],
+    basis_per_sell: Sequence[float],
+    config: TaxConfig,
+    end_date: date,
+) -> list[AnnualTaxSummary]:
+    """Group SELLs by calendar year; net per-bucket then cross-bucket; carry losses.
+
+    Args:
+        trades: All TradeRecords from the backtest or live trade log. BUYs are
+            ignored. SELL records must carry a non-None ``holding_period``.
+        basis_per_sell: Parallel list of share-weighted cost basis per SELL,
+            in the same order as SELL records appear in ``trades``.
+        config: Tax-rate policy.
+        end_date: Last bar of the backtest (or report-period end). Years whose
+            natural payment date falls past this are clamped to it.
+
+    Returns:
+        One AnnualTaxSummary per calendar year that contained at least one
+        SELL or that received a carryforward from the prior year. Sorted by
+        year ascending.
+    """
+    paired = _pair_sells_with_basis(list(trades), list(basis_per_sell))
+    by_year_st: dict[int, float] = defaultdict(float)
+    by_year_lt: dict[int, float] = defaultdict(float)
+
+    for trade, basis in paired:
+        if trade.direction != Direction.SELL or trade.holding_period is None:
+            continue
+        pnl = (trade.price - basis) * trade.shares
+        if trade.holding_period == HoldingPeriod.LONG_TERM:
+            by_year_lt[trade.date.year] += pnl
+        else:
+            by_year_st[trade.date.year] += pnl
+
+    years_with_activity = sorted(set(by_year_st) | set(by_year_lt))
+    if not years_with_activity:
+        return []
+
+    summaries: list[AnnualTaxSummary] = []
+    # carry_in is non-negative: it represents accumulated unused loss rolling
+    # in from prior years. Applied as an additional ST-character loss to the
+    # current year's net (loses ST/LT character on rollover; IRS preserves it,
+    # we don't — see module docstring).
+    carry_in = 0.0
+    for year in years_with_activity:
+        st_raw = by_year_st.get(year, 0.0)
+        lt_raw = by_year_lt.get(year, 0.0)
+
+        # Per-bucket netting is the raw sum (already done by accumulation).
+        # Cross-bucket: if signs differ, net them.
+        st_after_cross = st_raw
+        lt_after_cross = lt_raw
+        if st_raw > 0 and lt_raw < 0:
+            offset = min(st_raw, -lt_raw)
+            st_after_cross -= offset
+            lt_after_cross += offset
+        elif lt_raw > 0 and st_raw < 0:
+            offset = min(lt_raw, -st_raw)
+            lt_after_cross -= offset
+            st_after_cross += offset
+
+        # Apply prior-year carry as an additional loss. It nets first against
+        # any remaining ST gain, then any remaining LT gain, then becomes pure
+        # loss that pushes net_after_cross negative.
+        remaining_carry = carry_in
+        if remaining_carry > 0 and st_after_cross > 0:
+            shave = min(remaining_carry, st_after_cross)
+            st_after_cross -= shave
+            remaining_carry -= shave
+        if remaining_carry > 0 and lt_after_cross > 0:
+            shave = min(remaining_carry, lt_after_cross)
+            lt_after_cross -= shave
+            remaining_carry -= shave
+        # Any still-remaining carry is pure loss applied to ST bucket.
+        st_after_cross -= remaining_carry
+
+        net_after_cross = st_after_cross + lt_after_cross
+        deductible_loss = 0.0
+        carry_out = 0.0
+
+        if net_after_cross >= 0:
+            tax_owed = st_after_cross * config.short_term_rate + lt_after_cross * config.long_term_rate
+        else:
+            absolute = -net_after_cross
+            deductible_loss = min(absolute, config.deductible_loss_cap)
+            carry_out = absolute - deductible_loss
+            # Negative tax_owed == credit at ST rate (matches §1211(b) treatment
+            # of net capital loss as an offset against ordinary income).
+            tax_owed = -deductible_loss * config.short_term_rate
+
+        carry_in = carry_out
+
+        summaries.append(
+            AnnualTaxSummary(
+                year=year,
+                st_realized=st_raw,
+                lt_realized=lt_raw,
+                net_after_cross=net_after_cross,
+                deductible_loss=deductible_loss,
+                carry_forward=carry_out,
+                tax_owed=tax_owed,
+                payment_date=_payment_date_for_year(year, config.payment_lag_days, end_date),
+            )
+        )
+    return summaries
+
+
+def compute_after_tax_curve(
+    equity_curve: Sequence[tuple[date, float]],
+    summaries: Sequence[AnnualTaxSummary],
+    end_date: date,
+) -> list[tuple[date, float]]:
+    """Apply each year's tax_owed to *equity_curve* at its payment_date.
+
+    Refunds (negative tax_owed) increase the curve. The original curve is not
+    mutated. If summaries is empty, returns the gross curve as a copy.
+    """
+    if not summaries:
+        return list(equity_curve)
+    pending = sorted(((s.payment_date, s.tax_owed) for s in summaries), key=lambda item: item[0])
+    out: list[tuple[date, float]] = []
+    cumulative_deduction = 0.0
+    payment_idx = 0
+    for day, value in equity_curve:
+        while payment_idx < len(pending) and pending[payment_idx][0] <= day:
+            cumulative_deduction += pending[payment_idx][1]
+            payment_idx += 1
+        out.append((day, value - cumulative_deduction))
+    return out

--- a/src/midas/trade_log.py
+++ b/src/midas/trade_log.py
@@ -17,8 +17,11 @@ import datetime
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
+from typing import Literal
 
 from midas.models import Direction, HoldingPeriod, TradeRecord
+
+type PurchaseDate = date | Literal["various"] | None
 
 TRADE_LOG_COLUMNS: tuple[str, ...] = (
     "date",
@@ -50,13 +53,13 @@ class LoggedTrade:
     price: float
     strategy_name: str
     holding_period: HoldingPeriod | None
-    purchase_date: datetime.date | str | None
+    purchase_date: PurchaseDate
     cost_basis: float | None
     realized_pnl: float | None
     return_pct: float | None
 
 
-def _format_purchase_date(value: date | str | None) -> str:
+def _format_purchase_date(value: PurchaseDate) -> str:
     if value is None:
         return ""
     if isinstance(value, str):
@@ -71,8 +74,9 @@ def _format_holding_period(value: HoldingPeriod | None) -> str:
 def append_trade(
     path: Path,
     record: TradeRecord,
+    *,
     cost_basis: float | None,
-    purchase_date: date | str | None,
+    purchase_date: PurchaseDate,
 ) -> None:
     """Append one row to *path*, creating the file with header on first write.
 
@@ -82,8 +86,8 @@ def append_trade(
     are derived from it.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    needs_header = not path.exists() or path.stat().st_size == 0
     with open(path, "a", newline="", encoding="utf-8") as handle:
+        needs_header = handle.tell() == 0
         writer = csv.writer(handle)
         if needs_header:
             writer.writerow(TRADE_LOG_COLUMNS)
@@ -125,11 +129,11 @@ def _parse_holding_period(raw: str) -> HoldingPeriod | None:
         raise TradeLogError(msg) from exc
 
 
-def _parse_purchase_date(raw: str) -> date | str | None:
+def _parse_purchase_date(raw: str) -> PurchaseDate:
     if not raw:
         return None
     if raw == "various":
-        return raw
+        return "various"
     try:
         return date.fromisoformat(raw)
     except ValueError as exc:
@@ -158,8 +162,9 @@ def read_trades(path: Path) -> list[LoggedTrade]:
         reader = csv.reader(handle)
         try:
             header = next(reader)
-        except StopIteration:
-            return []
+        except StopIteration as exc:
+            msg = f"trade-log file {path} exists but is empty"
+            raise TradeLogError(msg) from exc
         if tuple(header) != TRADE_LOG_COLUMNS:
             msg = f"trade-log header drift in {path}: expected {TRADE_LOG_COLUMNS}, got {tuple(header)}"
             raise TradeLogError(msg)

--- a/src/midas/trade_log.py
+++ b/src/midas/trade_log.py
@@ -17,11 +17,9 @@ import datetime
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Literal
 
+from midas.live_state import PurchaseDate as PurchaseDate  # re-export
 from midas.models import Direction, HoldingPeriod, TradeRecord
-
-type PurchaseDate = date | Literal["various"] | None
 
 TRADE_LOG_COLUMNS: tuple[str, ...] = (
     "date",

--- a/src/midas/trade_log.py
+++ b/src/midas/trade_log.py
@@ -1,0 +1,193 @@
+"""Append-only trade-log writer and strict reader.
+
+Used by both the live engine (writes to ``<state_path>.trades.csv``) and the
+backtest result writer (writes to ``<output_dir>/trades.csv``). Single shape
+across both modes so ``midas tax-report`` has one reader.
+
+Header drift on read raises :class:`TradeLogError` rather than silently
+returning empty / wrong rows; partial rows raise with the offending line
+number. The log is intentionally permissive on content (negative shares,
+future dates) but strict on shape — hand-edits are an explicit escape valve.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from midas.models import Direction, HoldingPeriod, TradeRecord
+
+TRADE_LOG_COLUMNS: tuple[str, ...] = (
+    "date",
+    "ticker",
+    "direction",
+    "shares",
+    "price",
+    "strategy",
+    "holding_period",
+    "purchase_date",
+    "cost_basis",
+    "realized_pnl",
+    "return_pct",
+)
+
+
+class TradeLogError(ValueError):
+    """Raised on header drift, partial rows, or unparseable values."""
+
+
+@dataclass(frozen=True)
+class LoggedTrade:
+    """In-memory representation of one trade-log row."""
+
+    date: datetime.date
+    ticker: str
+    direction: Direction
+    shares: float
+    price: float
+    strategy_name: str
+    holding_period: HoldingPeriod | None
+    purchase_date: datetime.date | str | None
+    cost_basis: float | None
+    realized_pnl: float | None
+    return_pct: float | None
+
+
+def _format_purchase_date(value: date | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return value.isoformat()
+
+
+def _format_holding_period(value: HoldingPeriod | None) -> str:
+    return value.value if value is not None else ""
+
+
+def append_trade(
+    path: Path,
+    record: TradeRecord,
+    cost_basis: float | None,
+    purchase_date: date | str | None,
+) -> None:
+    """Append one row to *path*, creating the file with header on first write.
+
+    For BUY rows pass ``cost_basis=None``; the ``cost_basis``, ``realized_pnl``,
+    and ``return_pct`` columns are written empty. For SELL rows the bucket's
+    share-weighted cost basis is required; ``realized_pnl`` and ``return_pct``
+    are derived from it.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    needs_header = not path.exists() or path.stat().st_size == 0
+    with open(path, "a", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        if needs_header:
+            writer.writerow(TRADE_LOG_COLUMNS)
+        if record.direction == Direction.BUY or cost_basis is None:
+            cost_basis_cell: str | float = ""
+            pnl_cell: str | float = ""
+            ret_cell: str | float = ""
+        else:
+            pnl = round((record.price - cost_basis) * record.shares, 4)
+            ret = round((record.price - cost_basis) / cost_basis, 6) if cost_basis != 0 else 0.0
+            cost_basis_cell = round(cost_basis, 4)
+            pnl_cell = pnl
+            ret_cell = ret
+        writer.writerow(
+            [
+                record.date.isoformat(),
+                record.ticker,
+                record.direction.value,
+                record.shares,
+                record.price,
+                record.strategy_name,
+                _format_holding_period(record.holding_period),
+                _format_purchase_date(purchase_date),
+                cost_basis_cell,
+                pnl_cell,
+                ret_cell,
+            ]
+        )
+        handle.flush()
+
+
+def _parse_holding_period(raw: str) -> HoldingPeriod | None:
+    if not raw:
+        return None
+    try:
+        return HoldingPeriod(raw)
+    except ValueError as exc:
+        msg = f"unknown holding_period value {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def _parse_purchase_date(raw: str) -> date | str | None:
+    if not raw:
+        return None
+    if raw == "various":
+        return raw
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        msg = f"unparseable purchase_date {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def _parse_optional_float(raw: str) -> float | None:
+    if raw == "":
+        return None
+    try:
+        return float(raw)
+    except ValueError as exc:
+        msg = f"unparseable float {raw!r}"
+        raise TradeLogError(msg) from exc
+
+
+def read_trades(path: Path) -> list[LoggedTrade]:
+    """Read all rows from *path* into ``LoggedTrade`` instances.
+
+    Raises :class:`TradeLogError` on header drift or unparseable rows.
+    """
+    if not path.exists():
+        return []
+    with open(path, encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return []
+        if tuple(header) != TRADE_LOG_COLUMNS:
+            msg = f"trade-log header drift in {path}: expected {TRADE_LOG_COLUMNS}, got {tuple(header)}"
+            raise TradeLogError(msg)
+
+        out: list[LoggedTrade] = []
+        for line_num, row in enumerate(reader, start=2):
+            if len(row) != len(TRADE_LOG_COLUMNS):
+                msg = f"trade-log row at line {line_num} has {len(row)} fields, expected {len(TRADE_LOG_COLUMNS)}"
+                raise TradeLogError(msg)
+            try:
+                trade_date = date.fromisoformat(row[0])
+                direction = Direction(row[2])
+            except ValueError as exc:
+                msg = f"trade-log row at line {line_num}: {exc}"
+                raise TradeLogError(msg) from exc
+            out.append(
+                LoggedTrade(
+                    date=trade_date,
+                    ticker=row[1],
+                    direction=direction,
+                    shares=float(row[3]),
+                    price=float(row[4]),
+                    strategy_name=row[5],
+                    holding_period=_parse_holding_period(row[6]),
+                    purchase_date=_parse_purchase_date(row[7]),
+                    cost_basis=_parse_optional_float(row[8]),
+                    realized_pnl=_parse_optional_float(row[9]),
+                    return_pct=_parse_optional_float(row[10]),
+                )
+            )
+        return out

--- a/src/midas/trade_log.py
+++ b/src/midas/trade_log.py
@@ -57,7 +57,14 @@ class LoggedTrade:
     return_pct: float | None
 
 
-def _format_purchase_date(value: PurchaseDate) -> str:
+def format_purchase_date(value: date | str | None) -> str:
+    """Render a purchase-date value for the trade-log ``purchase_date`` cell.
+
+    None becomes the empty string, sentinel strings (``"various"``) pass
+    through, and ``date`` values are formatted ISO-8601. Accepts the
+    broader ``date | str | None`` shape used by ``TradeRecord`` as well as
+    the narrower ``PurchaseDate`` alias used by the live-engine writer.
+    """
     if value is None:
         return ""
     if isinstance(value, str):
@@ -65,7 +72,11 @@ def _format_purchase_date(value: PurchaseDate) -> str:
     return value.isoformat()
 
 
-def _format_holding_period(value: HoldingPeriod | None) -> str:
+def format_holding_period(value: HoldingPeriod | None) -> str:
+    """Render a ``HoldingPeriod`` for the trade-log ``holding_period`` cell.
+
+    None becomes the empty string; otherwise the enum value is returned.
+    """
     return value.value if value is not None else ""
 
 
@@ -107,8 +118,8 @@ def append_trade(
                 record.shares,
                 record.price,
                 record.strategy_name,
-                _format_holding_period(record.holding_period),
-                _format_purchase_date(purchase_date),
+                format_holding_period(record.holding_period),
+                format_purchase_date(purchase_date),
                 cost_basis_cell,
                 pnl_cell,
                 ret_cell,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date, timedelta
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -10,6 +12,32 @@ import pytest
 
 from midas.data.price_history import PriceHistory
 from midas.models import CashInfusion, Holding, PortfolioConfig
+
+
+@pytest.fixture
+def make_provider() -> Callable[[dict[str, list[float]], list[date]], MagicMock]:
+    """Factory fixture producing a fake DataProvider with controlled OHLCV data."""
+
+    def _make(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
+        provider = MagicMock()
+
+        def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
+            closes = prices[ticker]
+            return pd.DataFrame(
+                {
+                    "open": closes,
+                    "high": closes,
+                    "low": closes,
+                    "close": closes,
+                    "volume": [1000.0] * len(closes),
+                },
+                index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
+            )
+
+        provider.get_history.side_effect = get_history
+        return provider
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1809,9 +1809,38 @@ def test_backtest_result_after_tax_fields_populated_with_tax_config() -> None:
     assert result.after_tax_total_return is not None
     assert result.after_tax_cagr is not None
     assert result.after_tax_twr is not None
-    assert result.tax_cost_ratio is not None
     assert result.tax_summary, "tax_summary should be non-empty when sells happened"
     assert len(result.after_tax_equity_curve) == len(result.equity_curve)
+
+    # tax_cost_ratio is only meaningful when gross CAGR is positive; otherwise
+    # the field is None (a losing strategy still has tax drag, but expressing
+    # it as a ratio of negative CAGR is not interpretable).
+    if result.cagr > 0:
+        assert result.tax_cost_ratio is not None
+    else:
+        assert result.tax_cost_ratio is None
+
+    # The StopLoss fixture realizes a loss, so tax_owed is negative (a refund
+    # via the deductible-loss credit) and the after-tax curve sits above the
+    # gross curve. In a winning scenario, tax_owed > 0 and the after-tax curve
+    # would sit below. Either way: the sign of (after_tax - gross) must match
+    # the sign of (-tax_owed), and the after-tax curve must reflect that drag
+    # (or refund).
+    total_tax = sum(s.tax_owed for s in result.tax_summary)
+    if total_tax > 0:
+        assert result.after_tax_final_value < result.final_value
+        assert result.after_tax_cagr is not None and result.after_tax_cagr < result.cagr
+    elif total_tax < 0:
+        assert result.after_tax_final_value > result.final_value
+    else:
+        assert result.after_tax_final_value == result.final_value
+
+    # Structural shape of multi-year summaries: years and payment_dates monotonic.
+    if len(result.tax_summary) > 1:
+        years = [s.year for s in result.tax_summary]
+        payment_dates = [s.payment_date for s in result.tax_summary]
+        assert years == sorted(years)
+        assert payment_dates == sorted(payment_dates)
 
 
 def test_backtest_result_after_tax_fields_none_without_tax_config() -> None:

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1551,3 +1551,65 @@ def test_sell_mixed_basis_within_single_period() -> None:
     assert trade.holding_period == HoldingPeriod.SHORT_TERM
     assert trade.shares == 10.0
     assert basis == 92.0
+
+
+# --- TradeRecord.purchase_date population in _execute ---
+
+
+def _buy_order(ticker: str, shares: float, price: float, source: str = "Momentum") -> Order:
+    return Order(
+        ticker=ticker,
+        direction=Direction.BUY,
+        shares=shares,
+        price=price,
+        estimated_value=shares * price,
+        context=OrderContext(
+            contributions={source: 1.0},
+            blended_score=1.0,
+            target_weight=0.5,
+            current_weight=0.0,
+            reason="entry",
+            source=source,
+        ),
+    )
+
+
+def test_execute_buy_records_purchase_date_as_day() -> None:
+    """BUY records carry the fill date as their purchase_date."""
+    engine = _build_engine()
+    state = _SimState(cash=10000.0, starting_value=10000.0)
+
+    order = _buy_order("AAPL", 10.0, 20.0)
+    records = engine._execute(order, date(2026, 5, 8), state)
+    trade, _basis = records[0]
+    assert trade.purchase_date == date(2026, 5, 8)
+
+
+def test_execute_sell_single_lot_records_lot_purchase_date() -> None:
+    """SELL bucket consuming one lot records that lot's purchase date."""
+    engine = _build_engine()
+    state = _SimState(cash=0.0, starting_value=0.0)
+    state.lots["AAPL"] = [PositionLot(shares=10.0, purchase_date=date(2026, 1, 1), cost_basis=10.0)]
+    state.positions["AAPL"] = 10.0
+
+    order = _sell_order("AAPL", 10.0, 15.0, source="StopLoss")
+    records = engine._execute(order, date(2026, 5, 8), state)
+    trade, _basis = records[0]
+    assert trade.purchase_date == date(2026, 1, 1)
+
+
+def test_execute_sell_mixed_lot_records_various() -> None:
+    """SELL bucket spanning multiple lots with different dates records 'various'."""
+    engine = _build_engine()
+    state = _SimState(cash=0.0, starting_value=0.0)
+    state.lots["AAPL"] = [
+        PositionLot(shares=5.0, purchase_date=date(2026, 1, 1), cost_basis=10.0),
+        PositionLot(shares=5.0, purchase_date=date(2026, 2, 1), cost_basis=11.0),
+    ]
+    state.positions["AAPL"] = 10.0
+
+    order = _sell_order("AAPL", 10.0, 15.0, source="StopLoss")
+    records = engine._execute(order, date(2026, 5, 8), state)
+    # Only one ST bucket since both lots are <365 days from sell day → both ST → mixed.
+    trade, _basis = records[0]
+    assert trade.purchase_date == "various"

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1613,3 +1613,17 @@ def test_execute_sell_mixed_lot_records_various() -> None:
     # Only one ST bucket since both lots are <365 days from sell day → both ST → mixed.
     trade, _basis = records[0]
     assert trade.purchase_date == "various"
+
+
+def test_execute_sell_single_unseeded_lot_records_none() -> None:
+    """SELL bucket consuming one lot with purchase_date=None records None,
+    not 'various'. Mirrors live-mode unseeded lots from a fresh state file."""
+    engine = _build_engine()
+    state = _SimState(cash=0.0, starting_value=0.0)
+    state.lots["AAPL"] = [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]
+    state.positions["AAPL"] = 10.0
+
+    order = _sell_order("AAPL", 10.0, 15.0, source="StopLoss")
+    records = engine._execute(order, date(2026, 5, 8), state)
+    trade, _basis = records[0]
+    assert trade.purchase_date is None

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1744,3 +1744,189 @@ def test_backtest_trades_csv_round_trips_through_trade_log_reader(tmp_path: Path
     assert rows[1].holding_period == HoldingPeriod.SHORT_TERM
     assert rows[1].purchase_date == date(2026, 1, 5)
     assert rows[1].cost_basis == 20.0
+
+
+def _stop_loss_frame() -> tuple[PortfolioConfig, dict[str, pd.DataFrame]]:
+    """Frame and portfolio that triggers a StopLoss exit (one realized SELL)."""
+    n = 30
+    dates = [d.date() for d in pd.bdate_range(start=date(2024, 1, 2), periods=n)]
+    closes = np.full(n, 100.0)
+    opens = np.full(n, 100.0)
+    highs = np.full(n, 100.0)
+    lows = np.full(n, 100.0)
+    volumes = np.full(n, 1_000_000.0)
+    drop_day = 20
+    opens[drop_day] = 92.0
+    highs[drop_day] = 93.0
+    lows[drop_day] = 88.0
+    closes[drop_day] = 90.0
+    opens[drop_day + 1] = 89.0
+    highs[drop_day + 1] = 91.0
+    lows[drop_day + 1] = 88.0
+    closes[drop_day + 1] = 91.0
+    frame = pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": volumes},
+        index=dates,
+    )
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="GAPCO", shares=5, cost_basis=100.0)],
+        available_cash=10_000.0,
+    )
+    return portfolio, {"GAPCO": frame}
+
+
+def test_backtest_result_after_tax_fields_populated_with_tax_config() -> None:
+    """End-to-end: a backtest with TaxConfig set populates after_tax_* fields and tax_summary."""
+    from midas.models import TaxConfig
+
+    portfolio, price_data = _stop_loss_frame()
+    constraints = AllocationConstraints(min_buy_delta=0.01, max_position_pct=0.95)
+    allocator = Allocator(
+        [(GapDownRecovery(gap_threshold=0.03), 1.0)],
+        constraints,
+        n_tickers=1,
+    )
+    tax = TaxConfig(short_term_rate=0.30, long_term_rate=0.15)
+    engine = BacktestEngine(
+        allocator=allocator,
+        order_sizer=OrderSizer(default_slippage=0.0),
+        exit_rules=[StopLoss(loss_threshold=0.05)],
+        constraints=constraints,
+        enable_split=False,
+        execution_mode="next_open",
+        tax_config=tax,
+    )
+    frame = price_data["GAPCO"]
+    start, end = frame.index[0], frame.index[-1]
+    result = engine.run(portfolio, price_data, start, end)
+
+    # The fixture produces at least one realized SELL, so the tax pipeline
+    # has data to operate on.
+    sells = [t for t in result.trades if t.direction == Direction.SELL]
+    assert sells, "fixture must produce at least one SELL for the after-tax pipeline to engage"
+
+    assert result.after_tax_final_value is not None
+    assert result.after_tax_total_return is not None
+    assert result.after_tax_cagr is not None
+    assert result.after_tax_twr is not None
+    assert result.tax_cost_ratio is not None
+    assert result.tax_summary, "tax_summary should be non-empty when sells happened"
+    assert len(result.after_tax_equity_curve) == len(result.equity_curve)
+
+
+def test_backtest_result_after_tax_fields_none_without_tax_config() -> None:
+    """Backwards-compatible: without TaxConfig, all after-tax fields are None/empty."""
+    portfolio, price_data = _stop_loss_frame()
+    constraints = AllocationConstraints(min_buy_delta=0.01, max_position_pct=0.95)
+    allocator = Allocator(
+        [(GapDownRecovery(gap_threshold=0.03), 1.0)],
+        constraints,
+        n_tickers=1,
+    )
+    engine = BacktestEngine(
+        allocator=allocator,
+        order_sizer=OrderSizer(default_slippage=0.0),
+        exit_rules=[StopLoss(loss_threshold=0.05)],
+        constraints=constraints,
+        enable_split=False,
+        execution_mode="next_open",
+    )
+    frame = price_data["GAPCO"]
+    start, end = frame.index[0], frame.index[-1]
+    result = engine.run(portfolio, price_data, start, end)
+
+    assert result.after_tax_final_value is None
+    assert result.after_tax_total_return is None
+    assert result.after_tax_cagr is None
+    assert result.after_tax_twr is None
+    assert result.after_tax_equity_curve == []
+    assert result.tax_summary == []
+    assert result.tax_cost_ratio is None
+
+
+def test_equity_curve_csv_includes_nav_after_tax_when_set(tmp_path: Path) -> None:
+    """equity_curve.csv gains a parallel ``nav_after_tax`` column when after-tax curve is populated."""
+    from midas.results import _write_equity_curve_csv
+
+    result = _make_minimal_result(trades=[], basis_per_sell=[])
+    result.equity_curve = [(date(2026, 1, 5), 1000.0), (date(2026, 1, 6), 1010.0)]
+    result.after_tax_equity_curve = [(date(2026, 1, 5), 1000.0), (date(2026, 1, 6), 990.0)]
+
+    out = tmp_path / "equity_curve.csv"
+    _write_equity_curve_csv(result, out)
+    rows = list(csv_mod.DictReader(out.open()))
+    assert "nav_after_tax" in rows[0]
+    assert rows[0]["nav_after_tax"] == "1000.0"
+    assert rows[1]["nav_after_tax"] == "990.0"
+
+
+def test_equity_curve_csv_omits_nav_after_tax_when_not_set(tmp_path: Path) -> None:
+    """equity_curve.csv has no nav_after_tax column when after-tax curve is empty."""
+    from midas.results import _write_equity_curve_csv
+
+    result = _make_minimal_result(trades=[], basis_per_sell=[])
+    result.equity_curve = [(date(2026, 1, 5), 1000.0), (date(2026, 1, 6), 1010.0)]
+
+    out = tmp_path / "equity_curve.csv"
+    _write_equity_curve_csv(result, out)
+    rows = list(csv_mod.DictReader(out.open()))
+    assert "nav_after_tax" not in rows[0]
+
+
+def test_summary_json_includes_after_tax_block_when_set(tmp_path: Path) -> None:
+    """summary.json includes after-tax fields and tax_summary array when populated."""
+    from midas.results import _write_summary_json
+    from midas.tax import AnnualTaxSummary
+
+    result = _make_minimal_result(trades=[], basis_per_sell=[])
+    result.starting_value = 1000.0
+    result.final_value = 1100.0
+    result.after_tax_final_value = 1080.0
+    result.after_tax_total_return = 0.08
+    result.after_tax_cagr = 0.075
+    result.after_tax_twr = 0.078
+    result.tax_cost_ratio = 0.05
+    result.tax_summary = [
+        AnnualTaxSummary(
+            year=2026,
+            st_realized=100.0,
+            lt_realized=0.0,
+            net_after_cross=100.0,
+            deductible_loss=0.0,
+            carry_forward=0.0,
+            tax_owed=20.0,
+            payment_date=date(2027, 4, 15),
+        )
+    ]
+
+    out = tmp_path / "summary.json"
+    _write_summary_json(result, out)
+    summary = json.loads(out.read_text())
+    assert summary["after_tax_final_value"] == 1080.0
+    assert summary["after_tax_total_return"] == 0.08
+    assert summary["after_tax_cagr"] == 0.075
+    assert summary["after_tax_twr"] == 0.078
+    assert summary["tax_cost_ratio"] == 0.05
+    assert len(summary["tax_summary"]) == 1
+    assert summary["tax_summary"][0]["year"] == 2026
+    assert summary["tax_summary"][0]["tax_owed"] == 20.0
+    assert summary["tax_summary"][0]["payment_date"] == "2027-04-15"
+
+
+def test_summary_json_omits_after_tax_block_when_not_set(tmp_path: Path) -> None:
+    """summary.json has no after-tax fields when fields are None and tax_summary empty."""
+    from midas.results import _write_summary_json
+
+    result = _make_minimal_result(trades=[], basis_per_sell=[])
+    result.starting_value = 1000.0
+    result.final_value = 1100.0
+
+    out = tmp_path / "summary.json"
+    _write_summary_json(result, out)
+    summary = json.loads(out.read_text())
+    assert "after_tax_final_value" not in summary
+    assert "after_tax_total_return" not in summary
+    assert "after_tax_cagr" not in summary
+    assert "after_tax_twr" not in summary
+    assert "tax_cost_ratio" not in summary
+    assert "tax_summary" not in summary

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1702,3 +1702,45 @@ def test_trades_csv_includes_purchase_date_column(tmp_path: Path) -> None:
     assert "purchase_date" in rows[0]
     assert rows[0]["purchase_date"] == "2026-01-05"
     assert rows[1]["purchase_date"] == "2026-01-05"
+
+
+def test_backtest_trades_csv_round_trips_through_trade_log_reader(tmp_path: Path) -> None:
+    """Backtest's trades.csv shape must match TRADE_LOG_COLUMNS exactly so
+    the live and backtest paths share one reader. read_trades raises
+    TradeLogError on any header drift, so a successful round-trip pins
+    the column shape."""
+    from midas.results import _write_trades_csv
+    from midas.trade_log import read_trades
+
+    trades = [
+        TradeRecord(
+            date=date(2026, 1, 5),
+            ticker="AAPL",
+            direction=Direction.BUY,
+            shares=10.0,
+            price=20.0,
+            strategy_name="Momentum",
+            purchase_date=date(2026, 1, 5),
+        ),
+        TradeRecord(
+            date=date(2026, 4, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=10.0,
+            price=25.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.SHORT_TERM,
+            purchase_date=date(2026, 1, 5),
+        ),
+    ]
+    result = _make_minimal_result(trades=trades, basis_per_sell=[20.0])
+    out = tmp_path / "trades.csv"
+    _write_trades_csv(result, out)
+    rows = read_trades(out)  # raises on shape drift
+    assert len(rows) == 2
+    assert rows[0].direction == Direction.BUY
+    assert rows[0].purchase_date == date(2026, 1, 5)
+    assert rows[1].direction == Direction.SELL
+    assert rows[1].holding_period == HoldingPeriod.SHORT_TERM
+    assert rows[1].purchase_date == date(2026, 1, 5)
+    assert rows[1].cost_basis == 20.0

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -468,6 +468,7 @@ def test_backtest_results_output(tmp_path: Path) -> None:
         "price",
         "strategy",
         "holding_period",
+        "purchase_date",
         "cost_basis",
         "realized_pnl",
         "return_pct",
@@ -1627,3 +1628,77 @@ def test_execute_sell_single_unseeded_lot_records_none() -> None:
     records = engine._execute(order, date(2026, 5, 8), state)
     trade, _basis = records[0]
     assert trade.purchase_date is None
+
+
+def _make_minimal_result(
+    trades: list[TradeRecord],
+    basis_per_sell: list[float],
+) -> BacktestResult:
+    """Build a minimal ``BacktestResult`` for output-writer tests."""
+    return BacktestResult(
+        trades=trades,
+        final_value=0,
+        starting_value=0,
+        buy_and_hold_value=0,
+        train_trades=[],
+        test_trades=[],
+        train_return=0,
+        test_return=0,
+        train_bh_return=0,
+        test_bh_return=0,
+        split_date=None,
+        twr=0,
+        equity_curve=[],
+        total_days=0,
+        train_days=0,
+        test_days=0,
+        cagr=0,
+        max_drawdown=0,
+        sharpe_ratio=0,
+        sortino_ratio=0,
+        win_rate=0,
+        profit_factor=0,
+        avg_win=0,
+        avg_loss=0,
+        efficiency_ratio=0,
+        strategy_stats=[],
+        unrealized_pnl=0,
+        unrealized_pnl_by_ticker={},
+        basis_per_sell=basis_per_sell,
+    )
+
+
+def test_trades_csv_includes_purchase_date_column(tmp_path: Path) -> None:
+    """Backtest output's trades.csv has a purchase_date column populated for BUYs and SELLs."""
+    import csv
+
+    from midas.results import _write_trades_csv
+
+    trades = [
+        TradeRecord(
+            date=date(2026, 1, 5),
+            ticker="AAPL",
+            direction=Direction.BUY,
+            shares=10.0,
+            price=20.0,
+            strategy_name="Momentum",
+            purchase_date=date(2026, 1, 5),
+        ),
+        TradeRecord(
+            date=date(2026, 4, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=10.0,
+            price=25.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.SHORT_TERM,
+            purchase_date=date(2026, 1, 5),
+        ),
+    ]
+    result = _make_minimal_result(trades=trades, basis_per_sell=[20.0])
+    out = tmp_path / "trades.csv"
+    _write_trades_csv(result, out)
+    rows = list(csv.DictReader(out.open()))
+    assert "purchase_date" in rows[0]
+    assert rows[0]["purchase_date"] == "2026-01-05"
+    assert rows[1]["purchase_date"] == "2026-01-05"

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -170,3 +170,45 @@ def test_render_charts_rolling_sharpe(capsys: pytest.CaptureFixture[str]) -> Non
     render_charts(result)
     out = capsys.readouterr().out
     assert "Rolling Sharpe" in out
+
+
+def _make_result_with_curves(
+    *,
+    equity: list[tuple[date, float]],
+    after_tax: list[tuple[date, float]],
+) -> BacktestResult:
+    """Minimal BacktestResult with the two equity curves populated.
+
+    Everything else gets zero/empty defaults — just enough to drive
+    ``_render_equity`` without exercising any other code path.
+    """
+    result = _empty_result()
+    result.equity_curve = list(equity)
+    result.after_tax_equity_curve = list(after_tax)
+    return result
+
+
+def test_render_equity_includes_after_tax_overlay_when_populated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When BacktestResult.after_tax_equity_curve is non-empty, the equity chart
+    plots both gross and after-tax series."""
+    import plotext as plt
+
+    from midas.charts import _render_equity
+
+    plot_calls: list[dict] = []
+    real_plot = plt.plot
+
+    def spy(*args: object, **kwargs: object) -> object:
+        plot_calls.append(kwargs)
+        return real_plot(*args, **kwargs)
+
+    monkeypatch.setattr(plt, "plot", spy)
+
+    result = _make_result_with_curves(
+        equity=[(date(2026, 1, 1), 10000.0), (date(2026, 12, 31), 12000.0)],
+        after_tax=[(date(2026, 1, 1), 10000.0), (date(2026, 12, 31), 11500.0)],
+    )
+    _render_equity(result)
+
+    labels = [c.get("label", "") for c in plot_calls]
+    assert any("After-Tax" in lbl for lbl in labels), f"expected After-Tax label, got {labels}"

--- a/tests/test_cli_tax_report.py
+++ b/tests/test_cli_tax_report.py
@@ -1,0 +1,106 @@
+"""Smoke tests for the `midas tax-report` subcommand."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from midas.cli import cli
+from midas.models import Direction, HoldingPeriod, TradeRecord
+from midas.trade_log import append_trade
+
+
+def _seed_log(path: Path) -> None:
+    append_trade(
+        path,
+        TradeRecord(
+            date=date(2026, 6, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=10.0,
+            price=30.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.SHORT_TERM,
+            purchase_date=date(2026, 1, 1),
+        ),
+        cost_basis=20.0,
+        purchase_date=date(2026, 1, 1),
+    )
+    append_trade(
+        path,
+        TradeRecord(
+            date=date(2026, 7, 1),
+            ticker="AAPL",
+            direction=Direction.SELL,
+            shares=5.0,
+            price=40.0,
+            strategy_name="StopLoss",
+            holding_period=HoldingPeriod.LONG_TERM,
+            purchase_date=date(2024, 1, 1),
+        ),
+        cost_basis=15.0,
+        purchase_date=date(2024, 1, 1),
+    )
+
+
+def test_tax_report_emits_csv_and_prints_totals(tmp_path: Path) -> None:
+    log = tmp_path / "trades.csv"
+    output = tmp_path / "schedule_d_2026.csv"
+    _seed_log(log)
+    strategies = tmp_path / "strategies.yaml"
+    strategies.write_text(
+        "strategies:\n  - name: Momentum\n    params: {window: 20}\n"
+        "tax:\n  short_term_rate: 0.30\n  long_term_rate: 0.15\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tax-report",
+            "--from-trades",
+            str(log),
+            "--strategies",
+            str(strategies),
+            "--year",
+            "2026",
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # The Schedule D table is rendered via Rich — check for the per-row content
+    # and the per-year footer line. Field labels like "AAPL" and "long-term"
+    # / "short-term" appear in any sensible rendering.
+    assert "AAPL" in result.output
+    assert "long-term" in result.output or "short-term" in result.output
+    assert output.exists()
+    csv_text = output.read_text()
+    assert "AAPL" in csv_text
+
+
+def test_tax_report_no_sells_in_year_prints_message(tmp_path: Path) -> None:
+    log = tmp_path / "trades.csv"
+    _seed_log(log)
+    strategies = tmp_path / "strategies.yaml"
+    strategies.write_text(
+        "strategies:\n  - name: Momentum\n    params: {window: 20}\n"
+        "tax:\n  short_term_rate: 0.30\n  long_term_rate: 0.15\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tax-report",
+            "--from-trades",
+            str(log),
+            "--strategies",
+            str(strategies),
+            "--year",
+            "2099",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "No realized sales" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_load_portfolio_state_file_field_optional(tmp_path: Path) -> None:
 
 
 def test_load_strategies(strategy_yaml: Path) -> None:
-    configs, constraints, _risk = load_strategies(strategy_yaml)
+    configs, constraints, _risk, _tax = load_strategies(strategy_yaml)
     assert len(configs) == 3
 
     assert configs[0].name == "MeanReversion"
@@ -144,7 +144,7 @@ class TestLoadStrategiesRisk:
                 params: {window: 20}
             """,
         )
-        _configs, _constraints, risk = load_strategies(path)
+        _configs, _constraints, risk, _tax = load_strategies(path)
         assert risk == RiskConfig()
 
     def test_full_risk_block(self, tmp_path: Path) -> None:
@@ -162,7 +162,7 @@ class TestLoadStrategiesRisk:
               drawdown_floor: 0.5
             """,
         )
-        _configs, _constraints, risk = load_strategies(path)
+        _configs, _constraints, risk, _tax = load_strategies(path)
         assert risk.weighting == "inverse_vol"
         assert risk.vol_lookback_days == 90
         assert risk.vol_target == 0.20
@@ -180,7 +180,7 @@ class TestLoadStrategiesRisk:
               vol_target: 0.18
             """,
         )
-        _configs, _constraints, risk = load_strategies(path)
+        _configs, _constraints, risk, _tax = load_strategies(path)
         assert risk.vol_target == 0.18
         assert risk.weighting == "equal"
         assert risk.drawdown_penalty is None
@@ -199,3 +199,37 @@ class TestLoadStrategiesRisk:
         )
         with pytest.raises(ValueError, match="drawdown_floor"):
             load_strategies(path)
+
+
+# ---------------------------------------------------------------------------
+# Tax: block parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_strategies_with_tax_block(tmp_path: Path) -> None:
+    """Optional tax: block parses to a TaxConfig."""
+    path = tmp_path / "strategies.yaml"
+    path.write_text(
+        "strategies:\n"
+        "  - name: Momentum\n"
+        "    params: {window: 20}\n"
+        "tax:\n"
+        "  short_term_rate: 0.32\n"
+        "  long_term_rate: 0.15\n"
+        "  deductible_loss_cap: 3000.0\n"
+        "  payment_lag_days: 105\n"
+    )
+    _configs, _constraints, _risk, tax = load_strategies(path)
+    assert tax is not None
+    assert tax.short_term_rate == 0.32
+    assert tax.long_term_rate == 0.15
+    assert tax.deductible_loss_cap == 3000.0
+    assert tax.payment_lag_days == 105
+
+
+def test_load_strategies_without_tax_block(tmp_path: Path) -> None:
+    """Omitting tax: yields tax_config=None — no behavior change for existing configs."""
+    path = tmp_path / "strategies.yaml"
+    path.write_text("strategies:\n  - name: Momentum\n    params: {window: 20}\n")
+    _configs, _constraints, _risk, tax = load_strategies(path)
+    assert tax is None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,7 +54,7 @@ def test_full_pipeline(tmp_path: Path) -> None:
     assert len(portfolio.holdings) == 2
     assert portfolio.available_cash == 3000.0
 
-    strat_configs, constraints, _risk_config = load_strategies(strategy_path)
+    strat_configs, constraints, _risk_config, _tax_config = load_strategies(strategy_path)
     assert len(strat_configs) == 3
 
     # 4. Build allocator + order_sizer + exit rules

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -493,6 +493,54 @@ def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path) -> None
     second.close()
 
 
+def test_engine_creates_trade_log_alongside_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Smoke: a tick that produces a fill writes ``<state>.trades.csv`` with a BUY row."""
+    from midas.trade_log import read_trades
+
+    portfolio = PortfolioConfig(
+        holdings=[],
+        available_cash=1000.0,
+    )
+    state_path = tmp_path / "portfolio.state.yaml"
+    expected_log = state_path.with_suffix(state_path.suffix + ".trades.csv")
+    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    fake_buy = Order(
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=1.0,
+        price=100.0,
+        estimated_value=100.0,
+        context=OrderContext(
+            contributions={"fake": 1.0},
+            blended_score=1.0,
+            target_weight=1.0,
+            current_weight=0.0,
+            reason="test",
+            source="fake",
+        ),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [fake_buy])
+
+    try:
+        engine._tick(["AAPL"])
+    finally:
+        engine.close()
+
+    assert expected_log.exists(), "trade log should be created next to the state file"
+    trades = read_trades(expected_log)
+    buys = [t for t in trades if t.direction == Direction.BUY]
+    assert buys, "first tick should record at least one BUY row"
+
+
 def test_drawdown_overlay_produces_smaller_exposure_under_real_drawdown() -> None:
     """End-to-end check that current_drawdown actually affects exposure scaling.
 

--- a/tests/test_live_engine.py
+++ b/tests/test_live_engine.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pandas as pd
 import pytest
 
 from midas.allocator import Allocator
@@ -24,26 +24,7 @@ from midas.models import (
 )
 from midas.order_sizer import OrderSizer
 
-
-def _make_provider(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
-    """Build a fake DataProvider returning an OHLCV frame for each ticker."""
-    provider = MagicMock()
-
-    def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
-        closes = prices[ticker]
-        return pd.DataFrame(
-            {
-                "open": closes,
-                "high": closes,
-                "low": closes,
-                "close": closes,
-                "volume": [1000.0] * len(closes),
-            },
-            index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
-        )
-
-    provider.get_history.side_effect = get_history
-    return provider
+ProviderFactory = Callable[[dict[str, list[float]], list[date]], MagicMock]
 
 
 @pytest.fixture
@@ -54,13 +35,15 @@ def basic_portfolio() -> PortfolioConfig:
     )
 
 
-def test_live_engine_seeds_state_on_first_construction(basic_portfolio: PortfolioConfig, tmp_path: Path) -> None:
+def test_live_engine_seeds_state_on_first_construction(
+    basic_portfolio: PortfolioConfig, tmp_path: Path, make_provider: ProviderFactory
+) -> None:
     state_path = tmp_path / "portfolio.state.yaml"
     assert not state_path.exists()
 
     allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
     sizer = OrderSizer()
-    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
 
     LiveEngine(
         portfolio=basic_portfolio,
@@ -76,7 +59,7 @@ def test_live_engine_seeds_state_on_first_construction(basic_portfolio: Portfoli
     assert "AAPL" in state.lots
 
 
-def test_tick_advances_in_memory_hwm(tmp_path: Path) -> None:
+def test_tick_advances_in_memory_hwm(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """First tick should advance per-ticker HWM in self._state to the latest close."""
     portfolio = PortfolioConfig(
         holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
@@ -85,7 +68,7 @@ def test_tick_advances_in_memory_hwm(tmp_path: Path) -> None:
     state_path = tmp_path / "state.yaml"
     allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
     sizer = OrderSizer()
-    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
 
     engine = LiveEngine(
         portfolio=portfolio,
@@ -99,7 +82,7 @@ def test_tick_advances_in_memory_hwm(tmp_path: Path) -> None:
     assert engine._state.high_water_marks["AAPL"] == 200.0
 
 
-def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path) -> None:
+def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """If the operator has two lots at different prices, the exit-rule loop
     should see the share-weighted average basis, not the YAML's static value."""
     portfolio = PortfolioConfig(
@@ -122,7 +105,7 @@ def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path) -> None:
 
     allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
     sizer = OrderSizer()
-    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=allocator,
@@ -138,13 +121,13 @@ def test_tick_uses_weighted_avg_basis_from_state(tmp_path: Path) -> None:
     assert engine._state.high_water_marks["AAPL"] == 150.0
 
 
-def test_peak_equity_advances_and_persists(tmp_path: Path) -> None:
+def test_peak_equity_advances_and_persists(tmp_path: Path, make_provider: ProviderFactory) -> None:
     portfolio = PortfolioConfig(
         holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
         available_cash=0.0,
     )
     state_path = tmp_path / "state.yaml"
-    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -158,14 +141,14 @@ def test_peak_equity_advances_and_persists(tmp_path: Path) -> None:
     assert state.peak_equity == pytest.approx(10 * 200.0)
 
 
-def test_state_is_persisted_to_disk_each_tick(tmp_path: Path) -> None:
+def test_state_is_persisted_to_disk_each_tick(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """Even on a no-op tick (no orders), HWM and peak advance get saved."""
     portfolio = PortfolioConfig(
         holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
         available_cash=0.0,
     )
     state_path = tmp_path / "state.yaml"
-    provider = _make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [150.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -180,7 +163,9 @@ def test_state_is_persisted_to_disk_each_tick(tmp_path: Path) -> None:
     assert on_disk.peak_equity == pytest.approx(10 * 150.0)
 
 
-def test_cash_infusion_advances_when_due(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cash_infusion_advances_when_due(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """If today >= cash_infusion.next_date, cash increases by amount and
     next_date advances."""
     portfolio = PortfolioConfig(
@@ -189,7 +174,7 @@ def test_cash_infusion_advances_when_due(tmp_path: Path, monkeypatch: pytest.Mon
         cash_infusion=CashInfusion(amount=1500.0, next_date=date(2026, 5, 1), frequency="biweekly"),
     )
     state_path = tmp_path / "state.yaml"
-    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -212,7 +197,9 @@ def test_cash_infusion_advances_when_due(tmp_path: Path, monkeypatch: pytest.Mon
     assert state.cash_infusion_next_date == date(2026, 5, 15)  # +14 days for biweekly
 
 
-def test_alert_cash_display_does_not_double_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_alert_cash_display_does_not_double_count(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """``apply_buy``/``apply_sell`` mutate ``state.available_cash`` in place,
     so the per-alert running subtotal must seed from the *pre-fill* baseline.
     Otherwise a single $100 BUY against $1000 cash would print "$800" instead
@@ -223,7 +210,7 @@ def test_alert_cash_display_does_not_double_count(tmp_path: Path, monkeypatch: p
         available_cash=1000.0,
     )
     state_path = tmp_path / "state.yaml"
-    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -268,7 +255,7 @@ def test_alert_cash_display_does_not_double_count(tmp_path: Path, monkeypatch: p
     assert engine._state.available_cash == pytest.approx(900.0)
 
 
-def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path) -> None:
+def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """``_tick`` must compute ``(peak_equity - total_value) / peak_equity`` from
     persisted state and pass it as ``current_drawdown`` to the allocator. Without
     this, the CPPI overlay is inert in live regardless of how far below peak the
@@ -291,7 +278,7 @@ def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path) -> None:
     )
     save_atomic(seeded, state_path)
 
-    provider = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
     captured_kwargs: dict[str, object] = {}
     allocator = Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1)
 
@@ -317,7 +304,9 @@ def test_tick_passes_current_drawdown_to_allocator(tmp_path: Path) -> None:
     assert captured_kwargs["current_drawdown"] == pytest.approx(0.6)
 
 
-def test_peak_equity_survives_engine_restart_and_drives_drawdown(tmp_path: Path) -> None:
+def test_peak_equity_survives_engine_restart_and_drives_drawdown(
+    tmp_path: Path, make_provider: ProviderFactory
+) -> None:
     """Tick A advances peak via the engine's own logic, then a fresh engine
     constructed from the same state path reads peak from disk and the next
     tick's current_drawdown reflects the persisted value.
@@ -334,7 +323,7 @@ def test_peak_equity_survives_engine_restart_and_drives_drawdown(tmp_path: Path)
     state_path = tmp_path / "state.yaml"
 
     # Tick A: price at 200 → equity at $2000, peak ratchets to $2000.
-    provider_a = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    provider_a = make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
     engine_a = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -362,7 +351,7 @@ def test_peak_equity_survives_engine_restart_and_drives_drawdown(tmp_path: Path)
 
     allocator_b.allocate = capturing_allocate  # type: ignore[method-assign]
 
-    provider_b = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 8)])
+    provider_b = make_provider({"AAPL": [80.0]}, [date(2026, 5, 8)])
     engine_b = LiveEngine(
         portfolio=portfolio,
         allocator=allocator_b,
@@ -378,7 +367,7 @@ def test_peak_equity_survives_engine_restart_and_drives_drawdown(tmp_path: Path)
     assert captured["current_drawdown"] == pytest.approx(0.6)
 
 
-def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path) -> None:
+def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """HWM must only ratchet for tickers we actually hold. Otherwise a ticker
     that ran up before the strategy first bought it would seed ``TrailingStop``
     against a pre-purchase peak — silently more conservative than backtest,
@@ -397,7 +386,7 @@ def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path) -> None:
     )
     save_atomic(seeded, state_path)
 
-    provider = _make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [200.0]}, [date(2026, 5, 7)])
     engine = LiveEngine(
         portfolio=portfolio,
         allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
@@ -412,7 +401,7 @@ def test_tick_does_not_advance_hwm_for_unheld_tickers(tmp_path: Path) -> None:
     )
 
 
-def test_lockfile_prevents_concurrent_engines(tmp_path: Path) -> None:
+def test_lockfile_prevents_concurrent_engines(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """Two ``LiveEngine``s against the same state file would otherwise both
     load, both compute, both write — ``os.replace`` would pick a winner and
     silently drop the loser's fills. The advisory lock turns this into a clear
@@ -423,7 +412,7 @@ def test_lockfile_prevents_concurrent_engines(tmp_path: Path) -> None:
         available_cash=0.0,
     )
     state_path = tmp_path / "state.yaml"
-    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
 
     first = LiveEngine(
         portfolio=portfolio,
@@ -455,7 +444,7 @@ def test_lockfile_prevents_concurrent_engines(tmp_path: Path) -> None:
     second.close()
 
 
-def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path) -> None:
+def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path, make_provider: ProviderFactory) -> None:
     """If load_or_seed raises after the lock is acquired (e.g., corrupt state file),
     the lock fd must be released. Otherwise a retry in the same process hits a
     bogus 'another midas live process' RuntimeError.
@@ -468,7 +457,7 @@ def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path) -> None
         holdings=[Holding(ticker="AAPL", shares=10.0, cost_basis=100.0)],
         available_cash=0.0,
     )
-    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
 
     # First attempt: load_or_seed raises on the unsupported schema_version.
     with pytest.raises(StateFileError):
@@ -493,7 +482,9 @@ def test_lock_released_when_init_fails_after_acquisition(tmp_path: Path) -> None
     second.close()
 
 
-def test_engine_creates_trade_log_alongside_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_engine_creates_trade_log_alongside_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """Smoke: a tick that produces a fill writes ``<state>.trades.csv`` with a BUY row."""
     from midas.trade_log import read_trades
 
@@ -503,7 +494,7 @@ def test_engine_creates_trade_log_alongside_state(tmp_path: Path, monkeypatch: p
     )
     state_path = tmp_path / "portfolio.state.yaml"
     expected_log = state_path.with_suffix(state_path.suffix + ".trades.csv")
-    provider = _make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [100.0]}, [date(2026, 5, 7)])
 
     engine = LiveEngine(
         portfolio=portfolio,

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -415,3 +415,32 @@ def test_save_atomic_does_not_emit_yaml_aliases(tmp_path: Path) -> None:
     # Confirm round-trip still works after disabling aliases.
     loaded = load_state(path)
     assert loaded == state
+
+
+def test_consume_lots_fifo_records_purchase_dates_per_bucket() -> None:
+    """SellBreakdown should expose the purchase_date of each consumed lot,
+    grouped by ST/LT bucket, so trade-log writers can resolve to a single
+    date or the literal 'various'."""
+    from midas.live_state import consume_lots_fifo
+
+    lots = [
+        PositionLot(shares=10.0, purchase_date=date(2024, 1, 1), cost_basis=10.0),  # LT
+        PositionLot(shares=10.0, purchase_date=date(2024, 5, 1), cost_basis=12.0),  # LT
+        PositionLot(shares=10.0, purchase_date=date(2026, 1, 1), cost_basis=20.0),  # ST
+    ]
+    # Sell 25 on 2026-05-08 → 20 LT + 5 ST consumed.
+    breakdown = consume_lots_fifo(lots, shares=25.0, day=date(2026, 5, 8))
+    assert breakdown.lt_purchase_dates == (date(2024, 1, 1), date(2024, 5, 1))
+    assert breakdown.st_purchase_dates == (date(2026, 1, 1),)
+
+
+def test_consume_lots_fifo_records_none_purchase_date_in_st_bucket() -> None:
+    """A lot with purchase_date=None classifies as ST and surfaces None in the
+    ST date tuple. The downstream resolver maps tuples containing None to the
+    empty-string CSV value."""
+    from midas.live_state import consume_lots_fifo
+
+    lots = [PositionLot(shares=10.0, purchase_date=None, cost_basis=10.0)]
+    breakdown = consume_lots_fifo(lots, shares=10.0, day=date(2026, 5, 8))
+    assert breakdown.st_purchase_dates == (None,)
+    assert breakdown.lt_purchase_dates == ()

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -347,11 +347,16 @@ def test_apply_sell_consumes_fifo_and_increments_cash() -> None:
             ]
         },
     )
-    st_pnl, lt_pnl = apply_sell(state, "AAPL", shares=40.0, price=25.0, day=date(2026, 5, 7))
+    breakdown = apply_sell(state, "AAPL", shares=40.0, price=25.0, day=date(2026, 5, 7))
     assert state.available_cash == pytest.approx(40.0 * 25.0)
     assert state.lots["AAPL"] == [PositionLot(shares=10.0, purchase_date=date(2026, 4, 1), cost_basis=20.0)]
+
+    lt_pnl = breakdown.lt_shares * 25.0 - breakdown.lt_weighted
+    st_pnl = breakdown.st_shares * 25.0 - breakdown.st_weighted
     assert lt_pnl == pytest.approx(30.0 * (25.0 - 10.0))
     assert st_pnl == pytest.approx(10.0 * (25.0 - 20.0))
+    assert breakdown.lt_purchase_dates == (date(2025, 4, 1),)
+    assert breakdown.st_purchase_dates == (date(2026, 4, 1),)
 
 
 def test_apply_sell_drops_empty_ticker_entry() -> None:

--- a/tests/test_live_state.py
+++ b/tests/test_live_state.py
@@ -444,3 +444,20 @@ def test_consume_lots_fifo_records_none_purchase_date_in_st_bucket() -> None:
     breakdown = consume_lots_fifo(lots, shares=10.0, day=date(2026, 5, 8))
     assert breakdown.st_purchase_dates == (None,)
     assert breakdown.lt_purchase_dates == ()
+
+
+def test_consume_lots_fifo_partial_lot_records_date_once() -> None:
+    """A partially-consumed lot's purchase_date appears exactly once in the tuple,
+    not duplicated across the slice and the residual. Guards against append-in-the-
+    wrong-branch bugs in the lot-shrinking conditional."""
+    from midas.live_state import consume_lots_fifo
+
+    lots = [
+        PositionLot(shares=10.0, purchase_date=date(2024, 1, 1), cost_basis=10.0),  # LT
+        PositionLot(shares=10.0, purchase_date=date(2024, 6, 1), cost_basis=12.0),  # LT
+    ]
+    # Consume 15 → first lot fully (10 shares), second lot partially (5 of 10).
+    breakdown = consume_lots_fifo(lots, shares=15.0, day=date(2026, 5, 8))
+    assert breakdown.lt_purchase_dates == (date(2024, 1, 1), date(2024, 6, 1))
+    # Residual 5 shares of the second lot remain in `lots` — sanity check for the loop.
+    assert lots == [PositionLot(shares=5.0, purchase_date=date(2024, 6, 1), cost_basis=12.0)]

--- a/tests/test_live_trade_log.py
+++ b/tests/test_live_trade_log.py
@@ -1,0 +1,308 @@
+"""Integration test: live engine writes a complete trade log across ticks."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from midas.allocator import Allocator
+from midas.live import LiveEngine
+from midas.live_state import LiveState, save_atomic
+from midas.models import (
+    AllocationConstraints,
+    Direction,
+    Holding,
+    Order,
+    OrderContext,
+    PortfolioConfig,
+    PositionLot,
+)
+from midas.order_sizer import OrderSizer
+from midas.trade_log import read_trades
+
+
+def _make_provider(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
+    """Build a fake DataProvider returning an OHLCV frame for each ticker."""
+    provider = MagicMock()
+
+    def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
+        closes = prices[ticker]
+        return pd.DataFrame(
+            {
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "volume": [1000.0] * len(closes),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
+        )
+
+    provider.get_history.side_effect = get_history
+    return provider
+
+
+def _fake_context(source: str = "test") -> OrderContext:
+    return OrderContext(
+        contributions={source: 1.0},
+        blended_score=1.0,
+        target_weight=1.0,
+        current_weight=0.0,
+        reason="test",
+        source=source,
+    )
+
+
+def test_live_engine_writes_trade_log_for_full_exit_lt_sell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A full-exit SELL of an LT lot writes a single LT bucket row.
+
+    The row's ``purchase_date`` is the original lot's purchase date and the
+    ``cost_basis`` is the lot's basis. This exercises the live trade-log path
+    end-to-end: state is persisted, breakdown is captured per-order, and the
+    LT branch emits one row.
+    """
+    state_path = tmp_path / "portfolio.state.yaml"
+    log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+
+    # Seed the state directly so we control purchase_date precisely.
+    save_atomic(
+        LiveState(
+            available_cash=0.0,
+            cash_infusion_next_date=None,
+            high_water_marks={"AAPL": 100.0},
+            peak_equity=10000.0,
+            lots={
+                "AAPL": [
+                    PositionLot(shares=100.0, purchase_date=date(2024, 1, 1), cost_basis=50.0),
+                ]
+            },
+        ),
+        state_path,
+    )
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=50.0)],
+        available_cash=0.0,
+    )
+    provider = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Inject a synthetic full-exit SELL via the order sizer's sell pass; this
+    # bypasses allocator/exit-rule plumbing while exercising the real
+    # apply-fills + trade-log paths.
+    fake_sell = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=100.0,
+        price=80.0,
+        estimated_value=8000.0,
+        context=_fake_context(source="StopLoss"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_sells", lambda *a, **kw: [fake_sell])
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [])
+
+    try:
+        engine._tick(["AAPL"])
+    finally:
+        engine.close()
+
+    assert log_path.exists()
+    trades = read_trades(log_path)
+    sells = [t for t in trades if t.direction == Direction.SELL]
+    assert len(sells) == 1, f"expected exactly one SELL row, got {trades}"
+    sell = sells[0]
+    assert sell.holding_period is not None
+    assert sell.holding_period.value == "long-term"
+    assert sell.purchase_date == date(2024, 1, 1)
+    assert sell.cost_basis == pytest.approx(50.0)
+    assert sell.shares == pytest.approx(100.0)
+    assert sell.strategy_name == "StopLoss"
+
+
+def test_live_engine_writes_trade_log_across_three_ticks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three ticks: BUY, BUY (second lot), partial SELL.
+
+    The partial SELL consumes the older lot only (FIFO), producing one ST
+    bucket row (because both lots were bought within 365 days). The log
+    has three rows in order.
+
+    Patches ``midas.live.date`` so each tick sees a distinct ``today``,
+    pinning the per-row ``date`` and the BUY ``purchase_date`` columns.
+    """
+    state_path = tmp_path / "portfolio.state.yaml"
+    log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+
+    portfolio = PortfolioConfig(
+        holdings=[],
+        available_cash=10000.0,
+    )
+    provider = _make_provider(
+        {"AAPL": [100.0, 110.0, 120.0]},
+        [date(2026, 5, 6), date(2026, 5, 7), date(2026, 5, 8)],
+    )
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    days = [date(2026, 5, 6), date(2026, 5, 7), date(2026, 5, 8)]
+    day_idx = {"i": 0}
+
+    class _FakeDate:
+        @staticmethod
+        def today() -> date:
+            return days[day_idx["i"]]
+
+    monkeypatch.setattr("midas.live.date", _FakeDate)
+
+    # Tick 1: BUY 10 @ 100 on 2026-05-06.
+    buy_a = Order(
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=10.0,
+        price=100.0,
+        estimated_value=1000.0,
+        context=_fake_context("EntrySig"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_sells", lambda *a, **kw: [])
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [buy_a])
+    engine._tick(["AAPL"])
+
+    # Tick 2: BUY 5 @ 110 on 2026-05-07 (second lot).
+    day_idx["i"] = 1
+    buy_b = Order(
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=5.0,
+        price=110.0,
+        estimated_value=550.0,
+        context=_fake_context("EntrySig"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [buy_b])
+    engine._tick(["AAPL"])
+
+    # Tick 3: partial SELL of 7 @ 120 on 2026-05-08 — consumes 7 of the first lot.
+    day_idx["i"] = 2
+    sell = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=7.0,
+        price=120.0,
+        estimated_value=840.0,
+        context=_fake_context("StopLoss"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_sells", lambda *a, **kw: [sell])
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [])
+    try:
+        engine._tick(["AAPL"])
+    finally:
+        engine.close()
+
+    assert log_path.exists()
+    trades = read_trades(log_path)
+    assert len(trades) == 3, f"expected 3 rows (BUY, BUY, SELL), got {trades}"
+
+    assert trades[0].direction == Direction.BUY
+    assert trades[0].date == date(2026, 5, 6)
+    assert trades[0].shares == pytest.approx(10.0)
+    assert trades[0].price == pytest.approx(100.0)
+    assert trades[0].cost_basis is None
+    assert trades[0].purchase_date == date(2026, 5, 6)
+
+    assert trades[1].direction == Direction.BUY
+    assert trades[1].date == date(2026, 5, 7)
+    assert trades[1].shares == pytest.approx(5.0)
+    assert trades[1].price == pytest.approx(110.0)
+    assert trades[1].purchase_date == date(2026, 5, 7)
+
+    assert trades[2].direction == Direction.SELL
+    assert trades[2].date == date(2026, 5, 8)
+    assert trades[2].shares == pytest.approx(7.0)
+    assert trades[2].price == pytest.approx(120.0)
+    assert trades[2].holding_period is not None
+    assert trades[2].holding_period.value == "short-term"
+    # All consumed lots came from the first BUY on 2026-05-06.
+    assert trades[2].purchase_date == date(2026, 5, 6)
+    assert trades[2].cost_basis == pytest.approx(100.0)
+
+
+def test_live_engine_writes_trade_log_for_mixed_lot_sell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SELL spanning two lots with different purchase dates writes
+    ``'various'`` in the purchase_date column and a share-weighted basis.
+    Both lots are < 365 days old, so the entire sell is one ST bucket row.
+    """
+    state_path = tmp_path / "portfolio.state.yaml"
+    log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+
+    save_atomic(
+        LiveState(
+            available_cash=0.0,
+            cash_infusion_next_date=None,
+            high_water_marks={"AAPL": 130.0},
+            peak_equity=2000.0,
+            lots={
+                "AAPL": [
+                    PositionLot(shares=10.0, purchase_date=date(2026, 1, 5), cost_basis=80.0),
+                    PositionLot(shares=10.0, purchase_date=date(2026, 3, 5), cost_basis=120.0),
+                ]
+            },
+        ),
+        state_path,
+    )
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=20.0, cost_basis=100.0)],
+        available_cash=0.0,
+    )
+    provider = _make_provider({"AAPL": [130.0]}, [date(2026, 5, 7)])
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Sell 15 shares: consumes all 10 of lot1 (basis 80) + 5 of lot2 (basis 120).
+    # Weighted avg basis = (10*80 + 5*120) / 15 = 1400 / 15 ~= 93.333.
+    sell = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=15.0,
+        price=130.0,
+        estimated_value=1950.0,
+        context=_fake_context("StopLoss"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_sells", lambda *a, **kw: [sell])
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [])
+
+    try:
+        engine._tick(["AAPL"])
+    finally:
+        engine.close()
+
+    trades = read_trades(log_path)
+    sells = [t for t in trades if t.direction == Direction.SELL]
+    assert len(sells) == 1
+    sell_row = sells[0]
+    assert sell_row.holding_period is not None
+    assert sell_row.holding_period.value == "short-term"
+    assert sell_row.purchase_date == "various"
+    assert sell_row.cost_basis == pytest.approx(1400.0 / 15.0)
+    assert sell_row.shares == pytest.approx(15.0)

--- a/tests/test_live_trade_log.py
+++ b/tests/test_live_trade_log.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pandas as pd
 import pytest
 
 from midas.allocator import Allocator
@@ -24,26 +24,7 @@ from midas.models import (
 from midas.order_sizer import OrderSizer
 from midas.trade_log import read_trades
 
-
-def _make_provider(prices: dict[str, list[float]], dates: list[date]) -> MagicMock:
-    """Build a fake DataProvider returning an OHLCV frame for each ticker."""
-    provider = MagicMock()
-
-    def get_history(ticker: str, start: date, end: date) -> pd.DataFrame:
-        closes = prices[ticker]
-        return pd.DataFrame(
-            {
-                "open": closes,
-                "high": closes,
-                "low": closes,
-                "close": closes,
-                "volume": [1000.0] * len(closes),
-            },
-            index=pd.DatetimeIndex([pd.Timestamp(d) for d in dates]),
-        )
-
-    provider.get_history.side_effect = get_history
-    return provider
+ProviderFactory = Callable[[dict[str, list[float]], list[date]], MagicMock]
 
 
 def _fake_context(source: str = "test") -> OrderContext:
@@ -57,7 +38,9 @@ def _fake_context(source: str = "test") -> OrderContext:
     )
 
 
-def test_live_engine_writes_trade_log_for_full_exit_lt_sell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_engine_writes_trade_log_for_full_exit_lt_sell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """A full-exit SELL of an LT lot writes a single LT bucket row.
 
     The row's ``purchase_date`` is the original lot's purchase date and the
@@ -88,7 +71,7 @@ def test_live_engine_writes_trade_log_for_full_exit_lt_sell(tmp_path: Path, monk
         holdings=[Holding(ticker="AAPL", shares=100.0, cost_basis=50.0)],
         available_cash=0.0,
     )
-    provider = _make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [80.0]}, [date(2026, 5, 7)])
 
     engine = LiveEngine(
         portfolio=portfolio,
@@ -130,7 +113,9 @@ def test_live_engine_writes_trade_log_for_full_exit_lt_sell(tmp_path: Path, monk
     assert sell.strategy_name == "StopLoss"
 
 
-def test_live_engine_writes_trade_log_across_three_ticks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_engine_writes_trade_log_across_three_ticks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """Three ticks: BUY, BUY (second lot), partial SELL.
 
     The partial SELL consumes the older lot only (FIFO), producing one ST
@@ -147,7 +132,7 @@ def test_live_engine_writes_trade_log_across_three_ticks(tmp_path: Path, monkeyp
         holdings=[],
         available_cash=10000.0,
     )
-    provider = _make_provider(
+    provider = make_provider(
         {"AAPL": [100.0, 110.0, 120.0]},
         [date(2026, 5, 6), date(2026, 5, 7), date(2026, 5, 8)],
     )
@@ -241,7 +226,9 @@ def test_live_engine_writes_trade_log_across_three_ticks(tmp_path: Path, monkeyp
     assert trades[2].cost_basis == pytest.approx(100.0)
 
 
-def test_live_engine_writes_trade_log_for_mixed_lot_sell(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_engine_writes_trade_log_for_mixed_lot_sell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
     """A SELL spanning two lots with different purchase dates writes
     ``'various'`` in the purchase_date column and a share-weighted basis.
     Both lots are < 365 days old, so the entire sell is one ST bucket row.
@@ -269,7 +256,7 @@ def test_live_engine_writes_trade_log_for_mixed_lot_sell(tmp_path: Path, monkeyp
         holdings=[Holding(ticker="AAPL", shares=20.0, cost_basis=100.0)],
         available_cash=0.0,
     )
-    provider = _make_provider({"AAPL": [130.0]}, [date(2026, 5, 7)])
+    provider = make_provider({"AAPL": [130.0]}, [date(2026, 5, 7)])
 
     engine = LiveEngine(
         portfolio=portfolio,
@@ -306,3 +293,85 @@ def test_live_engine_writes_trade_log_for_mixed_lot_sell(tmp_path: Path, monkeyp
     assert sell_row.purchase_date == "various"
     assert sell_row.cost_basis == pytest.approx(1400.0 / 15.0)
     assert sell_row.shares == pytest.approx(15.0)
+
+
+def test_sell_spanning_st_and_lt_writes_two_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_provider: ProviderFactory
+) -> None:
+    """A single SELL consuming both old (LT) and recent (ST) lots writes
+    one ST bucket row and one LT bucket row, each with the bucket's own
+    purchase_date and cost_basis (not the order's blended basis)."""
+    state_path = tmp_path / "portfolio.state.yaml"
+    log_path = state_path.with_suffix(state_path.suffix + ".trades.csv")
+
+    # Seed: 30 LT shares (purchased >365 days ago at $10) + 20 ST shares
+    # (purchased <365 days ago at $20). Today (per the live engine) =
+    # 2026-05-08 — set in the provider date below and via real ``date.today()``.
+    save_atomic(
+        LiveState(
+            available_cash=0.0,
+            cash_infusion_next_date=None,
+            high_water_marks={"AAPL": 30.0},
+            peak_equity=10000.0,
+            lots={
+                "AAPL": [
+                    PositionLot(shares=30.0, purchase_date=date(2024, 1, 1), cost_basis=10.0),
+                    PositionLot(shares=20.0, purchase_date=date(2026, 4, 1), cost_basis=20.0),
+                ],
+            },
+        ),
+        state_path,
+    )
+
+    portfolio = PortfolioConfig(
+        holdings=[Holding(ticker="AAPL", shares=50.0, cost_basis=14.0)],
+        available_cash=0.0,
+    )
+    provider = make_provider({"AAPL": [30.0]}, [date(2026, 5, 8)])
+
+    engine = LiveEngine(
+        portfolio=portfolio,
+        allocator=Allocator(entries=[], constraints=AllocationConstraints(), n_tickers=1),
+        order_sizer=OrderSizer(),
+        provider=provider,
+        state_path=state_path,
+    )
+
+    # Pin today to 2026-05-08 so the ST/LT classification (>=365 days) is
+    # deterministic regardless of when the test runs.
+    class _FakeDate:
+        @staticmethod
+        def today() -> date:
+            return date(2026, 5, 8)
+
+    monkeypatch.setattr("midas.live.date", _FakeDate)
+
+    # Sell all 50 shares at $30 — FIFO consumes 30 LT shares (lot 1) then
+    # 20 ST shares (lot 2).
+    sell = Order(
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=50.0,
+        price=30.0,
+        estimated_value=1500.0,
+        context=_fake_context(source="StopLoss"),
+    )
+    monkeypatch.setattr(engine._order_sizer, "size_sells", lambda *a, **kw: [sell])
+    monkeypatch.setattr(engine._order_sizer, "size_buys", lambda *a, **kw: [])
+
+    try:
+        engine._tick(["AAPL"])
+    finally:
+        engine.close()
+
+    trades = read_trades(log_path)
+    sells = [t for t in trades if t.direction == Direction.SELL]
+    assert len(sells) == 2, f"expected ST + LT bucket rows, got {sells}"
+    by_period = {s.holding_period.value: s for s in sells if s.holding_period is not None}
+    assert "long-term" in by_period and "short-term" in by_period
+    assert by_period["long-term"].purchase_date == date(2024, 1, 1)
+    assert by_period["long-term"].cost_basis == pytest.approx(10.0)
+    assert by_period["long-term"].shares == pytest.approx(30.0)
+    assert by_period["short-term"].purchase_date == date(2026, 4, 1)
+    assert by_period["short-term"].cost_basis == pytest.approx(20.0)
+    assert by_period["short-term"].shares == pytest.approx(20.0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ from midas.models import (
     PositionLot,
     RiskConfig,
     StrategyConfig,
+    TaxConfig,
     TradeRecord,
 )
 
@@ -145,3 +146,52 @@ class TestRiskConfig:
     def test_weighting_validation(self) -> None:
         with pytest.raises(ValueError, match="weighting"):
             RiskConfig(weighting="bogus")
+
+
+class TestTaxConfig:
+    def test_defaults_instantiation(self) -> None:
+        cfg = TaxConfig()
+        assert cfg.short_term_rate == 0.37
+        assert cfg.long_term_rate == 0.20
+        assert cfg.deductible_loss_cap == 3000.0
+        assert cfg.payment_lag_days == 105
+
+    def test_short_term_rate_zero_valid(self) -> None:
+        TaxConfig(short_term_rate=0.0, long_term_rate=0.0)  # ok
+
+    def test_short_term_rate_one_invalid(self) -> None:
+        with pytest.raises(ValueError, match="short_term_rate"):
+            TaxConfig(short_term_rate=1.0)
+
+    def test_short_term_rate_negative_invalid(self) -> None:
+        with pytest.raises(ValueError, match="short_term_rate"):
+            TaxConfig(short_term_rate=-0.01)
+
+    def test_long_term_rate_zero_valid(self) -> None:
+        TaxConfig(long_term_rate=0.0)  # ok
+
+    def test_long_term_rate_one_invalid(self) -> None:
+        with pytest.raises(ValueError, match="long_term_rate"):
+            TaxConfig(long_term_rate=1.0)
+
+    def test_long_term_rate_negative_invalid(self) -> None:
+        with pytest.raises(ValueError, match="long_term_rate"):
+            TaxConfig(long_term_rate=-0.01)
+
+    def test_deductible_loss_cap_zero_valid(self) -> None:
+        TaxConfig(deductible_loss_cap=0.0)  # ok
+
+    def test_deductible_loss_cap_negative_invalid(self) -> None:
+        with pytest.raises(ValueError, match="deductible_loss_cap"):
+            TaxConfig(deductible_loss_cap=-1.0)
+
+    def test_payment_lag_days_zero_valid(self) -> None:
+        TaxConfig(payment_lag_days=0)  # ok
+
+    def test_payment_lag_days_negative_invalid(self) -> None:
+        with pytest.raises(ValueError, match="payment_lag_days"):
+            TaxConfig(payment_lag_days=-1)
+
+    def test_long_term_exceeds_short_term_raises(self) -> None:
+        with pytest.raises(ValueError, match="long_term_rate"):
+            TaxConfig(short_term_rate=0.20, long_term_rate=0.37)

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1,0 +1,164 @@
+"""Unit tests for capital-gains tax computation."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from midas.models import Direction, HoldingPeriod, TaxConfig, TradeRecord
+from midas.tax import (
+    AnnualTaxSummary,
+    compute_after_tax_curve,
+    compute_tax_summary,
+)
+
+CONFIG = TaxConfig(
+    short_term_rate=0.30,
+    long_term_rate=0.15,
+    deductible_loss_cap=3000.0,
+    payment_lag_days=105,
+)
+
+
+def _sell(year: int, period: HoldingPeriod, shares: float, price: float) -> TradeRecord:
+    return TradeRecord(
+        date=date(year, 6, 1),
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=shares,
+        price=price,
+        strategy_name="StopLoss",
+        holding_period=period,
+    )
+
+
+def test_pure_st_gain_taxed_at_short_term_rate() -> None:
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]  # gain = (30 - 20) * 10 = 100
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    assert len(summary) == 1
+    s = summary[0]
+    assert s.year == 2026
+    assert s.st_realized == pytest.approx(100.0)
+    assert s.lt_realized == 0.0
+    assert s.tax_owed == pytest.approx(100.0 * 0.30)
+    assert s.carry_forward == 0.0
+
+
+def test_st_gain_lt_loss_cross_nets() -> None:
+    """ST $100 gain, LT $40 loss → cross-net leaves $60 ST gain after offset.
+
+    Per IRS Schedule D, an LT loss first offsets LT gains; with no LT gain,
+    excess LT loss carries to ST. Result: $60 net ST gain taxed at ST rate.
+    """
+    trades = [
+        _sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0),  # +$100
+        _sell(2026, HoldingPeriod.LONG_TERM, 10.0, 16.0),  # -$40 vs basis=$20
+    ]
+    basis = [20.0, 20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    assert summary[0].net_after_cross == pytest.approx(60.0)
+    assert summary[0].tax_owed == pytest.approx(60.0 * 0.30)
+
+
+def test_net_loss_below_cap_full_deductible() -> None:
+    """Net loss of $1,200 → full $1,200 deducted at ST rate; no carry."""
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 8.0)]  # -$1200
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    s = summary[0]
+    assert s.net_after_cross == pytest.approx(-1200.0)
+    assert s.deductible_loss == pytest.approx(1200.0)
+    assert s.tax_owed == pytest.approx(-1200.0 * 0.30)  # negative → refund/credit
+    assert s.carry_forward == 0.0
+
+
+def test_net_loss_above_cap_caps_deductible_carries_remainder() -> None:
+    """Net loss of $5,000 → $3,000 deducted, $2,000 carries forward."""
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 30.0)]  # -$5000 vs $80 basis
+    basis = [80.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2026, 12, 31))
+    s = summary[0]
+    assert s.net_after_cross == pytest.approx(-5000.0)
+    assert s.deductible_loss == pytest.approx(3000.0)
+    assert s.tax_owed == pytest.approx(-3000.0 * 0.30)
+    assert s.carry_forward == pytest.approx(2000.0)
+
+
+def test_carry_forward_absorbs_next_year_gain() -> None:
+    """$5K loss in year 1 ($2K carries) absorbs $1.5K gain in year 2.
+
+    Year 2's net post-carry = $1.5K - $2K = -$500 → fully deductible at ST,
+    no remaining carry.
+    """
+    trades = [
+        _sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 30.0),  # -$5000
+        _sell(2027, HoldingPeriod.SHORT_TERM, 100.0, 35.0),  # +$1500 vs $20 basis
+    ]
+    basis = [80.0, 20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 12, 31))
+    assert len(summary) == 2
+    assert summary[0].carry_forward == pytest.approx(2000.0)
+    assert summary[1].net_after_cross == pytest.approx(-500.0)
+    assert summary[1].deductible_loss == pytest.approx(500.0)
+    assert summary[1].tax_owed == pytest.approx(-500.0 * 0.30)
+    assert summary[1].carry_forward == 0.0
+
+
+def test_empty_trades_returns_empty_summary() -> None:
+    summary = compute_tax_summary([], [], CONFIG, end_date=date(2026, 12, 31))
+    assert summary == []
+
+
+def test_payment_date_is_year_end_plus_lag() -> None:
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 12, 31))
+    # Dec 31 2026 + 105 days = Apr 15 2027
+    assert summary[0].payment_date == date(2027, 4, 15)
+
+
+def test_payment_date_clamped_to_end_date() -> None:
+    """If the natural payment date falls past end_date, clamp to end_date.
+
+    Year 2026 sale, end_date 2027-02-15 (before Apr 15) → deduct on 2027-02-15.
+    """
+    trades = [_sell(2026, HoldingPeriod.SHORT_TERM, 10.0, 30.0)]
+    basis = [20.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2027, 2, 15))
+    assert summary[0].payment_date == date(2027, 2, 15)
+
+
+def test_after_tax_curve_subtracts_owed_at_payment_date() -> None:
+    """compute_after_tax_curve subtracts each summary's tax_owed at payment_date."""
+    summaries = [
+        AnnualTaxSummary(
+            year=2026,
+            st_realized=100.0,
+            lt_realized=0.0,
+            net_after_cross=100.0,
+            deductible_loss=0.0,
+            carry_forward=0.0,
+            tax_owed=30.0,
+            payment_date=date(2027, 4, 15),
+        )
+    ]
+    gross = [
+        (date(2027, 4, 14), 1000.0),
+        (date(2027, 4, 15), 1010.0),
+        (date(2027, 4, 16), 1020.0),
+    ]
+    after_tax = compute_after_tax_curve(gross, summaries, end_date=date(2027, 12, 31))
+    assert after_tax[0] == (date(2027, 4, 14), 1000.0)
+    assert after_tax[1] == (date(2027, 4, 15), 1010.0 - 30.0)
+    assert after_tax[2] == (date(2027, 4, 16), 1020.0 - 30.0)
+    # Original not mutated.
+    assert gross[1] == (date(2027, 4, 15), 1010.0)
+
+
+def test_after_tax_curve_empty_summaries_returns_gross_copy() -> None:
+    gross = [(date(2026, 1, 1), 100.0), (date(2026, 6, 1), 110.0)]
+    result = compute_after_tax_curve(gross, [], end_date=date(2026, 12, 31))
+    assert result == gross
+    assert result is not gross

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -149,7 +149,7 @@ def test_after_tax_curve_subtracts_owed_at_payment_date() -> None:
         (date(2027, 4, 15), 1010.0),
         (date(2027, 4, 16), 1020.0),
     ]
-    after_tax = compute_after_tax_curve(gross, summaries, end_date=date(2027, 12, 31))
+    after_tax = compute_after_tax_curve(gross, summaries)
     assert after_tax[0] == (date(2027, 4, 14), 1000.0)
     assert after_tax[1] == (date(2027, 4, 15), 1010.0 - 30.0)
     assert after_tax[2] == (date(2027, 4, 16), 1020.0 - 30.0)
@@ -159,6 +159,6 @@ def test_after_tax_curve_subtracts_owed_at_payment_date() -> None:
 
 def test_after_tax_curve_empty_summaries_returns_gross_copy() -> None:
     gross = [(date(2026, 1, 1), 100.0), (date(2026, 6, 1), 110.0)]
-    result = compute_after_tax_curve(gross, [], end_date=date(2026, 12, 31))
+    result = compute_after_tax_curve(gross, [])
     assert result == gross
     assert result is not gross

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -162,3 +162,26 @@ def test_after_tax_curve_empty_summaries_returns_gross_copy() -> None:
     result = compute_after_tax_curve(gross, [])
     assert result == gross
     assert result is not gross
+
+
+def test_carry_forward_threads_through_inactive_year() -> None:
+    """A non-zero carry_forward survives years with no SELL activity.
+
+    Year 1 has $5K loss ($2K carry). Year 2 has no sells (no summary
+    emitted). Year 3 has a $1K gain. The $2K carry should still be
+    applied at Year 3, producing a $1K loss after netting.
+    """
+    trades = [
+        _sell(2026, HoldingPeriod.SHORT_TERM, 100.0, 30.0),  # -$5000 vs $80 basis
+        _sell(2028, HoldingPeriod.SHORT_TERM, 50.0, 30.0),  # +$1000 vs $10 basis
+    ]
+    basis = [80.0, 10.0]
+    summary = compute_tax_summary(trades, basis, CONFIG, end_date=date(2028, 12, 31))
+    # Two summaries: 2026 and 2028 (2027 omitted — no activity).
+    assert len(summary) == 2
+    assert summary[0].year == 2026
+    assert summary[0].carry_forward == pytest.approx(2000.0)
+    assert summary[1].year == 2028
+    assert summary[1].net_after_cross == pytest.approx(-1000.0)  # $1K gain - $2K carry = -$1K
+    assert summary[1].deductible_loss == pytest.approx(1000.0)
+    assert summary[1].carry_forward == 0.0

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -1,0 +1,110 @@
+"""Trade-log writer/reader unit tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from midas.models import Direction, HoldingPeriod, TradeRecord
+from midas.trade_log import TradeLogError, append_trade, read_trades
+
+TRADE_LOG_HEADER = (
+    "date,ticker,direction,shares,price,strategy,holding_period,purchase_date,cost_basis,realized_pnl,return_pct\n"
+)
+
+
+def _buy(day: date) -> TradeRecord:
+    return TradeRecord(
+        date=day,
+        ticker="AAPL",
+        direction=Direction.BUY,
+        shares=10.0,
+        price=20.0,
+        strategy_name="Momentum",
+        purchase_date=day,
+    )
+
+
+def _sell(day: date, holding: HoldingPeriod, purchase: date | str | None) -> TradeRecord:
+    return TradeRecord(
+        date=day,
+        ticker="AAPL",
+        direction=Direction.SELL,
+        shares=10.0,
+        price=25.0,
+        strategy_name="StopLoss",
+        holding_period=holding,
+        purchase_date=purchase,
+    )
+
+
+def test_first_append_writes_header(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    contents = path.read_text()
+    assert contents.startswith(TRADE_LOG_HEADER)
+    # one data row after the header
+    assert contents.count("\n") == 2
+
+
+def test_subsequent_appends_do_not_duplicate_header(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    append_trade(path, _buy(date(2026, 5, 9)), cost_basis=None, purchase_date=date(2026, 5, 9))
+    text = path.read_text()
+    assert text.count("date,ticker,direction") == 1
+    assert text.count("\n") == 3  # header + 2 rows
+
+
+def test_round_trip_buy_and_two_bucket_sell(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(path, _buy(date(2026, 5, 8)), cost_basis=None, purchase_date=date(2026, 5, 8))
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.SHORT_TERM, "various"),
+        cost_basis=20.5,
+        purchase_date="various",
+    )
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.LONG_TERM, date(2024, 1, 1)),
+        cost_basis=10.0,
+        purchase_date=date(2024, 1, 1),
+    )
+    rows = read_trades(path)
+    assert len(rows) == 3
+    assert rows[0].direction == Direction.BUY
+    assert rows[0].purchase_date == date(2026, 5, 8)
+    assert rows[1].holding_period == HoldingPeriod.SHORT_TERM
+    assert rows[1].purchase_date == "various"
+    assert rows[1].cost_basis == 20.5
+    assert rows[1].realized_pnl == pytest.approx((25.0 - 20.5) * 10.0)
+    assert rows[2].purchase_date == date(2024, 1, 1)
+
+
+def test_purchase_date_none_round_trips_as_empty(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    append_trade(
+        path,
+        _sell(date(2026, 6, 8), HoldingPeriod.SHORT_TERM, None),
+        cost_basis=10.0,
+        purchase_date=None,
+    )
+    rows = read_trades(path)
+    assert rows[0].purchase_date is None
+
+
+def test_header_drift_raises_with_named_divergence(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    path.write_text("date,ticker,direction\n2026-05-08,AAPL,BUY\n")
+    with pytest.raises(TradeLogError, match="header"):
+        read_trades(path)
+
+
+def test_partial_row_raises_with_line_number(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    path.write_text(TRADE_LOG_HEADER + "2026-05-08,AAPL\n")  # 2 fields instead of 11
+    with pytest.raises(TradeLogError, match="line 2"):
+        read_trades(path)

--- a/tests/test_trade_log.py
+++ b/tests/test_trade_log.py
@@ -103,6 +103,14 @@ def test_header_drift_raises_with_named_divergence(tmp_path: Path) -> None:
         read_trades(path)
 
 
+def test_empty_existing_file_raises(tmp_path: Path) -> None:
+    """A zero-byte existing file is a corruption signal — must raise, not silently return []."""
+    path = tmp_path / "portfolio.state.yaml.trades.csv"
+    path.touch()  # creates a zero-byte file
+    with pytest.raises(TradeLogError, match="empty"):
+        read_trades(path)
+
+
 def test_partial_row_raises_with_line_number(tmp_path: Path) -> None:
     path = tmp_path / "portfolio.state.yaml.trades.csv"
     path.write_text(TRADE_LOG_HEADER + "2026-05-08,AAPL\n")  # 2 fields instead of 11


### PR DESCRIPTION
Closes #66.

## Summary

- **Live trade log:** `LiveEngine` now appends every fill to `<state>.trades.csv` next to the state file. Same column shape as backtest's existing `trades.csv` (with a new `purchase_date` column added to both modes — single date / `'various'` for mixed-lot SELL buckets / empty for unseeded lots).
- **`midas tax-report` subcommand:** reads either trade log (`-p portfolio.yaml` for live or `--from-trades output/trades.csv` for backtest), emits a Schedule D-shaped table to stdout plus a CSV with per-year aggregate footer.
- **Backtest after-tax accounting:** opt-in via a `tax:` block in the strategies YAML. `BacktestResult` gains 7 after-tax fields (`after_tax_final_value`, `after_tax_total_return`, `after_tax_cagr`, `after_tax_twr`, `after_tax_equity_curve`, `tax_cost_ratio`, `tax_summary`); `equity_curve.csv` gains a `nav_after_tax` column; `summary.json` gains the after-tax block + per-year `tax_summary` array; the equity chart overlays both curves; the summary print adds an "After-Tax Performance" block + per-year "Realized Tax" table.

Tax math is fully isolated in a new `src/midas/tax.py` (`AnnualTaxSummary`, `compute_tax_summary`, `compute_after_tax_curve`) — pure functions used by both the backtest after-tax pipeline and the `tax-report` subcommand, so the two paths produce bit-identical numbers given identical inputs.

## What's in scope

- New `src/midas/trade_log.py` — append-only CSV writer + strict reader (header drift / partial rows raise with line numbers); `LoggedTrade` dataclass; race-free `tell() == 0` header detection.
- New `src/midas/tax.py` — IRS Schedule D-style annual ST/LT netting + cross-bucket netting + `$3K` deductible cap + carryforward threaded across years (loses ST/LT character on rollover, documented).
- `models.TaxConfig` (frozen dataclass with `__post_init__` validation including `long_term_rate <= short_term_rate`) loaded from optional `tax:` block in strategies YAML.
- `models.TradeRecord.purchase_date` (date | str | None — `'various'` literal for mixed-lot bucket sells).
- `live_state.SellBreakdown` extended with `st_purchase_dates` / `lt_purchase_dates`; `apply_sell` returns full `SellBreakdown` (was `(st_pnl, lt_pnl)`).
- `live_state.resolve_purchase_date` shared helper, used by both `live.py` and `backtest.py` (single source of truth for the date-resolution rule).
- `metrics.pair_sells_with_basis` promoted to public (was `_pair_sells_with_basis`).
- `trade_log.format_purchase_date` / `format_holding_period` promoted to public; both backtest and live writers call them (single source for cell formatting rules).
- Test count: 367 → 412 (+45). New: `tests/test_trade_log.py` (8), `tests/test_tax.py` (11), `tests/test_live_trade_log.py` (3), `tests/test_cli_tax_report.py` (2). Plus additions to `test_live_state.py`, `test_live_engine.py`, `test_backtest.py`, `test_charts.py`, `test_config.py`, `test_models.py`, `test_integration.py`.
- Docs: new `docs/tax-reporting.md`; reference from `docs/architecture.md`.

## What's out of scope (deferred)

- **Tax-aware optimizer objective** (`--objective gross|after_tax`) — separate follow-up at #69.
- Wash-sale detection — broker 1099-B handles it, replication is broker-specific.
- Specific-lot / LIFO accounting — engine is FIFO.
- Tax-aware allocation at runtime — explicit guardrail in #66.
- Per-strategy after-tax breakdown — tax netting doesn't decompose cleanly across strategies.

## Spec & plan

- `docs/specs/2026-05-08-tax-trade-log-design.md`
- `docs/plans/2026-05-08-tax-trade-log.md`

## Test plan

- [ ] `uv run pytest` (412 passing)
- [ ] `uv run ruff check . && uv run mypy src` (clean)
- [ ] Backtest with a `tax:` block in the strategies YAML emits an "After-Tax Performance" block + per-year "Realized Tax" table; `equity_curve.csv` has a `nav_after_tax` column; `summary.json` has the after-tax block + `tax_summary` array; chart overlays gross + after-tax curves.
- [ ] Backtest without a `tax:` block produces identical output to pre-branch (no behavior change).
- [ ] `midas live --dry-run` against a portfolio with one BUY signal: state file is created/updated AND `<state>.trades.csv` is created next to it with a header + one BUY row.
- [ ] `midas tax-report --year 2026 -p portfolio.yaml -s strategies.yaml` against a real trade log: prints a Schedule D-style table; writes `schedule_d_2026.csv` with per-row data + per-year footer.
- [ ] `midas tax-report --year 2099` against the same log: prints "No realized sales in 2099" and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)